### PR TITLE
bugfix: extract to unique temporary directory to avoid collisions

### DIFF
--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -1,4 +1,5 @@
 import os
+import shutil
 import numpy as np
 import warnings
 import tempfile
@@ -345,26 +346,26 @@ cdef class MZMLFile(BaseFile):
 
         if output_ext == '.msz':
             # Output as MSZ (compressed)
-            # Create a temporary mzML file path, extract to it, then compress to MSZ
-            temp_mzml_path = Path(tempfile.gettempdir()) / f"{output.stem}_temp.mzML"
-            
+            # Create a unique temporary directory to avoid collisions in concurrent extractions
+            temp_dir = tempfile.mkdtemp()
+            temp_mzml_path = Path(temp_dir) / f"{output.stem}_temp.mzML"
+
             # Delete output file if it already exists
             if output.exists():
                 output.unlink()
-            
+
             # Extract to temporary mzML file
-            self.extract(temp_mzml_path, indicies=indicies, scan_numbers=scan_numbers, ms_level=ms_level)
-            
-            # Compress the temporary mzML to MSZ
             temp_mzml = None
             try:
+                self.extract(temp_mzml_path, indicies=indicies, scan_numbers=scan_numbers, ms_level=ms_level)
+
+                # Compress the temporary mzML to MSZ
                 temp_mzml = MZMLFile(str(temp_mzml_path).encode('utf-8'))
                 return temp_mzml.compress(str(output))
             finally:
                 if temp_mzml is not None:
                     temp_mzml._cleanup()
-                if temp_mzml_path.exists():
-                    temp_mzml_path.unlink()
+                shutil.rmtree(temp_dir, ignore_errors=True)
 
         elif output_ext == '.mzml':
              # Convert Python lists to C arrays
@@ -373,12 +374,12 @@ cdef class MZMLFile(BaseFile):
                 indicies_arr = np.array(indicies, dtype=_c_long_dtype)
                 c_indicies = <long*>indicies_arr.data
                 indicies_length = len(indicies)
-            
+
             if scan_numbers is not None:
                 scans_arr = np.array(scan_numbers, dtype=np.uint32)
                 c_scans = <uint32_t*>scans_arr.data
                 scans_length = len(scan_numbers)
-            
+
             if ms_level is not None:
                 c_ms_level = <uint16_t>ms_level
 
@@ -393,7 +394,7 @@ cdef class MZMLFile(BaseFile):
                 c_scans,
                 scans_length,
                 c_ms_level,
-                self._positions, 
+                self._positions,
                 self.output_fd
             )
 
@@ -632,28 +633,27 @@ cdef class MSZFile(BaseFile):
         
         if output_ext == '.msz':
             # Output as MSZ (compressed)
-            # Create a temporary mzML file path, extract to it, then compress to MSZ
-            temp_mzml_path = Path(tempfile.gettempdir()) / f"{output.stem}_temp.mzML"
-            
+            # Create a unique temporary directory to avoid collisions in concurrent extractions
+            temp_dir = tempfile.mkdtemp()
+            temp_mzml_path = Path(temp_dir) / f"{output.stem}_temp.mzML"
+
             # Delete output file if it already exists to avoid stale data
             if output.exists():
                 output.unlink()
-            
+
             # Extract to temporary mzML file
-            self.extract(temp_mzml_path, indicies=indicies, scan_numbers=scan_numbers, ms_level=ms_level)
-            
-            # Compress the temporary mzML to MSZ
             temp_mzml = None
             try:
+                self.extract(temp_mzml_path, indicies=indicies, scan_numbers=scan_numbers, ms_level=ms_level)
+
+                # Compress the temporary mzML to MSZ
                 temp_mzml = MZMLFile(str(temp_mzml_path).encode('utf-8'))
                 return temp_mzml.compress(str(output))
             finally:
-                # Clean up MZMLFile's memory mapping before deleting the file
+                # Clean up MZMLFile's memory mapping before deleting the temp directory
                 if temp_mzml is not None:
                     temp_mzml._cleanup()
-                # Clean up temporary file
-                if temp_mzml_path.exists():
-                    temp_mzml_path.unlink()
+                shutil.rmtree(temp_dir, ignore_errors=True)
         
         elif output_ext == '.mzml':
             # Convert Python lists to C arrays

