### PR TITLE
updated build action to run partial ci/cd on dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - 'v*'
     branches:
       - 'stage'
+      - 'dev'
   workflow_dispatch:
 
 jobs:
@@ -191,7 +192,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21
         env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_BUILD: ${{ github.ref == 'refs/heads/dev' && 'cp312-*' || 'cp39-* cp310-* cp311-* cp312-* cp313-*' }}
           CIBW_SKIP: "*-musllinux_*"
           CIBW_ARCHS: "${{ matrix.cibw_arch }}"
           CIBW_BEFORE_BUILD: "python {package}/../vendor/generate_config.py"
@@ -201,7 +202,7 @@ jobs:
           output-dir: ./python/wheelhouse
       
       - name: Build source distribution
-        if: matrix.runner == 'ubuntu-latest'
+        if: matrix.runner == 'ubuntu-latest' && github.ref != 'refs/heads/dev'
         working-directory: ./python
         run: |
           python -m pip install build


### PR DESCRIPTION
Closes #88 

## Whats changed
- Updated build action so that the GitHub action runs a subset of the build and tests to ensure nothing regressed without taking too much time.