### PR TITLE
Add streaming response support for compress, decompress, and extract

### DIFF
--- a/python/mscompress/_core.pyi
+++ b/python/mscompress/_core.pyi
@@ -126,8 +126,50 @@ class BaseFile:
     def describe(self) -> Dict[str, Any]: ...
     
     def compress(self, output: Union[str, PathLike]) -> MSZFile: ...
-    
+
     def decompress(self, output: Union[str, PathLike]) -> MZMLFile: ...
+
+    def compress_stream(self, chunk_size: int = ...) -> Iterator[bytes]:
+        """Compress this file and yield the MSZ output as byte chunks.
+
+        Args:
+            chunk_size: Number of bytes to read per iteration (default 1MB).
+
+        Yields:
+            Chunks of compressed MSZ data.
+        """
+        ...
+
+    def decompress_stream(self, chunk_size: int = ...) -> Iterator[bytes]:
+        """Decompress this file and yield the mzML output as byte chunks.
+
+        Args:
+            chunk_size: Number of bytes to read per iteration (default 1MB).
+
+        Yields:
+            Chunks of decompressed mzML data.
+        """
+        ...
+
+    def extract_stream(
+        self,
+        indicies: Optional[list[int]] = None,
+        scan_numbers: Optional[list[int]] = None,
+        ms_level: Optional[int] = None,
+        chunk_size: int = ...,
+    ) -> Iterator[bytes]:
+        """Extract spectra and yield the mzML output as byte chunks.
+
+        Args:
+            indicies: List of spectrum indices to extract (optional).
+            scan_numbers: List of scan numbers to extract (optional).
+            ms_level: MS level to extract (optional).
+            chunk_size: Number of bytes to read per iteration (default 1MB).
+
+        Yields:
+            Chunks of extracted mzML data.
+        """
+        ...
 
     def extract(
             self,
@@ -186,18 +228,29 @@ class BaseFile:
 
 class MZMLFile(BaseFile):
     """Handler for mzML format files."""
-    
+
     def __init__(self, path: bytes) -> None: ...
-    
+
     def compress(self, output: Union[str, PathLike]) -> MSZFile:
         """
         Compress an mzML file to MSZ format.
-        
+
         Parameters:
             output: Output file path (string or path-like).
         """
         ...
-    
+
+    def compress_stream(self, chunk_size: int = ...) -> Iterator[bytes]:
+        """Compress this mzML file and yield the MSZ output as byte chunks.
+
+        Args:
+            chunk_size: Number of bytes to read per iteration (default 1MB).
+
+        Yields:
+            Chunks of compressed MSZ data.
+        """
+        ...
+
     def extract(self, output: str | PathLike, indicies: list[int] | None = ..., scan_numbers: list[int] | None = ..., ms_level: int | None = ...) -> Union[MZMLFile, MSZFile]: ...
     """
     Extract specific spectra from an mzML file to a new mzML or MSZ file.
@@ -208,6 +261,20 @@ class MZMLFile(BaseFile):
         scan_numbers: List of scan numbers to extract (optional).
         ms_level: MS level to extract (optional).
     """
+
+    def extract_stream(self, indicies: list[int] | None = ..., scan_numbers: list[int] | None = ..., ms_level: int | None = ..., chunk_size: int = ...) -> Iterator[bytes]:
+        """Extract spectra from this mzML file and yield mzML output as byte chunks.
+
+        Args:
+            indicies: List of spectrum indices to extract (optional).
+            scan_numbers: List of scan numbers to extract (optional).
+            ms_level: MS level to extract (optional).
+            chunk_size: Number of bytes to read per iteration (default 1MB).
+
+        Yields:
+            Chunks of extracted mzML data.
+        """
+        ...
 
     def get_mz_binary(self, index: int) -> npt.NDArray[Union[np.float32, np.float64]]:
         """
@@ -247,15 +314,26 @@ class MZMLFile(BaseFile):
 
 class MSZFile(BaseFile):
     """Handler for MSZ (compressed) format files."""
-    
+
     def __init__(self, path: bytes) -> None: ...
-    
+
     def decompress(self, output: Union[str, PathLike]) -> MZMLFile:
         """
         Decompress an MSZ file to mzML format.
-        
+
         Parameters:
             output: Output file path (string or path-like).
+        """
+        ...
+
+    def decompress_stream(self, chunk_size: int = ...) -> Iterator[bytes]:
+        """Decompress this MSZ file and yield the mzML output as byte chunks.
+
+        Args:
+            chunk_size: Number of bytes to read per iteration (default 1MB).
+
+        Yields:
+            Chunks of decompressed mzML data.
         """
         ...
 
@@ -268,6 +346,20 @@ class MSZFile(BaseFile):
         scan_numbers: List of scan numbers to extract (optional).
         ms_level: MS level to extract (optional).
     """
+
+    def extract_stream(self, indicies: list[int] | None = ..., scan_numbers: list[int] | None = ..., ms_level: int | None = ..., chunk_size: int = ...) -> Iterator[bytes]:
+        """Extract spectra from this MSZ file and yield mzML output as byte chunks.
+
+        Args:
+            indicies: List of spectrum indices to extract (optional).
+            scan_numbers: List of scan numbers to extract (optional).
+            ms_level: MS level to extract (optional).
+            chunk_size: Number of bytes to read per iteration (default 1MB).
+
+        Yields:
+            Chunks of extracted mzML data.
+        """
+        ...
     
     def get_mz_binary(self, index: int) -> npt.NDArray[Union[np.float32, np.float64]]:
         """

--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -4,8 +4,9 @@ import numpy as np
 import warnings
 import tempfile
 import ctypes
+import threading
 cimport numpy as np
-from typing import Union
+from typing import Union, Iterator, Optional
 from os import PathLike
 from pathlib import Path
 from xml.etree.ElementTree import fromstring, Element, ParseError
@@ -29,12 +30,14 @@ def _install_mscompress_warning_formatter():
     warnings.formatwarning = _mscompress_formatwarning
 
 _install_mscompress_warning_formatter()
-cdef void _python_error_handler(const char* message) noexcept:
+# `with gil` is required because these callbacks may be invoked from C code
+# running without the GIL (e.g., streaming methods release the GIL for I/O).
+cdef void _python_error_handler(const char* message) noexcept with gil:
     """Callback function to handle C errors in Python"""
     msg = message.decode('utf-8') if isinstance(message, bytes) else message
     warnings.warn(msg.strip(), RuntimeWarning, stacklevel=2)
 
-cdef void _python_warning_handler(const char* message) noexcept:
+cdef void _python_warning_handler(const char* message) noexcept with gil:
     """Callback function to handle C warnings in Python"""
     msg = message.decode('utf-8') if isinstance(message, bytes) else message
     warnings.warn(msg.strip(), RuntimeWarning, stacklevel=2)
@@ -42,6 +45,58 @@ cdef void _python_warning_handler(const char* message) noexcept:
 # Initialize callbacks when module is imported
 _set_error_callback(_python_error_handler)
 _set_warning_callback(_python_warning_handler)
+
+
+def _pipe_stream(c_func, args, chunk_size=1_048_576):
+    """
+    Pipe-based streaming bridge between C fd-oriented writes and Python iterators.
+
+    Creates an OS pipe, runs the C function in a background thread writing to the
+    pipe's write end, and yields bytes chunks read from the pipe's read end.
+
+    Args:
+        c_func: Callable that accepts (*args, write_fd) and writes output to the fd.
+        args: Tuple of arguments to pass to c_func before the write_fd.
+        chunk_size: Number of bytes to read per iteration (default 1MB).
+
+    Yields:
+        bytes: Chunks of output data from the C function.
+
+    Raises:
+        RuntimeError: If the C function raises an exception in the background thread.
+    """
+    read_fd, write_fd = os.pipe()
+    exc_holder = [None]
+
+    def _worker():
+        try:
+            c_func(*args, write_fd)
+        except Exception as e:
+            exc_holder[0] = e
+        finally:
+            os.close(write_fd)
+
+    t = threading.Thread(target=_worker, daemon=True)
+    t.start()
+
+    reader = os.fdopen(read_fd, 'rb')
+    try:
+        while True:
+            chunk = reader.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+    except GeneratorExit:
+        reader.close()
+        t.join()
+        return
+    finally:
+        reader.close()
+
+    t.join()
+    if exc_holder[0] is not None:
+        raise exc_holder[0]
+
 
 cdef class RuntimeArguments:
     cdef Arguments _arguments
@@ -316,6 +371,34 @@ cdef class MZMLFile(BaseFile):
             raise RuntimeError("Compression failed: write error during compression.")
         return MSZFile(output.encode('utf-8'))
 
+    def _compress_to_fd(self, int write_fd):
+        """Internal helper: run compression pipeline writing to the given fd."""
+        cdef int rv
+        cdef char* mapping = <char*> self._mapping
+        cdef size_t filesize = self.filesize
+        cdef Arguments* args = self._arguments.get_ptr()
+        cdef data_format_t* df = self._df
+        cdef divisions_t* divisions = self._divisions
+        # Release the GIL so the reader thread can drain the pipe; without this,
+        # write() blocks on a full pipe while holding the GIL → deadlock.
+        with nogil:
+            rv = _compress_mzml(mapping, filesize, args, df, divisions, write_fd)
+            _flush(write_fd)
+        if rv != 0:
+            raise RuntimeError("Compression failed: write error during compression.")
+
+    def compress_stream(self, chunk_size: int = 1_048_576) -> Iterator[bytes]:
+        """Compress this mzML file and yield the MSZ output as byte chunks.
+
+        Args:
+            chunk_size: Number of bytes to read per iteration (default 1MB).
+
+        Yields:
+            bytes: Chunks of compressed MSZ data.
+        """
+        self._prepare_divisions()
+        return _pipe_stream(self._compress_to_fd, (), chunk_size=chunk_size)
+
     def extract(
         self,
         output: Union[str, PathLike],
@@ -407,6 +490,70 @@ cdef class MZMLFile(BaseFile):
             return MZMLFile(str(output).encode('utf-8'))
         else:
             raise ValueError(f"Unsupported output file extension: {output_ext}. Use .msz or .mzML")
+
+    def _extract_mzml_to_fd(self, indicies_arr, scans_arr, uint16_t c_ms_level, int write_fd):
+        """Internal helper: run mzML extraction writing to the given fd."""
+        cdef long* c_indicies = NULL
+        cdef long indicies_length = 0
+        cdef uint32_t* c_scans = NULL
+        cdef long scans_length = 0
+        cdef char* mapping = <char*>self._mapping
+        cdef size_t filesize = self.filesize
+        cdef division_t* positions = self._positions
+
+        if indicies_arr is not None:
+            c_indicies = <long*>(<np.ndarray>indicies_arr).data
+            indicies_length = len(indicies_arr)
+
+        if scans_arr is not None:
+            c_scans = <uint32_t*>(<np.ndarray[np.uint32_t, ndim=1]>scans_arr).data
+            scans_length = len(scans_arr)
+
+        # Release the GIL so the reader thread can drain the pipe.
+        with nogil:
+            _extract_mzml_filtered(
+                mapping,
+                filesize,
+                c_indicies,
+                indicies_length,
+                c_scans,
+                scans_length,
+                c_ms_level,
+                positions,
+                write_fd
+            )
+            _flush(write_fd)
+
+    def extract_stream(
+        self,
+        indicies: Optional[list[int]] = None,
+        scan_numbers: Optional[list[int]] = None,
+        ms_level: Optional[int] = None,
+        chunk_size: int = 1_048_576
+    ) -> Iterator[bytes]:
+        """Extract spectra from this mzML file and yield mzML output as byte chunks.
+
+        Args:
+            indicies: Optional list of spectrum indices to extract.
+            scan_numbers: Optional list of scan numbers to extract.
+            ms_level: Optional MS level to filter by (e.g., 1 for MS1, 2 for MS2).
+            chunk_size: Number of bytes to read per iteration (default 1MB).
+
+        Yields:
+            bytes: Chunks of extracted mzML data.
+        """
+        indicies_arr = None
+        scans_arr = None
+        cdef uint16_t c_ms_level = 0
+
+        if indicies is not None:
+            indicies_arr = np.array(indicies, dtype=_c_long_dtype)
+        if scan_numbers is not None:
+            scans_arr = np.array(scan_numbers, dtype=np.uint32)
+        if ms_level is not None:
+            c_ms_level = <uint16_t>ms_level
+
+        return _pipe_stream(self._extract_mzml_to_fd, (indicies_arr, scans_arr, c_ms_level), chunk_size=chunk_size)
 
     def get_mz_binary(self, size_t index):
         cdef char* dest = NULL
@@ -603,6 +750,30 @@ cdef class MSZFile(BaseFile):
             raise RuntimeError("Decompression failed: error during decompression.")
         return MZMLFile(output.encode('utf-8'))
 
+    def _decompress_to_fd(self, int write_fd):
+        """Internal helper: run decompression pipeline writing to the given fd."""
+        cdef int rv
+        cdef char* mapping = <char*>self._mapping
+        cdef size_t filesize = self.filesize
+        cdef Arguments* args = self._arguments.get_ptr()
+        # Release the GIL so the reader thread can drain the pipe.
+        with nogil:
+            rv = _decompress_msz(mapping, filesize, args, write_fd)
+            _flush(write_fd)
+        if rv != 0:
+            raise RuntimeError("Decompression failed: error during decompression.")
+
+    def decompress_stream(self, chunk_size: int = 1_048_576) -> Iterator[bytes]:
+        """Decompress this MSZ file and yield the mzML output as byte chunks.
+
+        Args:
+            chunk_size: Number of bytes to read per iteration (default 1MB).
+
+        Yields:
+            bytes: Chunks of decompressed mzML data.
+        """
+        return _pipe_stream(self._decompress_to_fd, (), chunk_size=chunk_size)
+
     def extract(
         self,
         output: Union[str, PathLike],
@@ -697,7 +868,68 @@ cdef class MSZFile(BaseFile):
             return MZMLFile(str(output).encode('utf-8'))
         else:
             raise ValueError(f"Unsupported output file extension: {output_ext}. Use .msz or .mzML")
-        
+
+    def _extract_msz_to_fd(self, indicies_arr, scans_arr, uint16_t c_ms_level, int write_fd):
+        """Internal helper: run MSZ extraction writing to the given fd."""
+        cdef long* c_indicies = NULL
+        cdef long indicies_length = 0
+        cdef uint32_t* c_scans = NULL
+        cdef long scans_length = 0
+        cdef char* mapping = <char*>self._mapping
+        cdef size_t filesize = self.filesize
+
+        if indicies_arr is not None:
+            c_indicies = <long*>(<np.ndarray>indicies_arr).data
+            indicies_length = len(indicies_arr)
+
+        if scans_arr is not None:
+            c_scans = <uint32_t*>(<np.ndarray[np.uint32_t, ndim=1]>scans_arr).data
+            scans_length = len(scans_arr)
+
+        # Release the GIL so the reader thread can drain the pipe.
+        with nogil:
+            _extract_msz(
+                mapping,
+                filesize,
+                c_indicies,
+                indicies_length,
+                c_scans,
+                scans_length,
+                c_ms_level,
+                write_fd
+            )
+            _flush(write_fd)
+
+    def extract_stream(
+        self,
+        indicies: Optional[list[int]] = None,
+        scan_numbers: Optional[list[int]] = None,
+        ms_level: Optional[int] = None,
+        chunk_size: int = 1_048_576
+    ) -> Iterator[bytes]:
+        """Extract spectra from this MSZ file and yield mzML output as byte chunks.
+
+        Args:
+            indicies: Optional list of spectrum indices to extract.
+            scan_numbers: Optional list of scan numbers to extract.
+            ms_level: Optional MS level to filter by (e.g., 1 for MS1, 2 for MS2).
+            chunk_size: Number of bytes to read per iteration (default 1MB).
+
+        Yields:
+            bytes: Chunks of extracted mzML data.
+        """
+        indicies_arr = None
+        scans_arr = None
+        cdef uint16_t c_ms_level = 0
+
+        if indicies is not None:
+            indicies_arr = np.array(indicies, dtype=_c_long_dtype)
+        if scan_numbers is not None:
+            scans_arr = np.array(scan_numbers, dtype=np.uint32)
+        if ms_level is not None:
+            c_ms_level = <uint16_t>ms_level
+
+        return _pipe_stream(self._extract_msz_to_fd, (indicies_arr, scans_arr, c_ms_level), chunk_size=chunk_size)
 
     def get_mz_binary(self, size_t index):
         cdef char* res = NULL

--- a/python/mscompress/_headers.pxi
+++ b/python/mscompress/_headers.pxi
@@ -137,7 +137,7 @@ cdef extern from "../src/mscompress.h":
     int _open_output_file "open_output_file"(char* path)
     int _close_file "close_file"(int fd)
     int _remove_mapping "remove_mapping"(void* addr, size_t length)
-    int _flush "flush"(int fd)
+    int _flush "flush"(int fd) nogil
     size_t _get_filesize "get_filesize"(char* path)
     void* _get_mapping "get_mapping"(int fd)
     int _determine_filetype "determine_filetype"(void* input_map, size_t input_length)
@@ -175,10 +175,12 @@ cdef extern from "../src/mscompress.h":
     char* _extract_spectra "extract_spectra"(char* input_map, ZSTD_DCtx* dctx, data_format_t* df, block_len_queue_t* _xml_block_lens, block_len_queue_t* _mz_binary_block_lens, block_len_queue_t* _inten_binary_block_lens, long xml_pos, long mz_pos, long inten_pos, int mz_fmt, int inten_fmt, divisions_t* divisions, long index, size_t* out_len)
     char* _extract_mzml_header "extract_mzml_header"(char* blk, division_t* first_division, size_t* out_len)
     char* _extract_mzml_footer "extract_mzml_footer"(char* blk, divisions_t* divisions, size_t* out_len)
-    void _extract_msz "extract_msz"(char* input_map, size_t input_filesize, long* indicies, long indicies_length, uint32_t* scans, long scans_length, uint16_t ms_level, int output_fd)
-    int _compress_mzml "compress_mzml"(char* input_map, size_t input_filesize, Arguments* arguments, data_format_t* df, divisions_t* divisions, int output_fd)
-    int _decompress_msz "decompress_msz"(char* input_map, size_t input_filesize, Arguments* arguments, int fd)
-    void _extract_mzml_filtered "extract_mzml_filtered"(char* input_map, size_t input_filesize, long* indicies, long indicies_length, uint32_t* scans, long scans_length, uint16_t ms_level, division_t* division, int output_fd)
+    # `nogil` allows these to be called from `with nogil:` blocks in the streaming
+    # methods, which release the GIL to prevent pipe deadlocks between writer/reader threads.
+    void _extract_msz "extract_msz"(char* input_map, size_t input_filesize, long* indicies, long indicies_length, uint32_t* scans, long scans_length, uint16_t ms_level, int output_fd) nogil
+    int _compress_mzml "compress_mzml"(char* input_map, size_t input_filesize, Arguments* arguments, data_format_t* df, divisions_t* divisions, int output_fd) nogil
+    int _decompress_msz "decompress_msz"(char* input_map, size_t input_filesize, Arguments* arguments, int fd) nogil
+    void _extract_mzml_filtered "extract_mzml_filtered"(char* input_map, size_t input_filesize, long* indicies, long indicies_length, uint32_t* scans, long scans_length, uint16_t ms_level, division_t* division, int output_fd) nogil
 
     # Error/warning callback functions
     ctypedef void (*error_callback_t)(const char* message)

--- a/python/test/test_stream.py
+++ b/python/test/test_stream.py
@@ -1,0 +1,190 @@
+import os
+import tempfile
+import pytest
+from mscompress import MZMLFile, MSZFile, read
+
+
+def test_compress_stream(mzml_file_path):
+    """Compress via stream, verify output is non-empty bytes."""
+    with read(mzml_file_path) as mzml:
+        chunks = list(mzml.compress_stream())
+        assert len(chunks) > 0
+        data = b"".join(chunks)
+        assert len(data) > 0
+
+
+def test_compress_stream_roundtrip(mzml_file_path, tmp_path):
+    """Compress via stream, write to file, verify it can be opened as MSZFile."""
+    output_path = tmp_path / "stream_output.msz"
+    with read(mzml_file_path) as mzml:
+        with open(output_path, "wb") as f:
+            for chunk in mzml.compress_stream():
+                f.write(chunk)
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
+
+    # Verify the streamed output is a valid MSZ file
+    with read(str(output_path)) as msz:
+        assert isinstance(msz, MSZFile)
+        assert msz.format.source_total_spec > 0
+
+
+def test_compress_stream_matches_file(mzml_file_path, tmp_path):
+    """Verify stream output is byte-for-byte identical to file output."""
+    file_output = tmp_path / "file_output.msz"
+    with read(mzml_file_path) as mzml:
+        mzml.compress(file_output)
+
+    with open(file_output, "rb") as f:
+        file_bytes = f.read()
+
+    with read(mzml_file_path) as mzml:
+        stream_bytes = b"".join(mzml.compress_stream())
+
+    assert stream_bytes == file_bytes
+
+
+def test_decompress_stream(msz_file_path):
+    """Decompress via stream, verify output is non-empty bytes."""
+    with read(msz_file_path) as msz:
+        chunks = list(msz.decompress_stream())
+        assert len(chunks) > 0
+        data = b"".join(chunks)
+        assert len(data) > 0
+
+
+def test_decompress_stream_roundtrip(msz_file_path, tmp_path):
+    """Decompress via stream, write to file, verify it can be opened as MZMLFile."""
+    output_path = tmp_path / "stream_output.mzML"
+    with read(msz_file_path) as msz:
+        with open(output_path, "wb") as f:
+            for chunk in msz.decompress_stream():
+                f.write(chunk)
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
+
+    # Verify the streamed output is a valid mzML file
+    with read(str(output_path)) as mzml:
+        assert isinstance(mzml, MZMLFile)
+        assert mzml.format.source_total_spec > 0
+
+
+def test_decompress_stream_matches_file(msz_file_path, tmp_path):
+    """Verify stream output is byte-for-byte identical to file output."""
+    file_output = tmp_path / "file_output.mzML"
+    with read(msz_file_path) as msz:
+        msz.decompress(file_output)
+
+    with open(file_output, "rb") as f:
+        file_bytes = f.read()
+
+    with read(msz_file_path) as msz:
+        stream_bytes = b"".join(msz.decompress_stream())
+
+    assert stream_bytes == file_bytes
+
+
+def test_extract_stream_msz(msz_file_path):
+    """Extract from MSZ via stream, verify output is non-empty bytes."""
+    with read(msz_file_path) as msz:
+        chunks = list(msz.extract_stream())
+        assert len(chunks) > 0
+        data = b"".join(chunks)
+        assert len(data) > 0
+
+
+def test_extract_stream_msz_with_indicies(msz_file_path):
+    """Extract specific indices from MSZ via stream."""
+    with read(msz_file_path) as msz:
+        chunks = list(msz.extract_stream(indicies=[0, 1, 2]))
+        assert len(chunks) > 0
+        data = b"".join(chunks)
+        assert len(data) > 0
+
+
+def test_extract_stream_msz_with_ms_level(msz_file_path):
+    """Extract specific MS level from MSZ via stream."""
+    with read(msz_file_path) as msz:
+        chunks = list(msz.extract_stream(ms_level=1))
+        assert len(chunks) > 0
+        data = b"".join(chunks)
+        assert len(data) > 0
+
+
+def test_extract_stream_msz_matches_file(msz_file_path, tmp_path):
+    """Verify MSZ extract stream output matches file output."""
+    file_output = tmp_path / "file_extract.mzML"
+    with read(msz_file_path) as msz:
+        msz.extract(file_output, indicies=[0, 1, 2])
+
+    with open(file_output, "rb") as f:
+        file_bytes = f.read()
+
+    with read(msz_file_path) as msz:
+        stream_bytes = b"".join(msz.extract_stream(indicies=[0, 1, 2]))
+
+    assert stream_bytes == file_bytes
+
+
+def test_extract_stream_mzml(mzml_file_path):
+    """Extract from mzML via stream, verify output is non-empty bytes."""
+    with read(mzml_file_path) as mzml:
+        chunks = list(mzml.extract_stream())
+        assert len(chunks) > 0
+        data = b"".join(chunks)
+        assert len(data) > 0
+
+
+def test_extract_stream_mzml_with_indicies(mzml_file_path):
+    """Extract specific indices from mzML via stream."""
+    with read(mzml_file_path) as mzml:
+        chunks = list(mzml.extract_stream(indicies=[0, 1, 2]))
+        assert len(chunks) > 0
+        data = b"".join(chunks)
+        assert len(data) > 0
+
+
+def test_extract_stream_mzml_with_ms_level(mzml_file_path):
+    """Extract specific MS level from mzML via stream."""
+    with read(mzml_file_path) as mzml:
+        chunks = list(mzml.extract_stream(ms_level=1))
+        assert len(chunks) > 0
+        data = b"".join(chunks)
+        assert len(data) > 0
+
+
+def test_extract_stream_mzml_matches_file(mzml_file_path, tmp_path):
+    """Verify mzML extract stream output matches file output."""
+    file_output = tmp_path / "file_extract.mzML"
+    with read(mzml_file_path) as mzml:
+        mzml.extract(file_output, indicies=[0, 1, 2])
+
+    with open(file_output, "rb") as f:
+        file_bytes = f.read()
+
+    with read(mzml_file_path) as mzml:
+        stream_bytes = b"".join(mzml.extract_stream(indicies=[0, 1, 2]))
+
+    assert stream_bytes == file_bytes
+
+
+def test_stream_chunk_size(msz_file_path):
+    """Verify chunk_size parameter affects chunk sizes."""
+    small_chunk = 4096
+    with read(msz_file_path) as msz:
+        chunks = list(msz.decompress_stream(chunk_size=small_chunk))
+        # All chunks except possibly the last should be exactly chunk_size
+        for chunk in chunks[:-1]:
+            assert len(chunk) == small_chunk
+
+
+def test_stream_early_close(msz_file_path):
+    """Verify no crash/leak when iterator is abandoned early."""
+    with read(msz_file_path) as msz:
+        gen = msz.decompress_stream()
+        first_chunk = next(gen)
+        assert len(first_chunk) > 0
+        # Abandon the generator without consuming all chunks
+        gen.close()


### PR DESCRIPTION
Closes #84 

## Whats changed
- Adds `compress_stream()`, `decompress_stream()`, and `extract_stream()` methods to the Python bindings that return `Iterator[bytes]` instead of writing to a file.
- Enables piping output directly to network sockets, HTTP responses, or in-memory consumers without temporary files on disk
- Uses OS pipes as a bridge between the C library's fd-oriented writes and Python's iterator interface, with a background thread running the C function and the caller reading chunks from the pipe
