### PR TITLE
Bugfix/retention time

### DIFF
--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -837,7 +837,10 @@ cdef class Spectrum:
                     scan = self._xml.find('scanList/scan')
                     for param in scan.findall("cvParam"):
                         if param.attrib['accession'] == 'MS:1000016':
-                            return float(param.attrib['value'])
+                            if param.attrib.get('unitAccession', '') == 'UO:0000031':  # minutes
+                                return float(param.attrib['value']) * 60.0
+                            else:  # seconds
+                                return float(param.attrib['value'])
                 except ParseError as e:
                     return nan("1")
             else:

--- a/python/test/test_msz.py
+++ b/python/test/test_msz.py
@@ -169,3 +169,18 @@ def test_compress_msz_file(msz_file_path):
     with pytest.raises(NotImplementedError):
         msz = read(msz_file_path)
         msz.compress("test.out")
+
+def test_retention_time(msz_file_path):
+    msz = read(msz_file_path)
+    spectra = msz.spectra
+    for spectrum in spectra:
+        rt = spectrum.retention_time
+        assert isinstance(rt, float)
+        assert rt >= 0
+    
+    ## Test specific known retention time
+    spectrum = spectra[0]
+    assert abs(spectrum.retention_time - 0.21442476) < 1e-6
+
+    spectrum = spectra[10]
+    assert abs(spectrum.retention_time - 1.15352136) < 1e-6

--- a/python/test/test_mzml.py
+++ b/python/test/test_mzml.py
@@ -161,3 +161,18 @@ def test_decompress_mzml_file(mzml_file_path):
     with pytest.raises(NotImplementedError):
         mzml = read(mzml_file_path)
         mzml.decompress("test.out")
+
+def test_retention_time(mzml_file_path):
+    mzml = read(mzml_file_path)
+    spectra = mzml.spectra
+    for spectrum in spectra:
+        rt = spectrum.retention_time
+        assert isinstance(rt, float)
+        assert rt >= 0
+    
+    ## Test specific known retention time
+    spectrum = spectra[0]
+    assert abs(spectrum.retention_time - 0.21442476) < 1e-6
+
+    spectrum = spectra[10]
+    assert abs(spectrum.retention_time - 1.15352136) < 1e-6

--- a/src/preprocess.c
+++ b/src/preprocess.c
@@ -392,16 +392,39 @@ long get_scan(char* spectrum_start) {
    return strtol(ptr, &e, 10);
 }
 
+/**
+ * @brief Extract retention time (in seconds) from spectrum XML block.
+ * @param spectrum_start Pointer to the start of the spectrum XML block.
+ * @return Retention time as a float. Returns 0 on failure.
+ */
 float get_ret_time(char* spectrum_start) {
+   // Find the position of the retention time cvParam
    char* ptr = strstr(spectrum_start, "accession=\"MS:1000016\"") +
                sizeof("accession=\"MS:1000016\"");
+   // Return 0 if not found
    if (ptr == NULL)
       return 0;
+
+   // Move the pointer to the value attribute
    ptr = strstr(ptr, "value=\"") + sizeof("value=\"") - 1;
    char* e = strstr(ptr, "\"");
    if (e == NULL)
       return 0;
-   return strtof(ptr, &e);
+
+   // Convert the retention time string to float
+   float retention_time = strtof(ptr, &e);
+
+   // Find the unit of the retention time
+   ptr = strstr(e, "unitAccession=\"") + sizeof("unitAccession=\"") - 1;
+   e = strstr(ptr, "\"");
+   if (e == NULL)
+      return 0;
+
+   // Check if the unit is minutes and convert to seconds if necessary
+   if (strncmp(ptr, "UO:0000031", e - ptr) == 0) {
+      retention_time *= 60.0f;  // Convert minutes to seconds
+   }
+   return retention_time;
 }
 
 division_t* scan_mzml(char* input_map, data_format_t* df, long end, int flags) {


### PR DESCRIPTION
## Whats changed?
- Account for unitAccessions within mzML when parsing retention times. Retention time is now always in seconds.