### PR TITLE
bugfix: change return types for fails

### DIFF
--- a/cli/mscompress.c
+++ b/cli/mscompress.c
@@ -319,8 +319,11 @@ int main(int argc, char* argv[]) {
          }
 
          // Start compress routine.
-         compress_mzml((char*)input_map, input_filesize, &arguments, df,
-                       divisions, fds[1]);
+         if (compress_mzml((char*)input_map, input_filesize, &arguments, df,
+                           divisions, fds[1])) {
+            error_status = 1;
+            break;
+         }
 
          break;
       }
@@ -328,7 +331,10 @@ int main(int argc, char* argv[]) {
          print("\nDecompression and encoding...\n");
 
          // Start decompress routine.
-         decompress_msz(input_map, input_filesize, &arguments, fds[1]);
+         if (decompress_msz(input_map, input_filesize, &arguments, fds[1])) {
+            error_status = 1;
+            break;
+         }
 
          break;
       };
@@ -353,8 +359,11 @@ int main(int argc, char* argv[]) {
          preprocess_external((char*)input_map, input_filesize,
                              &(arguments.blocksize), &arguments, &df,
                              &divisions);
-         compress_mzml((char*)input_map, input_filesize, &arguments, df,
-                       divisions, fds[1]);
+         if (compress_mzml((char*)input_map, input_filesize, &arguments, df,
+                           divisions, fds[1])) {
+            error_status = 1;
+            break;
+         }
          break;
       }
       case DESCRIBE: {

--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -307,10 +307,12 @@ cdef class MZMLFile(BaseFile):
         output = os.fspath(output)
         self._prepare_divisions()
         self.output_fd = self._prepare_output_fd(output)
-        _compress_mzml(<char*> self._mapping, self.filesize, self._arguments.get_ptr(), self._df, self._divisions, self.output_fd)
+        cdef int rv = _compress_mzml(<char*> self._mapping, self.filesize, self._arguments.get_ptr(), self._df, self._divisions, self.output_fd)
         _flush(self.output_fd)
         _close_file(self.output_fd)
         self.output_fd = -1
+        if rv != 0:
+            raise RuntimeError("Compression failed: write error during compression.")
         return MSZFile(output.encode('utf-8'))
 
     def extract(
@@ -592,10 +594,12 @@ cdef class MSZFile(BaseFile):
     def decompress(self, output: Union[str, PathLike]) -> MZMLFile:
         output = os.fspath(output)
         self.output_fd = self._prepare_output_fd(output)
-        _decompress_msz(<char*>self._mapping, self.filesize, self._arguments.get_ptr(), self.output_fd)
+        cdef int rv = _decompress_msz(<char*>self._mapping, self.filesize, self._arguments.get_ptr(), self.output_fd)
         _flush(self.output_fd)
         _close_file(self.output_fd)
         self.output_fd = -1
+        if rv != 0:
+            raise RuntimeError("Decompression failed: error during decompression.")
         return MZMLFile(output.encode('utf-8'))
 
     def extract(

--- a/python/mscompress/_headers.pxi
+++ b/python/mscompress/_headers.pxi
@@ -176,8 +176,8 @@ cdef extern from "../src/mscompress.h":
     char* _extract_mzml_header "extract_mzml_header"(char* blk, division_t* first_division, size_t* out_len)
     char* _extract_mzml_footer "extract_mzml_footer"(char* blk, divisions_t* divisions, size_t* out_len)
     void _extract_msz "extract_msz"(char* input_map, size_t input_filesize, long* indicies, long indicies_length, uint32_t* scans, long scans_length, uint16_t ms_level, int output_fd)
-    void _compress_mzml "compress_mzml"(char* input_map, size_t input_filesize, Arguments* arguments, data_format_t* df, divisions_t* divisions, int output_fd)
-    void _decompress_msz "decompress_msz"(char* input_map, size_t input_filesize, Arguments* arguments, int fd)
+    int _compress_mzml "compress_mzml"(char* input_map, size_t input_filesize, Arguments* arguments, data_format_t* df, divisions_t* divisions, int output_fd)
+    int _decompress_msz "decompress_msz"(char* input_map, size_t input_filesize, Arguments* arguments, int fd)
     void _extract_mzml_filtered "extract_mzml_filtered"(char* input_map, size_t input_filesize, long* indicies, long indicies_length, uint32_t* scans, long scans_length, uint16_t ms_level, division_t* division, int output_fd)
 
     # Error/warning callback functions

--- a/src/compress.c
+++ b/src/compress.c
@@ -422,20 +422,22 @@ int cmp_flush(compression_fun compression_fun, ZSTD_CCtx* czstd,
 /**
  * @brief Writes a compressed block to file.
  *
- * Program exits via `error()` if writing to file fails.
- * TODO: This no longer exits. This should return an error code.
- *
  * @param blk A `cmp_block_t` with `mem` and `size` populated.
  * @param fd File descriptor to write to.
+ * @return 0 on success, -1 on write failure.
  */
-void write_cmp_blk(cmp_block_t* blk, int fd)
+int write_cmp_blk(cmp_block_t* blk, int fd)
 {
-   int rv;
+   size_t rv;
 
    rv = write_to_file(fd, blk->mem, blk->size);
 
-   if (rv != blk->size)
+   if (rv != blk->size) {
       error("write_cmp_blk: Did not write all bytes to disk.\n");
+      return -1;
+   }
+
+   return 0;
 }
 
 /**
@@ -448,15 +450,16 @@ void write_cmp_blk(cmp_block_t* blk, int fd)
  * @param cmp_buff A `cmp_blk_queue_t` to pop compressed blocks from.
  * @param blk_len_queue A `block_len_queue_t` to append block length metadata to.
  * @param fd File descriptor to write compressed data to.
+ * @return 0 on success, -1 on write failure.
  */
-void cmp_dump(cmp_blk_queue_t* cmp_buff, block_len_queue_t* blk_len_queue,
-              int fd)
+int cmp_dump(cmp_blk_queue_t* cmp_buff, block_len_queue_t* blk_len_queue,
+             int fd)
 {
    cmp_block_t* front;
    double start, end;
 
    if (cmp_buff == NULL)
-      return;  // Nothing to do.
+      return 0;  // Nothing to do.
 
    while (cmp_buff->populated > 0) {
       front = pop_cmp_block(cmp_buff);
@@ -464,7 +467,10 @@ void cmp_dump(cmp_blk_queue_t* cmp_buff, block_len_queue_t* blk_len_queue,
       append_block_len(blk_len_queue, front->original_size, front->size);
 
       start = get_time();
-      write_cmp_blk(front, fd);
+      if (write_cmp_blk(front, fd)) {
+         dealloc_cmp_block(front);
+         return -1;
+      }
       end = get_time();
 
       print("\tWrote %ld bytes to disk (%1.2fmb/s)\n", front->size,
@@ -472,6 +478,8 @@ void cmp_dump(cmp_blk_queue_t* cmp_buff, block_len_queue_t* blk_len_queue,
 
       dealloc_cmp_block(front);
    }
+
+   return 0;
 }
 
 typedef void (*cmp_routine_func)(compression_fun compression_fun, ZSTD_CCtx*,
@@ -717,8 +725,8 @@ void* compress_routine(void* args)
  * @param threads The maximum number of concurrent threads.
  * @param fd The output file descriptor to write compressed data to.
  * @return A pointer to the `block_len_queue_t` containing block length metadata for all
- *         compressed blocks. The caller is responsible for freeing this via
- *         `dealloc_block_len_queue()`.
+ *         compressed blocks, or `NULL` on error. The caller is responsible for freeing
+ *         this via `dealloc_block_len_queue()`.
  * @note Each `compress_args_t` and its compressed output are freed after writing to disk.
  */
 block_len_queue_t* compress_parallel(char* input_map, data_positions_t** ddp,
@@ -788,7 +796,14 @@ block_len_queue_t* compress_parallel(char* input_map, data_positions_t** ddp,
 #endif
 
       for (i = divisions_used; i < divisions_used + threads; i++) {
-         cmp_dump(args[i]->ret, blk_len_queue, fd);
+         if (cmp_dump(args[i]->ret, blk_len_queue, fd)) {
+            /* Clean up remaining args on write failure */
+            for (int j = i; j < divisions; j++)
+               dealloc_compress_args(args[j]);
+            free(args);
+            free(ptid);
+            return NULL;
+         }
          dealloc_compress_args(args[i]);
       }
       divisions_used += threads;
@@ -812,12 +827,13 @@ block_len_queue_t* compress_parallel(char* input_map, data_positions_t** ddp,
  * @param df A pointer to the `data_format_t` struct with source format and compression settings.
  * @param divisions A pointer to the `divisions_t` struct describing how the input was partitioned.
  * @param output_fd The file descriptor for the output .msz file.
+ * @return 0 on success, -1 on error.
  * @note This function writes the complete MSZ file (header, compressed streams,
  *       block lengths, divisions, footer). The caller is responsible for opening
  *       and closing the file descriptors.
  */
-void compress_mzml(char* input_map, size_t input_filesize, Arguments* arguments,
-                   data_format_t* df, divisions_t* divisions, int output_fd) {
+int compress_mzml(char* input_map, size_t input_filesize, Arguments* arguments,
+                  data_format_t* df, divisions_t* divisions, int output_fd) {
    // Initialize footer to all 0's to not write garbage to file.
    footer_t* footer = calloc(1, sizeof(footer_t));
 
@@ -855,6 +871,13 @@ void compress_mzml(char* input_map, size_t input_filesize, Arguments* arguments,
        blocksize / 3, _xml_, divisions->n_divisions, threads,
        output_fd); /* Compress XML */
    free(xml_divisions);
+   if (xml_block_lens == NULL) {
+      error("compress_mzml: Failed to compress XML stream.\n");
+      free(footer);
+      free(mz_divisions);
+      free(inten_divisions);
+      return -1;
+   }
 
    print("\t===m/z binary===\n");
    footer->mz_binary_pos = get_offset(output_fd);
@@ -865,6 +888,13 @@ void compress_mzml(char* input_map, size_t input_filesize, Arguments* arguments,
        blocksize / 3, _mass_, divisions->n_divisions, threads,
        output_fd); /* Compress m/z binary */
    free(mz_divisions);
+   if (mz_binary_block_lens == NULL) {
+      error("compress_mzml: Failed to compress m/z binary stream.\n");
+      dealloc_block_len_queue(xml_block_lens);
+      free(footer);
+      free(inten_divisions);
+      return -1;
+   }
 
    print("\t===int binary===\n");
    footer->inten_binary_pos = get_offset(output_fd);
@@ -875,6 +905,13 @@ void compress_mzml(char* input_map, size_t input_filesize, Arguments* arguments,
        blocksize, blocksize / 3, _intensity_, divisions->n_divisions, threads,
        output_fd); /* Compress int binary */
    free(inten_divisions);
+   if (inten_binary_block_lens == NULL) {
+      error("compress_mzml: Failed to compress intensity binary stream.\n");
+      dealloc_block_len_queue(xml_block_lens);
+      dealloc_block_len_queue(mz_binary_block_lens);
+      free(footer);
+      return -1;
+   }
 
    // Dump block_len_queue to msz file.
    footer->xml_blk_pos = get_offset(output_fd);
@@ -904,6 +941,8 @@ void compress_mzml(char* input_map, size_t input_filesize, Arguments* arguments,
    end = get_time();
 
    print("Decoding and compression time: %1.4fs\n", end - start);
+
+   return 0;
 }
 
 /**

--- a/src/decompress.c
+++ b/src/decompress.c
@@ -514,9 +514,10 @@ void* decompress_routine(void* args) {
  * @param input_filesize The size of the input buffer.
  * @param arguments A pointer to an `Arguments` struct containing the command line arguments.
  * @param fd The file descriptor to write the decompressed data to.
+ * @return 0 on success, -1 on error.
  */
-void decompress_msz(char* input_map, size_t input_filesize,
-                    Arguments* arguments, int fd) {
+int decompress_msz(char* input_map, size_t input_filesize,
+                   Arguments* arguments, int fd) {
    block_len_queue_t *xml_block_lens, *mz_binary_block_lens,
        *inten_binary_block_lens;
    footer_t* msz_footer;
@@ -536,13 +537,13 @@ void decompress_msz(char* input_map, size_t input_filesize,
 
    if (n_divisions == 0) {
       warning("No divisions found in file, aborting...\n");
-      return;
+      return -1;
    }
 
    int ret = set_decompress_runtime_variables(df, msz_footer);
    if (ret != 0) {
       error("decompress_msz: Failed to set decompression runtime variables.\n");
-      return;
+      return -1;
    }
 
    decompress_args_t** args =
@@ -597,14 +598,14 @@ void decompress_msz(char* input_map, size_t input_filesize,
              CreateThread(NULL, 0, decompress_routine_win, args[i], 0, NULL);
          if (ptid[i] == NULL) {
             perror("CreateThread");
-            return;
+            return -1;
          }
 #else
          int ret =
              pthread_create(&ptid[i], NULL, decompress_routine, (void*)args[i]);
          if (ret != 0) {
             perror("pthread_create");
-            return;
+            return -1;
          }
 #endif
       }
@@ -616,7 +617,7 @@ void decompress_msz(char* input_map, size_t input_filesize,
          int ret = pthread_join(ptid[i], NULL);
          if (ret != 0) {
             perror("pthread_join");
-            return;
+            return -1;
          }
       }
 #endif
@@ -624,7 +625,7 @@ void decompress_msz(char* input_map, size_t input_filesize,
       for (i = divisions_used; i < divisions_used + threads; i++) {
          if (args[i]->ret == NULL || args[i]->ret_len == -1) {
             error("decompress_msz: Decompression failed for division %d.\n", i);
-            return;
+            return -1;
          }
          start = get_time();
          write_to_file(fd, args[i]->ret, args[i]->ret_len);
@@ -648,6 +649,8 @@ void decompress_msz(char* input_map, size_t input_filesize,
    dealloc_block_len_queue(inten_binary_block_lens);
    dealloc_df(df);
    dealloc_read_divisions(divisions);
+
+   return 0;
 }
 
 /**

--- a/src/mscompress.h
+++ b/src/mscompress.h
@@ -486,8 +486,8 @@ void* zstd_compress(ZSTD_CCtx* cctx, void* src_buff, size_t src_len,
                     size_t* out_len, int compression_level);
 void* compress_routine(void* args);
 void dump_block_len_queue(block_len_queue_t* queue, int fd);
-void compress_mzml(char* input_map, size_t input_filesize, Arguments* arguments,
-                   data_format_t* df, divisions_t* divisions, int output_fd);
+int compress_mzml(char* input_map, size_t input_filesize, Arguments* arguments,
+                  data_format_t* df, divisions_t* divisions, int output_fd);
 int get_compress_type(char* arg);
 compression_fun set_compress_fun(int accession);
 
@@ -539,8 +539,8 @@ void* zstd_decompress(ZSTD_DCtx* dctx, void* src_buff, size_t src_len,
 void* decmp_block(decompression_fun decompress_fun, ZSTD_DCtx* dctx,
                   void* input_map, long offset, block_len_t* blk);
 void* decompress_routine(void* args);
-void decompress_msz(char* input_map, size_t input_filesize, Arguments* args,
-                    int fd);
+int decompress_msz(char* input_map, size_t input_filesize, Arguments* args,
+                   int fd);
 decompression_fun set_decompress_fun(int accession);
 
 /* algo.c */


### PR DESCRIPTION
Closes #77 
## Whats changed
- Changed return type of `write_cmp_blk` such that it returns an error code on failure.
- Changed return type of `compress_mzml()` and `decompress_msz()` to indicate failure to caller.