### PR TITLE
Drop support for python 3.9, add support for python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,18 +159,24 @@ jobs:
           - runner: ubuntu-latest
             cibw_arch: x86_64
             os_name: Linux
+            cibw_build_full: "cp310-* cp311-* cp312-* cp313-* cp314-*"
           - runner: ubuntu-24.04-arm
             cibw_arch: aarch64
             os_name: Linux
+            cibw_build_full: "cp310-* cp311-* cp312-* cp313-* cp314-*"
           - runner: windows-latest
             cibw_arch: AMD64
             os_name: Windows
+            cibw_build_full: "cp310-* cp311-* cp312-* cp313-* cp314-*"
           - runner: macos-latest
             cibw_arch: arm64
             os_name: macOS
+            cibw_build_full: "cp310-* cp311-* cp312-* cp313-* cp314-*"
           - runner: macos-15-intel
             cibw_arch: x86_64
             os_name: macOS
+            # PyTorch for macOS Intel is no longer updated beyond Python 3.12, so we limit to cp312.
+            cibw_build_full: "cp310-* cp311-* cp312-*"
     
     steps:
       - name: Checkout code
@@ -195,7 +201,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21
         env:
-          CIBW_BUILD: ${{ (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/stage') && 'cp39-* cp310-* cp311-* cp312-* cp313-*' || 'cp312-*' }}
+          CIBW_BUILD: ${{ (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/stage') && matrix.cibw_build_full || 'cp312-*' }}
           CIBW_SKIP: "*-musllinux_*"
           CIBW_ARCHS: "${{ matrix.cibw_arch }}"
           # Use manylinux_2_28 so pre-built scipy wheels (required by mlcroissant) are available

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "mscompress"
 version = "1.0.10"
 description = "Python bindings for mscompress, a compression library for mass spectrometry data"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "mlcroissant>=1.0.0",
     "numpy<2",
@@ -40,7 +40,7 @@ include-package-data = false
 "*" = ["*.pyx", "*.pxd", "*.c", "*.h", "*.pyi", "py.typed"]
 
 [tool.cibuildwheel]
-build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
+build = ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
 skip = ["*-musllinux_*"]
 build-verbosity = 1
 


### PR DESCRIPTION
## Whats changed
- PyTorch for macOS Intel is no longer maintained upstream past Python 3.12. MacOS Intel now only supports Python 3.10-3.12.
- Python 3.9 is EOL since October 2025. Dropped support.
- Added build for Python 3.14.