--- a/python/test/test_extract_concurrent.py
+++ b/python/test/test_extract_concurrent.py
@@ -1,0 +1,111 @@
+import tempfile
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from mscompress import read, MSZFile, MZMLFile
+
+
+def _extract_msz_to_msz(msz_file_path, output_path, scan_numbers):
+    """Worker function: extract specific scans from MSZ to MSZ."""
+    with read(msz_file_path) as msz:
+        msz.extract(output=output_path, scan_numbers=scan_numbers)
+
+
+def _extract_msz_to_mzml(msz_file_path, output_path, scan_numbers):
+    """Worker function: extract specific scans from MSZ to mzML."""
+    with read(msz_file_path) as msz:
+        msz.extract(output=output_path, scan_numbers=scan_numbers)
+
+
+def _extract_mzml_to_msz(mzml_file_path, output_path, scan_numbers):
+    """Worker function: extract specific scans from mzML to MSZ."""
+    with read(mzml_file_path) as mzml:
+        mzml.extract(output=output_path, scan_numbers=scan_numbers)
+
+
+def test_concurrent_msz_to_msz_extract(msz_file_path):
+    """Concurrent MSZ->MSZ extractions must not collide on temp paths."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tasks = [
+            (msz_file_path, str(Path(tmp) / "out_a.msz"), [1, 2]),
+            (msz_file_path, str(Path(tmp) / "out_b.msz"), [3, 4]),
+            (msz_file_path, str(Path(tmp) / "out_c.msz"), [1, 5]),
+        ]
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = {
+                pool.submit(_extract_msz_to_msz, *t): t for t in tasks
+            }
+            for f in as_completed(futures):
+                f.result()  # propagate any exception
+
+        # Verify each output independently
+        with read(str(Path(tmp) / "out_a.msz")) as a:
+            assert len(a.spectra) == 2
+            assert [s.scan for s in a.spectra] == [1, 2]
+
+        with read(str(Path(tmp) / "out_b.msz")) as b:
+            assert len(b.spectra) == 2
+            assert [s.scan for s in b.spectra] == [3, 4]
+
+        with read(str(Path(tmp) / "out_c.msz")) as c:
+            assert len(c.spectra) == 2
+            assert [s.scan for s in c.spectra] == [1, 5]
+
+
+def test_concurrent_msz_to_mzml_extract(msz_file_path):
+    """Concurrent MSZ->mzML extractions must not collide on temp paths."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tasks = [
+            (msz_file_path, str(Path(tmp) / "out_a.mzML"), [1, 2]),
+            (msz_file_path, str(Path(tmp) / "out_b.mzML"), [3, 4]),
+            (msz_file_path, str(Path(tmp) / "out_c.mzML"), [1, 5]),
+        ]
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = {
+                pool.submit(_extract_msz_to_mzml, *t): t for t in tasks
+            }
+            for f in as_completed(futures):
+                f.result()
+
+        with read(str(Path(tmp) / "out_a.mzML")) as a:
+            assert len(a.spectra) == 2
+            assert [s.scan for s in a.spectra] == [1, 2]
+
+        with read(str(Path(tmp) / "out_b.mzML")) as b:
+            assert len(b.spectra) == 2
+            assert [s.scan for s in b.spectra] == [3, 4]
+
+        with read(str(Path(tmp) / "out_c.mzML")) as c:
+            assert len(c.spectra) == 2
+            assert [s.scan for s in c.spectra] == [1, 5]
+
+
+def test_concurrent_mzml_to_msz_extract(mzml_file_path):
+    """Concurrent mzML->MSZ extractions must not collide on temp paths."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tasks = [
+            (mzml_file_path, str(Path(tmp) / "out_a.msz"), [1, 2]),
+            (mzml_file_path, str(Path(tmp) / "out_b.msz"), [3, 4]),
+            (mzml_file_path, str(Path(tmp) / "out_c.msz"), [1, 5]),
+        ]
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = {
+                pool.submit(_extract_mzml_to_msz, *t): t for t in tasks
+            }
+            for f in as_completed(futures):
+                f.result()
+
+        with read(str(Path(tmp) / "out_a.msz")) as a:
+            assert len(a.spectra) == 2
+            assert [s.scan for s in a.spectra] == [1, 2]
+
+        with read(str(Path(tmp) / "out_b.msz")) as b:
+            assert len(b.spectra) == 2
+            assert [s.scan for s in b.spectra] == [3, 4]
+
+        with read(str(Path(tmp) / "out_c.msz")) as c:
+            assert len(c.spectra) == 2
+            assert [s.scan for s in c.spectra] == [1, 5]


### PR DESCRIPTION
Closes #83 
## Whats changed
- Uses `tempfile.mkdtemp()` to create a unique temporary directory for each extract call to avoid collisions.
- Uses `shutil.rmtree()` to cleanup temporary directory created in extract.