### PR TITLE
Fix segfault in get_scan() for mzML without scan= attribute

### DIFF
--- a/cli/test/CMakeLists.txt
+++ b/cli/test/CMakeLists.txt
@@ -82,6 +82,17 @@ add_cli_test(CompressDecompressIntLossy_vdelta24 "--int-lossy;vdelta24")
 add_cli_test(CompressDecompressIntLossy_vbr "--int-lossy;vbr")
 add_cli_test(CompressDecompressIntLossy_bitpack "--int-lossy;bitpack")
 
+# Test mzML files without scan= attribute (e.g. Sciex TTOF6600: sample/period/cycle/experiment IDs)
+# Regression test for GitHub issue #103
+add_test(NAME CompressSciexNoScanAttr
+    COMMAND ${CMAKE_COMMAND}
+    -DEXECUTABLE=$<TARGET_FILE:mscompress>
+    "-DARGS="
+    -DINPUT_FILE=${TEST_DATA_DIR}/sciex_ttof6600_100.mzML
+    -DTEMP_DIR=${CMAKE_CURRENT_BINARY_DIR}/tmp_sciex_no_scan
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/run_test_simple.cmake
+)
+
 # Verbose mode test
 add_test(NAME VerboseOutputTest
     COMMAND ${CMAKE_COMMAND}

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -23,6 +23,11 @@ def mszx_file_path():
     return str(_TEST_DATA_DIR / "mszx" / "test.mszx")
 
 @pytest.fixture
+def sciex_mzml_file_path():
+    return str(_TEST_DATA_DIR / "sciex_ttof6600_100.mzML")
+
+
+@pytest.fixture
 def pepxml_file_path():
     return str(_TEST_DATA_DIR / "pepXML" / "test.pepXML")
 

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -33,11 +33,13 @@ def test_mscompress_dataset_directory(test_data_dir):
             global_index += 1
     assert global_index == total_spectra
 
-    # Test same sample across different files
-    sample_1 = dataset[0]
-    sample_1_repeat = dataset[50] # Will be index 0 from second file.
-    assert torch.equal(sample_1[0], sample_1_repeat[0])
-    assert torch.equal(sample_1[1], sample_1_repeat[1])
+    # Test same sample from test.mzML and test.msz (identical data)
+    mzml_member = dataset.members["test.mzML"]
+    msz_member = dataset.members["test.msz"]
+    sample_mzml = mzml_member[0]
+    sample_msz = msz_member[0]
+    assert torch.equal(sample_mzml[0], sample_msz[0])
+    assert torch.equal(sample_mzml[1], sample_msz[1])
 
 
 def test_mscompress_dataset_w_annotations(mszx_file_path):

--- a/python/test/test_sciex_no_scan.py
+++ b/python/test/test_sciex_no_scan.py
@@ -30,20 +30,24 @@ def test_sciex_scan_numbers_fallback(sciex_mzml_file_path):
 
 def test_sciex_compress_decompress(sciex_mzml_file_path):
     """Compress and decompress a Sciex mzML file without crashing."""
-    mzml = read(sciex_mzml_file_path)
-    with tempfile.TemporaryDirectory() as tmpdir:
-        msz_path = Path(tmpdir) / "sciex.msz"
+    msz_path = Path(sciex_mzml_file_path).with_suffix('.msz')
+
+    with read(sciex_mzml_file_path) as mzml:
         mzml.compress(output=msz_path)
-        assert msz_path.exists()
-        assert msz_path.stat().st_size > 0
 
-        msz = read(str(msz_path))
-        assert isinstance(msz, MSZFile)
-        assert len(msz.spectra) == 100
+    assert msz_path.exists()
+    assert msz_path.stat().st_size > 0
 
-        # Verify scan fallback persists through compress/decompress
-        for i, spectrum in enumerate(msz.spectra):
-            assert spectrum.scan == i + 1
+    try:
+        with read(str(msz_path)) as msz:
+            assert isinstance(msz, MSZFile)
+            assert len(msz.spectra) == 100
+
+            # Verify scan fallback persists through compress/decompress
+            for i, spectrum in enumerate(msz.spectra):
+                assert spectrum.scan == i + 1
+    finally:
+        msz_path.unlink(missing_ok=True)
 
 
 def test_sciex_spectrum_metadata(sciex_mzml_file_path):

--- a/python/test/test_sciex_no_scan.py
+++ b/python/test/test_sciex_no_scan.py
@@ -1,0 +1,55 @@
+"""Regression tests for GitHub issue #103.
+
+Sciex TTOF6600 mzML files use spectrum IDs like
+  sample=1 period=1 cycle=1 experiment=1
+instead of containing a scan= attribute. This caused a segfault in get_scan()
+due to NULL pointer arithmetic, and O(n^2) scanning from unbounded strstr.
+"""
+import tempfile
+from pathlib import Path
+
+import pytest
+from mscompress import read, MZMLFile, MSZFile
+
+
+def test_read_sciex_mzml(sciex_mzml_file_path):
+    """Opening a Sciex mzML (no scan= attribute) should not segfault."""
+    mzml = read(sciex_mzml_file_path)
+    assert isinstance(mzml, MZMLFile)
+    assert len(mzml.spectra) == 100
+
+
+def test_sciex_scan_numbers_fallback(sciex_mzml_file_path):
+    """When scan= is absent, scan numbers should fall back to index+1."""
+    mzml = read(sciex_mzml_file_path)
+    for i, spectrum in enumerate(mzml.spectra):
+        assert spectrum.scan == i + 1, (
+            f"Spectrum at index {i} should have scan={i + 1}, got {spectrum.scan}"
+        )
+
+
+def test_sciex_compress_decompress(sciex_mzml_file_path):
+    """Compress and decompress a Sciex mzML file without crashing."""
+    mzml = read(sciex_mzml_file_path)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        msz_path = Path(tmpdir) / "sciex.msz"
+        mzml.compress(output=msz_path)
+        assert msz_path.exists()
+        assert msz_path.stat().st_size > 0
+
+        msz = read(str(msz_path))
+        assert isinstance(msz, MSZFile)
+        assert len(msz.spectra) == 100
+
+        # Verify scan fallback persists through compress/decompress
+        for i, spectrum in enumerate(msz.spectra):
+            assert spectrum.scan == i + 1
+
+
+def test_sciex_spectrum_metadata(sciex_mzml_file_path):
+    """MS level and retention time should be parsed correctly even without scan=."""
+    mzml = read(sciex_mzml_file_path)
+    spectrum = mzml.spectra[0]
+    assert spectrum.ms_level in (1, 2)
+    assert spectrum.retention_time is not None
+    assert spectrum.retention_time >= 0

--- a/src/preprocess.c
+++ b/src/preprocess.c
@@ -10,6 +10,10 @@
  *
  */
 
+#ifndef _WIN32
+#define _GNU_SOURCE  // memmem (SIMD-optimized on glibc)
+#endif
+
 #include <assert.h>
 #include <ctype.h>  // for isspace
 #include <math.h>
@@ -17,6 +21,26 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/**
+ * @brief Search for needle in haystack, reading at most hay_len bytes.
+ *
+ * Uses memmem where available (glibc / BSD — SIMD-optimized on modern glibc),
+ * falls back to a portable loop on Windows.
+ */
+#ifdef _WIN32
+static void* bounded_search(const void* haystack, size_t hay_len,
+                            const void* needle, size_t needle_len) {
+   const char* h = (const char*)haystack;
+   for (size_t i = 0; i + needle_len <= hay_len; i++) {
+      if (memcmp(h + i, needle, needle_len) == 0)
+         return (void*)(h + i);
+   }
+   return NULL;
+}
+#else
+#define bounded_search memmem
+#endif
 
 #include "mscompress.h"
 #include "yxml.h"
@@ -495,10 +519,12 @@ char* get_spectrum_start(char* ptr) {
  * @return A pointer to the character immediately after the "</spectrum>" closing tag, or `NULL` if not found.
  */
 char* get_spectrum_end(char* ptr) {
-   char* res = strstr(ptr, "</spectrum>") + strlen("</spectrum>");
-   if (res == NULL)
+   char* res = strstr(ptr, "</spectrum>");
+   if (res == NULL) {
       warning("Could not find end of spectrum.\n");
-   return res;
+      return NULL;
+   }
+   return res + strlen("</spectrum>");
 }
 
 /**
@@ -507,10 +533,12 @@ char* get_spectrum_end(char* ptr) {
  * @return A pointer to the first character after the "<binary>" opening tag, or `NULL` if not found.
  */
 char* get_binary_start(char* ptr) {
-   char* res = strstr(ptr, "<binary>") + strlen("<binary>");
-   if (res == NULL)
+   char* res = strstr(ptr, "<binary>");
+   if (res == NULL) {
       warning("Could not find start of binary.\n");
-   return res;
+      return NULL;
+   }
+   return res + strlen("<binary>");
 }
 
 /**
@@ -528,15 +556,23 @@ char* get_binary_end(char* ptr) {
 /**
  * @brief Extracts the MS level from a spectrum XML block by finding the MS:1000511 accession.
  * @param spectrum_start Pointer to the start of the spectrum XML block.
+ * @param search_len Number of bytes to search from spectrum_start.
  * @return The MS level as a long integer (e.g., 1 for MS1, 2 for MS2). Returns 0 on failure.
  */
-long get_ms_level(char* spectrum_start) {
+long get_ms_level(char* spectrum_start, size_t search_len) {
    char* ptr =
-       strstr(spectrum_start, "\"MS:1000511\"") + sizeof("\"MS:1000511\"");
+       bounded_search(spectrum_start, search_len, "\"MS:1000511\"", 12);
    if (ptr == NULL)
       return 0;
-   ptr = strstr(ptr, "value=\"") + sizeof("value=\"") - 1;
-   char* e = strstr(ptr, "\"");
+   ptr += sizeof("\"MS:1000511\"");
+   size_t remaining = search_len - (ptr - spectrum_start);
+
+   ptr = bounded_search(ptr, remaining, "value=\"", 7);
+   if (ptr == NULL)
+      return 0;
+   ptr += sizeof("value=\"") - 1;
+
+   char* e = memchr(ptr, '"', search_len - (ptr - spectrum_start));
    if (e == NULL)
       return 0;
    return strtol(ptr, &e, 10);
@@ -544,42 +580,74 @@ long get_ms_level(char* spectrum_start) {
 
 /**
  * @brief Extracts the scan number from a spectrum XML block by parsing the "scan=" attribute.
+ *
+ * Search is limited to the opening <spectrum ...> tag to avoid O(n^2) scanning
+ * when the attribute is absent (e.g. Sciex TTOF6600 files using
+ * sample/period/cycle/experiment IDs).
+ *
  * @param spectrum_start Pointer to the start of the spectrum XML block.
- * @return The scan number as a long integer. Returns 0 on failure.
+ * @return The scan number as a long integer, or -1 if "scan=" is not found.
  */
 long get_scan(char* spectrum_start) {
-   char* ptr = strstr(spectrum_start, "scan=") + sizeof("scan=") - 1;
-   char* e = strstr(ptr, "\"");
-   if (e == NULL)
-      return 0;
-   return strtol(ptr, &e, 10);
+   // Limit search to the opening <spectrum ...> tag.
+   char* tag_end = strchr(spectrum_start, '>');
+   if (tag_end == NULL)
+      return -1;
+
+   char* ptr = strstr(spectrum_start, "scan=");
+   if (ptr == NULL || ptr >= tag_end)
+      return -1;
+
+   ptr += sizeof("scan=") - 1;
+   if (ptr >= tag_end)
+      return -1;
+
+   char* endptr;
+   long val = strtol(ptr, &endptr, 10);
+   if (endptr == ptr)  // No digits parsed
+      return -1;
+
+   return val;
 }
 
 /**
  * @brief Extract retention time (in seconds) from spectrum XML block.
  * @param spectrum_start Pointer to the start of the spectrum XML block.
+ * @param search_len Number of bytes to search from spectrum_start.
  * @return Retention time as a float. Returns 0 on failure.
  */
-float get_ret_time(char* spectrum_start) {
+float get_ret_time(char* spectrum_start, size_t search_len) {
    // Find the position of the retention time cvParam
-   char* ptr = strstr(spectrum_start, "accession=\"MS:1000016\"") +
-               sizeof("accession=\"MS:1000016\"");
-   // Return 0 if not found
+   char* ptr = bounded_search(spectrum_start, search_len,
+                              "accession=\"MS:1000016\"", 21);
    if (ptr == NULL)
       return 0;
+   ptr += sizeof("accession=\"MS:1000016\"");
+   size_t remaining = search_len - (ptr - spectrum_start);
 
    // Move the pointer to the value attribute
-   ptr = strstr(ptr, "value=\"") + sizeof("value=\"") - 1;
-   char* e = strstr(ptr, "\"");
+   ptr = bounded_search(ptr, remaining, "value=\"", 7);
+   if (ptr == NULL)
+      return 0;
+   ptr += sizeof("value=\"") - 1;
+   remaining = search_len - (ptr - spectrum_start);
+
+   char* e = memchr(ptr, '"', remaining);
    if (e == NULL)
       return 0;
 
    // Convert the retention time string to float
    float retention_time = strtof(ptr, &e);
+   remaining = search_len - (e - spectrum_start);
 
    // Find the unit of the retention time
-   ptr = strstr(e, "unitAccession=\"") + sizeof("unitAccession=\"") - 1;
-   e = strstr(ptr, "\"");
+   ptr = bounded_search(e, remaining, "unitAccession=\"", 15);
+   if (ptr == NULL)
+      return 0;
+   ptr += sizeof("unitAccession=\"") - 1;
+   remaining = search_len - (ptr - spectrum_start);
+
+   e = memchr(ptr, '"', remaining);
    if (e == NULL)
       return 0;
 
@@ -669,23 +737,27 @@ division_t* scan_mzml(char* input_map, data_format_t* df, long end, int flags) {
 
       spectra_dp->start_positions[spec_curr] = ptr - input_map;
 
+      // Find end of this spectrum to bound metadata searches, preventing
+      // O(n^2) scanning when attributes are absent.
+      char* spec_end = strstr(ptr, "</spectrum>");
+      size_t spec_len =
+          spec_end ? (size_t)(spec_end - ptr) : (size_t)(end - (ptr - input_map));
+
       // From here, get any metadata we want to extract from the spectrum
       if (flags & SCANNUM) {  // If we want to extract scan numbers
-         scans[spec_curr] = get_scan(ptr);
-         if (ptr == NULL)
-            return NULL;
+         long scan = get_scan(ptr);
+         // Fall back to index+1 when scan= attribute is absent (e.g. Sciex
+         // TTOF6600 files that use sample/period/cycle/experiment IDs).
+         scans[spec_curr] =
+             (scan > 0) ? (uint32_t)scan : (uint32_t)(spec_curr + 1);
       }
 
       if (flags & MSLEVEL) {  // If we want to extract ms levels
-         ms_levels[spec_curr] = get_ms_level(ptr);
-         if (ptr == NULL)
-            return NULL;
+         ms_levels[spec_curr] = get_ms_level(ptr, spec_len);
       }
 
       if (flags & RETTIME) {  // If we want to extract ret_times
-         ret_times[spec_curr] = get_ret_time(ptr);
-         if (ptr == NULL)
-            return NULL;
+         ret_times[spec_curr] = get_ret_time(ptr, spec_len);
       }
 
       // Now, get the binaries and set the start and end positions

--- a/test/data/sciex_ttof6600_100.mzML
+++ b/test/data/sciex_ttof6600_100.mzML
@@ -1,0 +1,5402 @@
+<?xml version="1.0" encoding="utf-8"?>
+<indexedmzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.2_idx.xsd">
+  <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" id="HYE110_TTOF6600_32fix_lgillet_I160308_001-Pedro Sample A - 32 fixed" version="1.1.0">
+    <cvList count="2">
+      <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="4.1.182" URI="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo"/>
+      <cv id="UO" fullName="Unit Ontology" version="09:04:2014" URI="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"/>
+    </cvList>
+    <fileDescription>
+      <fileContent>
+        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+      </fileContent>
+      <sourceFileList count="2">
+        <sourceFile id="WIFF" name="HYE110_TTOF6600_32fix_lgillet_I160308_001.wiff" location="file://Z:\data\input">
+          <cvParam cvRef="MS" accession="MS:1000770" name="WIFF nativeID format" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000562" name="ABI WIFF format" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="9f9c16998a8e91dd1f6985300d78715b1464b798"/>
+        </sourceFile>
+        <sourceFile id="WIFFSCAN" name="HYE110_TTOF6600_32fix_lgillet_I160308_001.wiff.scan" location="file://Z:\data\input">
+          <cvParam cvRef="MS" accession="MS:1000770" name="WIFF nativeID format" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000562" name="ABI WIFF format" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="c93c94cb175ca7b1288667c28ea5615924fe0717"/>
+        </sourceFile>
+      </sourceFileList>
+    </fileDescription>
+    <softwareList count="2">
+      <software id="Analyst" version="unknown">
+        <cvParam cvRef="MS" accession="MS:1000551" name="Analyst" value=""/>
+      </software>
+      <software id="pwiz_Reader_ABI" version="3.0.25182">
+        <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" value=""/>
+      </software>
+    </softwareList>
+    <instrumentConfigurationList count="1">
+      <instrumentConfiguration id="IC1">
+        <cvParam cvRef="MS" accession="MS:1002533" name="TripleTOF 6600" value=""/>
+        <cvParam cvRef="MS" accession="MS:1000529" name="instrument serial number" value="BR21571511"/>
+        <componentList count="5">
+          <source order="1">
+            <cvParam cvRef="MS" accession="MS:1000073" name="electrospray ionization" value=""/>
+          </source>
+          <analyzer order="2">
+            <cvParam cvRef="MS" accession="MS:1000081" name="quadrupole" value=""/>
+          </analyzer>
+          <analyzer order="3">
+            <cvParam cvRef="MS" accession="MS:1000081" name="quadrupole" value=""/>
+          </analyzer>
+          <analyzer order="4">
+            <cvParam cvRef="MS" accession="MS:1000084" name="time-of-flight" value=""/>
+          </analyzer>
+          <detector order="5">
+            <cvParam cvRef="MS" accession="MS:1000253" name="electron multiplier" value=""/>
+          </detector>
+        </componentList>
+        <softwareRef ref="Analyst"/>
+      </instrumentConfiguration>
+    </instrumentConfigurationList>
+    <dataProcessingList count="1">
+      <dataProcessing id="pwiz_Reader_ABI_conversion">
+        <processingMethod order="0" softwareRef="pwiz_Reader_ABI">
+          <cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" value=""/>
+        </processingMethod>
+        <processingMethod order="1" softwareRef="pwiz_Reader_ABI">
+          <cvParam cvRef="MS" accession="MS:1000035" name="peak picking" value=""/>
+          <userParam name="ABI/Analyst peak picking"/>
+        </processingMethod>
+      </dataProcessing>
+    </dataProcessingList>
+    <run id="HYE110_TTOF6600_32fix_lgillet_I160308_001-Pedro_x0020_Sample_x0020_A_x0020_-_x0020_32_x0020_fixed" defaultInstrumentConfigurationRef="IC1" startTimeStamp="2016-03-08T03:48:05Z" defaultSourceFileRef="WIFF">
+      <spectrumList count="100" defaultDataProcessingRef="pwiz_Reader_ABI_conversion">
+        <spectrum index="0" id="sample=1 period=1 cycle=1 experiment=1" defaultArrayLength="2">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
+          <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="3301.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="395.092994346388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="31925.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.004583333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="360.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1460.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="32">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwryNw1sXBjhUPppVwxv4YqBwBC5QdR</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="24">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJyba7jKNXrOORcAELwDxw==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="1" id="sample=1 period=1 cycle=1 experiment=2" defaultArrayLength="295">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="537.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="33822.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.0067" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="412.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="12.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="12.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="412.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="21.808494567871" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2940">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzXlcjIkDBvAN2eUj+XSQXUxTs2WiHEV+LXq62DYKhVQzTXM0zU5zvO9s9E5sp7Lr6GCtommaDkqXiNXaLmzIrmpKhBodWyzKJrKt/N6/vp/nj+d5bq/yV7M9AuGc9WU8pzEIdw9p/15hvBMbV8d+MlgfjDuJG6pSvfcg7hg32dU9FIevB/ixEArpE+F55/hQfGiHj2V9KP7QOyYUN4XhzMMUi8gZHCjZnXUccOCU4P6nxIMDqx6TrBmeHDxJskjzPshF1WRHT1AqFwdvGB4fv8mF22TgAw9bHnjf377a4cmD0F1RMsLlQWG/ZrZ7OA/5S5brE2j7uYIr3Roezt3JiM+q5+Gi1dvQy5oIjIsuq5jaCJx8eqA2rSEC1dOsnhpP48Mt/M9FIQw+3q/+dc4zJh/VKQWh9jZ8HHqz9ewTDh9bmdJBNpePipz9xBHa/Wk700oFfLBj/K6eyuMj9+APhm7aHIZxWLGWj8Pv/krf3MaHZZlF3m4DHzz58euCTwTwvc0TuVoLkPmbs9m/7gLIxnw3ZGgE2HckW9/WJMDR1AvcNIMA77YXvtR/IoTN6wCLVKYQP3dfHCmJEGJrOnt9UqIQwRUfKoQaIZYLP5s5yBThUIWJnYIngsjOf5qW9sjzauJcngjV7rMDVfUiyBcdTqntEcHhoms+q1eEAm5cy37auCtvsvtoB/q+zavvF0HplOVGDYiwbalqevP0SKzd+TG3kBGJHSn3K+clRiLM7xi1tTcSvg/96tJpo5r/sx00RGIi1KvGnyGG4+VnIi1TDHm7WpbuKYbxnWWDd7zEqHPKz7DgibHp1ondv0SI8dw/SdaTIMaT2fXLqjRiFFDVT0/0inFooD/uc4MYdzly35u0jOTy5rGPYnx9dz55MjwK3/9bxJ6Kj0JRMDn5MiEKa653Tm5siILiEbkhGxKMalZmTnhIcNVubdFhTwkM+gXcrjAJruUujAngSGBjUqH7NUmCn49WiK1TJDBhDo52n5Ege7TLnZ8rgcuOmnVfFEggvlVXMdIjgelI18XHBgmGv/hHvTzvW1B267avmSHFuZpT2ePeUvhHXpjXwJdiKCvwgSFRiqAZabv9dFI4OXy6v8UgxYLuF6cWWkfj2pfzfq11j8bv4d7vir2iMT9V+jEvLBolVj4hmeHRuL8rt6iwIBr6qfWOm2fI0H/QbirAWgZXXTTjR9rWzjVxZ71laNtVYDTGkaH9So37JZ4MlcGxDuUJMtgq+np/a5LhwU+/VOmmy9G19LjLqhlyJDAsdLdo3c/GCwKWyMEs9di8myWHlW49x54rxyWmnr8uSY6zLG/TzSlyLCkV6SwP0n3dE5crGjlqOKyhHp0c5hfmJR2YkuOGo3SXq5ECOS4fGJkMBcwaZsb5hCtwIKb1koangI/DYceaBAV+OKqtsElUYCo8emUG7aM9C2o2JSmwdOZW+bUGBXq6d7B8BxR4tuVr6RkzJbpkEy751ko4fjbnq8tMJcLIV6/kNkpU/119rAxKzB+Jyu/zV8JV8UExL0CJlJLWZxt3KNGYX9UcQhuXdLZoL22G7v61Etr8lkKs4StxJbO8SES71+OI9jRtVdCE94Sc7nWsZx0jlMgZ5PziRCox1h2VuyJLiaFJ24c6nRLDiwZ0ryuVML1RuMyhQYmXa98tlBsR2P9vzhZ7awL2BRPBAtrFHOrSByaB9wtvRI+sIrDyixKH3NUEOo2S37s4EwhhXOaJaQNMgpxKPAlMG/znXGk8gZY9Gpkmk4BtyYbg+7STN7rPb9ES+C/56uCJfAKBlWW+OZUEykPY9/pov+scfjq3mkDmWvHi/kYCbg1ck7h7BHayHh+waCVw2vHgSTWt1d/2tg20D6a6jL5uI3D71HDKaA+B4bXF9msNBMSGFk3HKwLR+mshx0YInBDllJt8JLCxb9mKVlppovkcM1MSosFmvxHaFaR1x09mJFp+XHjjLIPEUO34KoYNCb13Q4aU1t3IpCWd1uiPJreHtOdYqU3xq0n8tqn8n1XOJE7b3XMbdScxcmyo6SPobDZkyfEgYWnp1ZbsScLxjWjJaAAJY08z/qiSBPF6y7rueBI2Yt+4+gQS+fd6rWYlkjhkoWGa60gcLijV+tE+s/3U9W0VCZ+3ibOyL9A7xhxxRQOJIw8/Foc1kvjUeleqmpaX0dlU20oiKiH1qbCdxK3KCucwA4l3bW5c4SsS53vO9FqMkIjM8irm09rFx/UTY/RvW1H5mykSD83VW7SmKvx1xHxbOUOFGI2/apGNCrJZBdlZtGz2zcpQngonO/aPz05X4W7hqNv9LBUGZq3U+pt+hzKp22s2PwYrYi3nLs2LwVcRLs0plTHorK/9/jGtcPH6M7L6GLA4eZ+z7sVAn1WqL2yPgf9FcVvBtL3Ia2pczyP2IqKp5fbv2r14sbvAY2flXny15/nMZtpqB2XHlM0+zA0KeDTRuw8lqhqr+RaxSH4tujnXNhY1Q+ZFRqxYBFHpf8x0jsWzgDfpTZ6xcJz/0/98zCl4nx8rb6etDtyxPdyCgmm/ujWcQSE0r+W1nzOFM+saX7TRBka7Jpm7UMDx5O0ZtMMFjwrfgILRrTTJIi8Kz687bo+i3bcgbMcIbeOmyFQnbwoujKQxp0AKgva/hlJoF413tbCDKGyvu54UGkFhd91l9mIBhWbjxo0ZtC/LDC8gpHBhMKZnloqCKMnTtJrWsu6qfUM6Ba4+Md8tg8KP5yz7L9Cq+7s6uvMo2Kzr3yTWUjivEfvuq6awwufz4JEmCr4RnDnn2ymoLAmNr55Cccqst6V9FN429vFy+yl8s6R5/OQ8NZYXGvWVmath6FkyYG6hRsLo1qM5tmp8M95bNpulxq2raiblrIbZZFPqQhc1GIu9s4/Svv+h/lqYlxoh7FpLtrcawze3TZcEqUF80+6RIFDj/wZZO04=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1500">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwN0o1bDAYcB/Bc6Xq5qbiIU5JellLnWut40v2+vxOpHFpRFp5r0xt5faSnyCl3sTWlqDErvXguGinC6BzmdUueFj1WN4nw0Hq0xSTR9vkbPjk+BoW5MA+u8StxJqOdIvMq6fnQfOVeUbdiyZJs2F/zZI3suaLK5yQd806hyMd+UEhTKNxmJcurGkjhvh71pgBOsPTGWlEu7BI/wu50OnnuzSD1d7uQ0bcKikEjKTaY4fW8ZKWshmlry06KPHeVlkTcQ/6gEsHvlXg7aQvsRsZB4GwA7zOngV/EaMtymau7YMYfFmtZZdSSKvVLdOUIaVJSIabk+Cm/6jqIqvZ+DNrdpaY139A6NxFm/i2Cyl8K05FoLmv9lJvbY0hfOAYenzeQ8WQS1HtK+XHFGMSqMuGaUEBrN6zgAUE1zKaN0LVVRjQYJdy9yZojbwQhzjccay38WSz5kzbeLqY2TzFb/iNmbVoXGUNd+MfaHETuKCGRcBe4PBiONaVo859IAZ/osMFOB6ewZzQvPBEv3h6kL4YSceuDDgg7RFlxk/A+UcMDYyU41ddL2ZtcqM9/Clq3BqCn9RUtWhSGmJkLYPMoEEtHu+Gj0wDJYt3QVzhAHnlBOLZmNNfXanFVW03re6uxOr8QEVeEyoeDLXDY/I4qRnmRPlPA6rwhehShp/J4L/p9WE91pd/ztMQayj88TKcst2P3hO2wOnuMVh3+SMkzbFh2aTrFOJjBves+abYT50hqKc65loZu1GKU8yiU3v+JhOKx3Oh5gvZPP0FpzTOQNSOaJxcLEDX9JNGRHJz4/4nB14/8hU9R9EiAizv9SDvWHPcmmyP7nh+0adcx1GWOYomUVpKedTfr6bxqC4J+yObkjTJaca2B3jhawt5JhzvlerRkL0DN0jP0cFkm+5e04/qcBAxJBJxQVYYCVSDJzK3w7ZsyuPQ3kvyzcmzTTeRD/wbS4neBhDorHOo+jledUn6w+g4cp8YoG32t4eVqx3VB5+A74Snu552jOXXWiD61B+0lQWTWYI3Ul65s1m8NtfQu4qVyCpCdJ4FcjtosOTWGLkbFzSQUi23hpw/g0n22OOs0G43q2WzfbMueFiKUnL5ACxNS8E4hQkdoPl6UW3LF1lR4bUuFT0M+kuJc+EmvCAVBwTDomkh+vZ4dDjTR8tVW3BS1DuMuhuDwTRsuWj6fJqbfop4rYbS/qIQsKr3ZdmQ8Zn19m3a1bkNK+A6c99HgfbQGtPMy8lcsoqhhZ6hrXPCsuY3syx04/cA69GEKLiSEc8STZXD/ayo6xQ9oR2osW2RuRnyUG1I85vL4ow/I+FbM7bmVKKqPpV6vCC47W4nLr2NpWOPNaUtfo+XXZ1w8Kw4Lgv+g7Kw4ylWF8O6MafD9OYQ5eDd6RGoeCe6gjj0d1C1xx5WF1Qhx7KTfNO7oX96J404m0h+5jHQvEy4lmyBcE8+d0tlsOmrgwqyX2G9I5bpGD+4xZcCQYsP/AZBT4nQ=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="2" id="sample=1 period=1 cycle=1 experiment=3" defaultArrayLength="229">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="234.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.082648552041" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="20498.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.008383333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="3"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="437.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="437.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="23.321104049683" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2304">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwVzXs4lIkCx/GQyiW5tNtuhWGolHY1ToVDfsZtRZkdXaQwhhnMYN533hE708GkTWhJM53dzZZB2S7SsolKq1ChElErXUxSrYpWFAdl3/PX53m+/3wD8t1aTfQ3g1U3PqSuD0Vo14Mr5Mww6Dv2N7l4bsfLK/cD5mA7AmpGrsQ0hGPvWU20x/cRMD+TZ4xrETBWKzWnEAmlXD1tyeDhUb/g6nEbHsjPOw5ymDy0Wac+yWTzcG7YbNrLmwf3vFuh8yJ5cDMUml6v5yHctrPx+NEoNJblevyP9t5ohFVIURQypH6S/U+i4Hhuof2UDh+W6sPFBdF8fFrpv80yho9Vq1qGVh/lIznslOM2DR9LvhpfvUHLR7us//HkjGj8tFPR+FwnGm/SXdPBiEYx034yMTIay28F16U8iYZVq8raSCcGi3v9DvUoY3DQNHyRbXEM6j6bDHxuKYD5350556wFcGHUciyYAuyZnXugpkgARrX+Cj2NAJ8lBJ5qeCZAPqdVO5YhRK1BQTV7txB8v9cZN48KkcOkJJJeIQq7GjITp4XIk6f/i2cdC4MxN/Mhm1hMOH/3S7JPLPKZRV829saixS94MkobC4eU0K02GXGQZPkxZinjoLJ3fl9eEgfxRuobv9I4PGp/WLamMQ4/JLecd9PGoVj31uyzXvGYPPm3lU5UPGTrWKOnaZtHmMLNe+IRou5y8W2g/UsYvaQ3Ho99L3Ef0RptOQbz6XhsnPOCMrAWYfRPqz9DfEUonNPqKsoUQVxYnNhLu0olmkgpEqHCiTdoViJCgeE9O3a9CJPHgx5OWIoxWCjseO0rhlQhuKi3W4xNXW1/HKe94HVkmelTMRw9prx/p7URKyvW6SbgyDXtvFVRCajZELJTkp6AUtLA+0JkIkLap9L/rUxEo9mBt35WSXg1HeF2jzZbV+S6SJCEtL1sC4vdSfDkW5eHliRB+eJa7E1a/96MkeaZEtzZ4ZDB1JegPLDnTravBG/VUUmmSgnUi7y5fbS60ZmLfntM+/bbtaXTEsy3GKos0yGQfHhi8aQZgUb2w7dGDAKX9euH82mLI9+JbtJ+/BT5Ya4tAWauwJn7fw3jkUmbbtcXxHUiUKBpMlbThuX/F0O0k92uq+1YBD6knXTdBQLWZFNAKS3bWxxzk0P3GX90B3EJVM/5VMHjEzjtXmV5OonAejnvLx8JAbeF9vNeEwS2hfk0/5ROoGmZNm+kgIDWN6dMt4TALBbxIb+SwJGmalstbYWHbuDCKgL3S92Ddlwh0Jc6dLWI9lXtiduvaD/FCKoc7hDg9vgsnaYd2DkWkNpBgPf8hODgXQKbOjXxZloCzUUvdZfOIFG3wrggR5fEGbG/6o4JidU/WyxRmZHYPMuEXM8gkdX9dtcQbZlo5E65DQkzg9dO/k4kuBcflGx1JpFTxY3dxyaRN91yNZdLIizxY/ePBSS8fhX3ddH66LtpYopJFHheaD1xlsSXpd3OJ3tJbMoaH1QPk0j2WbkgzVwK67usBXa2UvzmlCTfx5Iie0bB4ZOeUrAKmcG/cKRIVW7cZ6+UgqnH8jlUKYXGSFU3bU6hTxDJ/8qWwse0bPeZLAoCzdmgHA6FGW2MwXQehbnZizVzoyiM6bdPte+msPY1w/9NAYXzHHVK/EEKhCDpSUsxhdl155OWXaHQLjTotGyn4MBf6h9Oe32Lo4VbB4UH3xuuyKZ9GlfByeyjYLydfaiGduvQGeewYQq3jz3M2f+OQkSkZ5yW1rO037PNVAbj0RjdPeYytLmTizZYy7C8/OffNTYy3OcLL4UFyzDG/LzuFVeGmmtffD0rWoZHake/54QM6/7jNOdrUgbfpyWlrRky7FDFR7CVMqhQ1KCXL8P8F4T1AO1NoxM7C+tluKEydKltlGH4JUvr1SfDe8bJ/Gra2TJnq7B39LftV5utnGQkLjl8meAl42nakVwOkYxQh6Nde21SsF+aZeXLScH8gbt2EZUpYDiu8LtMS52LP2pUlYKRF96ma3ipCCr74WJzlRyXHq285tMoR8Qa5jdTHXJUr7UrGuiUo6IruOdYnxw1lnlXXzyTo9g7fKx8RA6Fw/LaSh0FFno0VeXrKSARj+//SGv/PqEjZqYCnO5Q1jYLBew6TCZu07K5yzLY8xV4NXRfccNWAaNanYZ9TAWUpxea1rEU6JSVjYQ4K1B1fYxVSymwWDQQdUOlQE9W0frgYwpsWeGyYPCZAgiUSXn9CiwZdzBpG1Hg2wPv/e1GFWi/1aN3jrbpO1bUCb1dOHCxcUunxS6oKt+cSWbuwj/t8Tb1</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1176">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwQ80FHYAB/Bp/mwapS1/r85DL/+OrqZeFr7fn5i1VzIj26sh6nWIJ7ZqS9ipbf7UcNoql7K1uyl/ej1/hvaYdDx0TWwoJqznubbKyGaLfT7luz+gcvAiJgzfIvHyK+KfpbHokiXyrGRPYKnLY2qNUhF+dwaGwEhqbn7ByV8/hMv+BizfIRcjTk24NbUI+R+LCJ8JYMX9LBxX24kLSe+KwcZPUZ3gQvmXSlzL+ku0jedg9qExvP4t4T5PU+Q+MINpU4Bo1ftRn+AiWqS9aHXtxdSafD5qsWDQN31wH1KL/IUpjj+Jov7oIGr2nxSKkHv4uWQFt23LYv/p3VRPq1Awo8KtcWvGPbTG8HYbnpobw/u540g2t2Vl9+/Iu3mVL6rOQtNhK7zrz6FRNYlHX00ipa6QPd0O7PcvhfmcBF+nG2BIL6a9rkx0aVZhQfInmtdLcaH3Mc6Ml2HprCMePHOkyWIqtu5zQm2TEzt75xBTchltT+cRvn0tHG2PISJGy9sNroyzeQ53nRt8O76Hi3UELe2vIETigeHXPPGGQz5DP/bEhl5PvP5LNg+c6eHTw2lCMWLEN9MHYO4h40F1OXNzzEToERm6jleiImoJT3bLsOvKe6x1r4LbZj31rV4waq+CR/YQmh2qYZfhLVTDSi7a59BNkkN3z2DOlE6zMK0Gw8pgioFg8XaxMZ271+FzdQ57bOUYaJEjoucaFBbrOaoy4ScOEpFpGs25uydYnRDNeltTNmR0svDgdYRaeIugz8woNfah5NIYa8RG/K2ug3PQJiSq6hEydZEveIdyWWYDYtN+4PP4RviEbKFlcgHD7JK48NEN+LTfgEHnx9kkf5TV/YgO89PQO2u4OiOF+YZlHJ2UCYXhOs8bApjpB+6UW4vEE4CiNIoliuVkfCq3rCHtzK1omkzeqbPixJNDfFXzE555FTFoXRGlS+rpsykQPZHprFSvoDR6K++fmmX7W0aBL5m04/Z8MV07jzD3HR3mlUe5OduBL6+WsC92FafXKjkyFAZFuZSy/jtcafobmg9pmBfbxoTaPE4URKPunoYbzFy5yyoGOy212GhzjCv9Xenre44FkTGsKIqBl/Y/6vpGGX5Jy8MH3Lgnfoxh2r1MuBoHVsVxb4qOO8IgPNJ0/K7UUpxPiRc1dh38H1TKiOU=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="3" id="sample=1 period=1 cycle=1 experiment=4" defaultArrayLength="204">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="531.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="274.021054740076" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="24383.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.010066666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="4"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="462.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="462.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="24.884387969971" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2076">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzHk41AkAxnFrsCrFJhFbGcIWtTnaJ+1uXuNIh9YkbSrMwWgcM/Ob38wYZhwj2nLssGmvB2NS1HaIDmVtuVIZq0Wr4pEZq1WbrZ5sk5Ts76/P832e93mdwnkh+a07kRuWvCSmcyec2DL7RLM9aMlY0OkdsBcB99rq3lN2ZrYWh+bHonGLYTrjYCxoNk5KhisLSf7bgzbFsXDC0G1tPsICc+FloZ8LG8xzfvvnmXLgO3jrS3YsB+eeE1MlXA5+qpj/zQtK18cNYwYNB0z6fP6vVRw4DGk3SHo5UHjHhu/Uc7C0syzA0sBBeM2b4z+acDFzpE7NdOaiaYchsp2yvvXQheqNXHw65FGmrOTi8Xc/l1TqubjtqrAymsTDuVJ7yoEej4r6yxVX2PH4mDeR1aGKR/zNk6tTsxNQeEB3b58mAfOkfRt7KG/Q1YlJ1xOQcWzXz31/JeCDV/O1gzQeDC/fTDia8fDvm/yndct48Ch6Ovcqh4evd21ULlLx8Ie6y3+Thoczy7pWfajl4aVm+7bwER4uXOoJbabM2322zT0wEfMsfB9YsxLBG+R/yRxJxC+hJwbcRxMhN2TQv6WcoBWP+uXsx80nas8ESouVpXXj1fuR7PbsrjaQDzuT62H+bD4Oao+OR3H5KMvyXTB0gI+aVKfTvDw+VDxdYZae2mnXl96nVE6kPvTTJOFE/y/7LI4lwa5/6g5zJAkF1r+Tt4OToQu6a+UckowVy1akWeYmo4yZJzhfmQxFgFGh0ydja1iw311GCnQPV5zubEnBjwWNsoq2FLTt83mXFpyKtPJF6sScVDiW2b8tUKXiWMFy1UWaAHm0SIZjrgAh/LL9qZSeLq/OnasUIPepod9GI8BHyxeXmFUJ4HbJscXYIcCa5srw6PcCuOfjWy9zIdqfnC8JoAsx7NwSOzdACNtDfIGNSog916OqCikdts36uuQK4T413fiuSogn7bblgy1C+Pc7fBX1UIjWYb20wEYE1eaB3EvOImTP2VI4Q6mb7pvZ7CKC833aF9lrRZgcbjp6i/Kf32IFvRAhodq1a1ugCNFxbNphjgjeQY2vp0tF+PVKUF9dvQhtV01bIu6IoDYp8DZ7LoIh8rnqc8rwprhaDxsC1jERs1HOBDQBed0b1hJQTHw3KKOUPX2VsNqHQJ+F7J9AXwKfuUaf8QABvwdh8VmUThfCwo4zCIRe/uD2FOVhaaSOFUHAQbbpsAuLgKHDgs/OIeBj2W/+QykB36Iev5NaAgcP0cYrHlJeO/mTfITA7x/pZHtHCbxfOnzx0jMCjjEfR5nOErjZl/HDEUrzZrvj66zFcOtlF1+lbL0aNV67UAzX5+kWXcvFmPNsTeBWFzFqvIy+4xBjjExfJGWIURnh1dTEEqNWON14NluMZtHbxUbKF8V7lnySQ/3oytfPUNL0UZGWpWI8Jn2Cj9aLUTyataGlVYy5ExFTmZNiNHrKNqpNScQOiU7N2pB4QJ8svbeQhLjddNTFloSX/6OLf1M+4CqPvqGTKFJYEetdSEQFt+5VUeaE7jDlskj03HLzLKOs/bCz6LMDJAZy+8OHq0h4GGNqkxpIZKdNmm/tJREt76iuoHQli1PMDSS8y3cklb0kYbK4m3GGIcG2HKuE/ioJBH/QhVN1EijXdneOXZdgxvrdyrh2CYwZ16Lb9RIU3I8ZszJI8E1EUf5Xo1Qzx/3zKVO0C/JuPpPAOs2kZ/CFBF41/oHuLyU4MrS7fZYuxenwx6Y5DCnI0i1nu5hSvD59wn/VDik2D9L+5VNadEr/HGNLseaC/SOxRop8/qmZpmop1p1JnbW9I4VhsadCTTmgHwh51CcF80bmxGXvNDirmopWs+RY6/79/EKtHNem4uqy6+VQ2r22t2yQY3iBXaWiVY60a97vLNvkuL87pHFeSTrKa/57m0FZsdR+pEGTDmP6pxqnqnSkpNAzZefTMdzUnS3uzUCQem8Mo12BXQ0rbZuPKHH+P0bzyg4lEtN69D43lDD3i/g86S8lNpQsmjabVGLh8QmfU5S68qVb62mZ2M5YZfybMrQh0MZtZyb+BxUC6UE=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1064">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwQ1QE2QABmDNGyPH2NwCw5RDh14SKKiBZ6y97zdoKeZBY7tTIi+pIM4f7mASx5HjP22ohHHhHBxyBgIrwXSdjG7EpJ1kkPITmueFpFecmJaZE6nncWyrY8gBry72twx02ENFvewdFFaPi0Nr9+KWKozDe3184acefJWshepFpzh68l2ObLJTLPbCdngBbLXl+C5jAJ71Uv2N/ArkTFZgZZqE3W9Wou1CJTy3F7PxlxR2/ecQzd5A6MfyOFjTyUhnLOUeOax9NTg+ahVn4l4RQ1IFXqoZg3TnEVzfpIRnpFS/+6kSuZoW7loQyWVd11A/Tw2t+gaijM9wkf85pD85hpv2RDrNk9jvn0TWD++h7dMGBDU04MG/t3F/NoxXj+fgL5Udo3enYUtzIDognLnmUjp8M2i8cg9zGyKQ9HcEykLyMWHRwLHxIar+iETBo23U1a/E9PxWHN7Zhl7ZAyKgBBPSpzjR3Yb9VY08de40SjrnEBoSxbfmmZhktIqT6VYcnTJx4Z8SYYnbTXtoNCyXouHmqMjVOPHjaidmLTEYDCvj4+1lyDjYz3XLd/BOyn3eXXGKw54z0MslXBEsEb++3MvA8A+S9D3d6F0VI5oursOe5wPYviWAxVMyscG1VIwtPQvzrrOYirpE846voVwWro/4YpCZ2vP4hvE4NJXF8ulAWi1G0d73hujJPsiSBBf3FTzL8o8TEPeZCznxQ3QlbESj3slWpYyxvmwuOZHKzLebRNiTYfYOylh17gJy+2xMexxE06uJ3Gdwoz1eztNb3bDtkdNY54bzmBupJSZ2XdQi+mowS3QKdqfr8OjOOOemdayO96D4/CyzggTvTah4WaHm+EgHZ/K8iEyeLxSOTLbq/0FQv5rXtcloNiRzq1/Nz9cMoH/gNa4P/h4/KwxYssjA1O0G5hf6kPLJ6/AaN3POtBnltZMsbBrCWmklFz408Upos16ypY61ro+Ev3QMRUUtVBW38ECHhpc7NTSXXsNy3sTMqltotryPvNwYfpuYzQKfk86iMlb7laJi9RpGfOlm3oe/4387+VhI</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="4" id="sample=1 period=1 cycle=1 experiment=5" defaultArrayLength="203">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="299.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="274.028023899039" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="21582.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.01175" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="5"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="487.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="487.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="26.447591781616" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2064">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzX08lAkCB3C9aC+Xl5q13GrXNKSWkuSTO1l+g+ydpBe1aAZjGGMM5nlmhmm9TI2mN7VeZtuWVWoM2t2rHKNlHTfy1idqmdkrWtUM4dZh6mKTEvf89f3z+6Vb/dKiMgKuFytt5LpoBNzrsLi48gg6/jTNjA5kIfm8da61joW4mpNjXGYsvudrrzXoYmFg9+r72mLxvGlXqe/JODS+oCewuuIwwMsd7qZs7hdPFiMe9lEt1X4uHPRpInz+HsTB1U/UxK5gDixZKZ4FOg4udytOVVck4LORHQ96KL3WfpO9uIwLvoFzJ2Y5F4rrGTfe0bmoV2pYmxhcWHto9/XHcnGbJtvyQyIXcZFV8okrXNzUGodINRcuzxV1bBMX6/nD16LoiZDmuu8uNyXCxn7Q5ZFFEiL9RcZsRRK+ootMduokaGYGq65Q7nbatPkjOg/bh1YJIq7wEFQt5Gsot/bkN1td5WGvErSHz3godYpoy13iwc285x/aFcmQhVb80chJRr0pdc5GkYzpautf+9XJINbVbY8yJuNOtN0vjyjfd4wecBpOxuQKsy6BMsk+IPGeBR+OkV+sebCBj4auQ2ldFXy0bnaJ1Bj5ELtHC0aPpUB0N+EnS00KfvQvO6yjLNn/wLm7PQUjHa8SCQigZ1zYdJgpgJrIc3VRCtD6u7G3iXK4fbKxuFWAc0VnbO2MAjT5norRmgRwDPUIsl+eil2LpfxC51Q8Cd/qX3YiFWz2QN6RK6mgbw10ZFamouumcluaLhU7z+lncoypaAuf6q0JEcI5/PNhxm4hGMpvs+zjhfBZuXx0Z74Qb0om/mq4LMSrM5VWxa1C2CT8bX7QJMT0aY/c4MA0sBuSui9RXvhsft45JA33ugq8RCHpeGeu6FBTto3fahmk9Nhv3SxrT0ct6+jLiRUZ8LJQ+mZ/nIGQO4cnX1M+l8yyphUZKEj2Lk/Kz8DS60Slr6UIs0Mee27Ei9Bh/WdD53ERoj6QV8UsiWB+YngdaEHgtxz5syfLCHiuHgnXOBNQhQ0VutIJvDHnhDVRGjbmRHozCNyfCFZu9SIw+LhmTECZ/954wF1KPY13XQgC7p1qWk8EAa8XN/9y9iCBZ+e1DulcAltsX3KeZhDwu2w+rioikL2N5b5KRaCl5G7s72oCv7747vqGNgJ/GNOGefYTiNy/w/hST6BnZ/NbOxOBItr382zKXgem2M2OxAVN2+lkytNPrz2KpZMQvZkNmKHc61kwy/MiEanwqblH+bNT5E/YQcKtiuvNBonOteUVB4JIFKT1HXTnkFBUeQaXEiSCTj6mHSoiwTy0M62khAQ/xfLSbcpazUC0Uk2i6Z/D2ZW1JP5L9qo7dCTk3oHrVupJmN1j2t8ukti4vfiDW0skpnNsfL5YJ0ZL2cORAaYYIv99F+kKMdZ+eemTV8VifDU557vmuRilDjVn42bE8JuipXjPihE7OGFg2ErwYd1tCw+GBB9t/qFaSxn36by5kCOBg+v4g17K9DmmziFBgjv5df4skQR1TtcWVJTVjMXSxnwJVj+ds/1cJUGXku1ylDI0rzuLXimB+UCwa3q/BDf2GSdfmCToJheYX49IUOhD2C77H/UFLYyH2krht/HGVYIphenpW78prhSqoRbeq3YpbjWu2LxFL0XzqaM9owYp0PD4Xz0mKfbS5CGbhqWYIs97ho5IkbNes7uT8mPrlbW2BzNRvWfBqjohEw5hLT73VZlIUtG7xzSZsBqZKK6sz0Txa1qCozYT9p3H7x7xzkItERD29YEs6N91ndWJs3D11OOw1tos9GqK0hT1WVC8dKz8N+V/jpzbVdiXhW3bDtuKGDKcPrG09v52GfKDxr6z2C/DnFfZBr1Ihpj4+DhTvgxHV/dHnFHJUOHtVjtKSStbvLVMLUOY2NK+vk6G3OljS1NGGTb+rC+XHs9G0JaHkooTeciNKldNa/MQ3tZ3KKczD49KGFXNv+RhHxn4W+hMHtK61mRaVMkxNLpoNU6ZscrzU4NWDqFb3cKPDXKw6boPCzvkWPByX982I4eVd0Oj4P1j+D/5ZPD9</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1060">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwX1Q03UAB+A25+LFzbYbnsApHk4gD5wCeQ05+Xy+hKBA4bGIQ1Tg/IM7cqImqF2G2Z2UdjXAQ3wDrBiZQOdEONshykRhunixAoqzNmcGHcJJ6uyn9jxzTkswjjbgbDH4xNXGDVnnkOFuxZVTR1gcOZm0biQhWaV/mPRRvg0psp2YmZiFZnQPTOP/IugTHxomPobfPy9xr7tJ1G0+iC1OGRUDB3kqcyl/77Kx5d3r1NQcwg5dn7B8PcPc8XRmDxSKLwICWFKwliG6GPYtH8JU/R0suqri1msqOHTVotenZtWDBtpXHWZYT3SyqXIUE04PbU4N593x0D5gQWO8lmWntciJrEGEIYGNJxMZ9qSIURtrUV7pQa6hDrsOJPHEb5f49/M6qL47ge58iyjXhiK/LBR5rpMw7y5B0cofRc5/k5A0KWxWLoYuMUio+qYQvimVJncY9scugfXnaRzTtnOx8hEWemupDH2ExIlvIJ/UM+IzI/0zIlAht2LS7z6rZp/hra1R2Gx/T6j364W0AFwa/D2vZMuoyZFx74fRqA6NQccvMt5XTVE6VMtlH7RgyZlwUVkeA60zhnOr5PQ1yHmuYgX/uNaKHaUGNCdL7Bxsw3n/X8XcGgWtrpU4PKRgz7CCj323xPgNIYYKfMlSSSymzwaKEbWSnrEFYv18G3YHx8Fls/H1wEJusMZj290/ccN2EV7FG+x+nC5669vxdJ8fF7kvweldzcCUDpyJfxO3dhl5PLaY/T/M4+y0Qcy0rcFYpIq5AXni22N2tD5YJV6Y1KxI2E7vV9v5VN2Ffa+a+WVnFzzZz3iv18ykuw+pXw12ZpZS1yKxKYgY/1TD2iaBl2YHoi848PZlB6ThtaLluQN/ya+jeV0Zj6cHMTI3lf2JadQeTUPWwE3sHEqjZFrIF2Fe9jCD7ldCeLkoUxzddhuO90N4JO8njtW/wz36Hl64mMUD/oPwGh20ZA1yOr+DxtGNtFj0orD9cw5bDbSPVLFRVs3+OS5WTJVg7xqlCG4yIzwqjueXx/G16AKR6o5jf04p/gfZNl6m</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="5" id="sample=1 period=1 cycle=1 experiment=6" defaultArrayLength="173">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="195.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.082648552041" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="18256.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.013433333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="6"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="512.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="512.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="28.010726928711" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1772">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwN0Wk8lAkAx3FHRBtyVtSqWRUbKldtij9qJGWTbHI1HscYmpnnmWFMxIyoxFLpQBrZwcqxWdpq22odRVIIHdv2KVOORK6KpFr7vPq++735TdsFDlaq+aLCyl1b3TkAU+3/DW+sDcCVWdt6zbjB4Gq4zF5zKBiZzLcXjxwORnpS14LwxmCc6Snv433HAif3seZlVxb4g9ymnXtZGJyW2dwvCIH7XkOXGWUCJt4s/XQVAvWNR+VEMAFu1YPkM6EEvhhoNmSlEPDpzNGsKCTQl+W4bKuCQH5iHLNIKRQG69wzJ01DMZEkU+ItCYW+a1Fbs1IY4p4HXVqhHAZN3X/NEmldhn/LsF4ahmPGw0m3k8Ng9pNO60RhGCLfuS14xwjHWbuwD/zacJh/83dYV3c4+t1NvYmecAwZqbm9oZ2URZ+Q9IajZCbEVyU5Ah1GBQOttMf0JN87/BKBPN52jRt1EZjRyb3K7o7AUlsnWwXY6P9rumENwYbRnllWZXI2iPCZyrbnbKT19iQYK9i4sFl9hbVpJHKqsh+6SSNxvvnryOKiSOxiGjtbBHHQu755tlcqB2csDSPqXnBwu7g5U6WbA5fyLvNGRhQObLSN3yGPwp9RH6ZbN0XDdUe6QyURjWVbLG0uJUdDkjTQf7FhH35IJ18kOnGxcLfSePsmLtbo39siZ3FxcmWUVmItF+RgYIKeMw/95XNJAjxY66ra2h/kIdD8aelkAQ9sY+bspEYeDKzV/Qpe8eCxNuicvRofirgpLX4oH5ZvdPj+Ej6GWq5pdEj5iJ3RG0tM5mNqarOoW5fEVHEt9+ASEpzmurJfaWdaX85dxiARKBgZ4dHW9NwcLQEJ+69WU+KdJBx5GVoJBAmdJ3umEwUkJt++9315gtY/tUNbTiKXEC4qqyYRPKaW8YVW+yR7vU8diU8POthN9SR8x2UMIwWJwZNKgSMjJJ5lGq4MGCWRnTv8T5AyhXb1j39k0uYFXA4V6FFY9/mZLNSUAqcppfTHJRT9f87LzqUUUk8//jltFQWudN6E52oKLZFMh8O0+aTYdastBT/X/JIsVwo5kobiCDcKanEmZDCLwhXDTG6UlILH7++5945T2GA4R+XcCbo/1FCnIaewwqvF82oVhU7poL1aDQX5t2Mnb9ZSWB2Ua5HbTuFOYYvDvVEKD9I8mxgzFJoEZ7XYtOdn5+2qpXXW0mdO6QnQNuCv7q8vgH4lU+bsIkCfiJVlKBXAo9zH1SlZADv54w12owJYMYfEMlUhmgU3a7QYQlw4aBIRskqI1kM10kCWEN6LnoR8oi16lLFlbYcQFmm6zxLmxeCLJHgfd1UMVDOuX9S2iQHnTvN50N56X2rMaY9BynJzrYruGCjGLZ2MXsXAkcWqEtNuvusv83sXg06FqYE0OxYbFnaH2KwW4Xqn3+kSbxHyfFtEj2nX9Xh1TFaLMHDr+kNOjQgBR2w1qmnFBiZPuupFuNbnvP8GIw7HOm+ciqiPw+hE7K2rHXHI23Y3p9NajNybnOEba8QYn2OsymOJYWj1+u5RgRieBtuLT2WL8XFYTJgUimEyt8ogsVqMgQeL7Fpou6oVZbvrxZCK+mWMcTEONx534dKaE2p3GPb70e7l7l4q2I8jvb3Plwv3Q/4sbrKwKh7RZqFJFioHMPbms8NrYRL02+afixdK0PcB+RqpEtyJTBndR5v1ukL2iHbtYuVst1MSDPIz1ZtoHXNsnm4plsDnRUDUCRsp/L3iY+evl0L3Pve5wkOK/wF+X3aw</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="904">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwQssFHAcB/DI6+S85n2Zq3mElKOLVvh9/9xKdWexWzFpXSE1qyhLpBNXJMVOI5ENLTJdKWStmLxZmxCXqGGUR4RZhdXnI/TLI+MEN5ZiMe5X1DPn5+hr599T5kHX1rORMrtMqqQoBNYkYG2hkY7Ne7EdERr49fgGHAvCWbjLRrwLFaGvmOMvrq/DWpA2Mo5o43NqD/HMtdjO0Ax6f/Q8FJtuU9glfZp2MAD5SKHzZYBKRR6oEuxltktS/OAUs8VHxhSrUFPSGROy7cpF/T9TRNuOUKZnHqXPmtGzJTNaVX6jSqkM3kGWuBM4SU/WrEkikKKB+5DmB3nUtnoOS0IblnPTjlx758ki7DBUanvSnCnHhz2PKSfyDzldXaWsp04oz0lG2nAwXlo7U0WMM/3c0AhFpwtizKtoJVgOb54rSnq3E59fTZxvv6HrXE15LtUU21NNWqZ6rKIjG4X8jQi9b8iUA+VotXfH283p0ONfYbmJz2nSSoCGqBfU1zwC/XYBaWocgIzvgYkubUj0Sv0zL3jgO0cHl9/U4GJkEURVZ5lS1Q9jO0+yqfWkDrNKrDvMYbhMxGJ0hcgXC6lJJUNbiRA1C7U0mldH42N15DuxG1uTV3FvvxeuB3rhkeA1mXdG42R8A514YQCXdQMMxnJhVMJFc8hdZLT7wHDaDwX9xuAFmCDfNQ4iiQnUlS1UtBJAhx5w2cdCLuuWiGC5SwWe6SFqftpNo01WCA+Xo0gmxpR+IUkqxDio4ME+JA2DUcEUJE/HMscOM6UlSN0mpVut6zCK50NRMcde7f1E+77yUS4eJLekLTgeN0TqRDX9TVKT+6sIDDidhtZULC2FCDGiFYdTSjmzEFlC038RRkMtUMoXSabrjTEHfVaZ5Y3/WAccjg==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="6" id="sample=1 period=1 cycle=1 experiment=7" defaultArrayLength="194">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="231.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="274.018731706783" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="21717.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.015116666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="7"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="537.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="537.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="29.573804855347" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1980">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzn081AcAx3G6tpY2lA6TFSerpjBNpYf5itarrpXIrkWcc3fcOe734OHuprlDYi3Rkx6504MeSatJeTrVrHLJY8zTNVOpCS22Wy+z31/v1+vz+v7xvdf2o0ql3wbP50ssnjOentFT4u8biosJKTbRqaE488t8/7HqUBw+IohcszscK0zzw/beC8fHza0fLXDhw4Ns/HPAyEfY0UEnTUEkuOKrXdN7I1Hh8M/JYHMBxmSj9f8yug49Wm/OEeB5+9j+OeECSPKX2ByPEuDM3NUhzkIBThcv7GgoFOAFLYqr0wrQJam/GWMUIMdhe/d2sygMvzwytZaReytyi61TFB42nq9x10bhTeKqaoOZELcWV0bscxaCk9Ue2BMphCRxVYpULUR9Yu3lNo0QrQuVN1U6IbJeVn0/xBFhf8QHo7cLRfBZ9sP1xn4RGoKvb61jicGt6exN5Ytx517anGkaMdpHQovW6cQwKfzoy3oxDi3ReYr6xJgweQf9ZRTjybLUxe/MomFYkRkU5xeNkD9M5VcKotGX7dH2llEbJ3dalREDG1ttvYYjwTVx1qsKSJCQp15a7ifBuw0HY09lSPBq3SKL4l4J2oOlnew+Cfq4GebbGZ8NaH59yPjEkn2tzCiB/YDlj2HzpNBq9XWjBVKkldZH5hZKcfnGp6KagFhE2K89EyGIRfVB+XvvR8Xigk9dwVNNLNy/8Rx8CRm4s0z+oyUyLPgi59HfehnkJam9ZJ0M1JvdB7MD4sAbPb80+k4cPixrc1w5NR4nWMdjV6bF40boghpWejwemKJuD92Nh/HOYiI/Qo6aEF948eXwLj7bIlfLwXJj27M0csjc/La5pcmhnPCfEaRlduyRjc46OerPTfF/WytHUiOfe8mcgOj5qaH+eQRcPX45r3EikNHS51PF+DQwIfJ3DgErm+EIoycB6bk4SR4I1M8JWTC0mUB/48WfY4IIWMRoe9YLCCw9ukfbkcd0b1341CICDbMeLCxgrPyW+PJFKQG2V/PEoqsEeOob2YVlBKZcUAw/Y1TXlF/i1BKQf+m8WcFYXp2f7fqYgPmJo10ORubfNHa+5zCBquwttj9Zkqj071JMWpG4+75fxjprEpzVOQMXZ5IgmseLgpxIjHW/uDXI2LJ6q6+vJ4nvu2fkxDDu9bOe9F5K4siOk0pzkJgli/IKYyw226CoWUvCwbFTvYxPQjRUaNipJlG6q/Jcey4Jwf2Glqw8EpMs/Z5GRiJtB/uhlkTm8qu8Wh2JtvGuFYmlJFJGnixcNcn0NyJ7gxUFvfDr6e42FM4Urm4P51BwKW36xMyDAlVMbMr0orDzaOAWu60U3p1Wtm5MpZBuqipwVFPIv9ttYamhEO7Wqx7MpeAhTVqeVkRhrijO6mYZhWDrzM/HGavtevyS9BROeXS6tDEaPK/k8ZoobAu+6yL7i8Lerh3cGsYq31q79Ck01mzjsQYZXwrU4YksGpNv+9XNM2mMHXIpsuPQoCbcBfZeNPwbn/1nDKdxr/IP6Xo+jYejFZ1Zchr6g26SXIIG77Lwt4wDNCzLUjdf0tHg3mf3W9bSCHK2nwx8TGOua0VfEaM0ta2T10SjO72nZZ+Rhpx8YGFg3PVxd8PGURo3dHM/2mSVAFXBYdPE/gSM/HZnyPpxAm6y1OUjxgTwZltjZWMiOv60byovTcLUc5PZK64lYdHrB7vGPZKRmftz9qz0ZMyuPjX4w4FkJH7y2VdVZckoMYz/29eXjFdHOlLXG5MxqlG6Nlsq0LAybbkPXwGnPLYjN0qBnNOvA7zlChhSDLHflSlw7GxTtb1eAWedm2Ano2CNXVgr40lPP7uduUq4KXz2vipU4nig5qyqTonceJM7/6kSFbzZqmMjSjyVXQgIs1bhZGuHadhGhde3xR9e4qjQ6q6u3rFWBYdFtwds/FWA49bpBWoVstWLS04UMjtb2R7bayqETDvgmOL1Hf4HwfDRZQ==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1016">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwQlME2YABlBwgEihIEUiIhAUjSk2XkEQq3zfX02FbjoqY3KDm2gzq4igDEe6TVG3ISipwNroGjwwHtnATCIKw03FLIPKComp2KlJxWpNJWGMIMLe2zE6hHe6DZBHeDgS8hw3P5Yz2yBVbUQ/8l6NptQ9vgW7ywCb3Qu2LG/UuW+ItFn1zBj/g5m7B7hPt5Ci9jAqsu+hMTVNZUxX89OMHritcjEsmUnnyEqhuO+Psb19KAuwotA4grhWKzpuf8YNoePofhknolwWtq4KwcRTX5X1g9k49MVsNsUa6L5hx+qEUJZ7y1if7EC80gHV23BcXe+E9oETy3p3MHKdgvmBZtwMMtMgNeNOcCTyQyN5r9eM/ZuimOp5jYZUiZgqVlOj8SD3WQz+9m+GS/Yh1325kE2V5xBW+B8ubl5MafUE9IWXRMv2JUw+/x4xO0/zeIgXlVovPliTI76PukL7nnhOO8AFPfHcWbmUbYPeXHS5hjbdI04vVcCnQkF1aBN/P5vFg5ZvOd0TJJafiBBmawdj7T/yuzAf1s7x4dSKUo5F19Gw3cS20uWYazzCw3NbGbZrBe+edPDX2mruNjmgnd+GbwbdqkcPfSm/tRJqbZJ4UpQk5qT5MdlWwGuR1/Gb/E9O9p3hkohoEfhPkZBWjHMZn3PMNwGT/2p4TD6LVYntsGxKhPF0Io3brlI93I75RQFcFSxhvX4NNSa90KVLmGTZRfwlobu4Ay6/GuoLzlEjAhl0pwbt19ZyT/lWnpgIZOm7tSgWSp7McIqSZ0ps7OxEysEZ4r60C1ZZF06NmVi2oIUvG1Jw3ZmCkjfBHPTU8afkbTyQAMRWd+OjnH00namnr3jC8k4ZR7uU4mcoRHje17Q0bkFeQDrMm/s57/ZdVlzQMqpFi5mN0dQ1x9DrxQAmIz5BKuep+qsyITNkcviphZfGs1jm3yCGe7PR8VUcS07l4EpmHwuauzny+RCOvsql/k0uf/Hk8aHfD9zflc+ztkL+D6CoQ6A=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="7" id="sample=1 period=1 cycle=1 experiment=8" defaultArrayLength="148">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="126.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="144.064195038667" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="13424.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.0168" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="8"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="562.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="562.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="31.136831283569" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1532">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxX040wkAB3CtsqJUrpOXHm2WiuK0WF1qvkpveuU5z+OlWGObbtjvZVuzVrhelOsSh+cc19bkKLks3ctzHbab6uSk6EUvInWVhFauIqf7ff75HNS9ykdIHCRHp+qmNsTBsKQiasHBeFzL+6UQPBEmlh/uHl4lgqXrad6sBBHS1S1t5hM7EVi3um+uficWTQn6dwZLDB+3eu8TzAKV3Xp/LzEmPY1Lnh8vRknfsqXfJYrRU/+h/ZJejDD71gdR3WLc4r6U+tolospRtnJ0TiKIu03/9XMScbY3e77fuCSk5D1YXyWS4MFpzrw/9RIsVnH+yOmSoK0CufcfS9Dxa6EDf68UR15dtqeZewKCd3lkSZGZJQo8zuxsW1Gn7ZJCF5Hp27tahpEz7cYJehlqZ3jWz85Mhod7iUBYlowjT/huIQd2wa3anrvW+CX8C0Tr7oTJESyo+dBcJ4er6/hv2Y/kkPfGfL+blQKesDqbCklB3+GjAYqwVOwpZ39dmpmKmqJ301nmVATFDo+keqbhL8vFVblJaYjeVzP5TaYCqSUrk6qzFHg/rPAY+kqBgpeGyDGDArIA9sd9ZgVIdX7+bIsC27uEN49aFbBu2FV8hUNg8z8eG/y9CFj92k2xoQQKHCvD90QS+C+707ZAQWBU8bmfQz6Bey28gOcmAhtZffA+T6Ct39NlipmAn1O5OqqVQBNPwHK+TqDE3OjpwCERa2ueHMs8otJ0NHBJtNmrX4QuIXHIg+TuYd4yeeD3nDwSVZHsnWUnSTRUNcuu/kQi/7XPIdk5EkJ3XmQxc1C8uCjyPIltaWmWA60kdBs7H70dI/HJu5ra0o8k5tjsDHXOFG4NNxYFe1GIydZkk8z2lVdZhXwKdwbU99UhFCJaD/veZF4qX7C/SUTBuM7b25pBIWvj3x1vmc1xSS9YWRTERp+MyjwKHfeu9bkbKISd3f9NlJFC1LOKIrmFQlVMglF4g4Lj2ZdmXxsFboS2hWAu6Jn0bNMbCp8e0yYfZxbq7cZWj6ORtrdsOHwaDa7Mac0Al8bC4rTnPC8aLdRSsSufxpbC0Qs7KBpDvCV7ozNoTHOq/YJVQCNhwJjjZ6YhOtXZuP4GDUt/Tm0zc7CoXsoZpOHdxO6cZ6NR7bC18ofXNCZtH9/hO04Jgaua08dVIqjsidRGKDG4uGHmXEqJmHg307ksJYTW5ezaBiWcEuwwyJzioRZHdyuxPOSyXNCjxMqUCQ6C10oE9p6O+TCmBDmyaLQ1QoVB5+37M7pV+Dk5vmFdqBqS6bcFDiI1DtwpLXTn78apd2srS/J3Y1u54uFlJw0uWO/zZVwNXAyVW5JNGgy974y+wnypINRa0aPBZxIV+3FuOkoDQmftOJ6OzQKr9Ed9OhS8ije3mR03reGPMs9fdezjVkM65lWZNlwzpaP45L6HQ9O1WJjXb6qZoUWjBHdnBmrhG956aYVeC67g4g13Ox38xe0Dc1g6uPyWO1vFfF3osqzLoEO464Tct7ZM+FgmaqLPZOF/6YkSsQ==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="788">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwW0sFHAcB3BnHqY4euGpeehpdlxDcnKM+33/TdhZl5UrDy3ptC55GKlNGrk25MjDjdoa7jplc1S0Ll01E8mYxzRLXsRkIZ075bLa+nzcjCN46boocqyuYoKnepLN/aKW3j7sMgWhdL2EVguG2XOnflKPczCj7cGBhg5EJw0Sx/KY5SYO0VSCHMdO2qJgvhZbG0oKWjvPJuq4CLyhYM6zs2Rd50KlK2egHwxFSNQLcq/5Qt48FakW3SDfykDrQVdm3F6FYWgdg91xMG3uQWrSXvyzM1POipaWLcfhH/OIngheo5LLI6X9XaZemKFgXz5ZGbLQqJdCeTuMHYoDTtx0Z2+kGvilWaOTH4j3hZ8hq76PpsMmZHrb4O+lNnTV2uDDQDCZL4ZQYckI88sLQbaHHRI87aBWfWL1sQuQb4zAXtOM3dv2zJwiIIlRAIW/AyRLYVQ12YExlZ5GK8bQ+cMB13x24GpAOK5PhJMhS0ip58w4kt9L/FM7Ee/0CsseEfjaE0Fz/XIYWyMh1hiorM+R0b3LcN9UIpfnhKTsahxt47BRzyto9oom27S31OTijOImEY2v9mB+TUS6IoL0ggtyFKGse5IoPhdU9L2fgn8yihK+o2JOOTrSB2jszwA1PzzLnml12HcnhsTcWPLSDpMwXQzVmhgC9ThlSCZptmCaIj/6IF8oZWWRUng5n0bL72RqtySDI6vA0q1C5On2YyqzAo7lKWR6sAVWX4nErjRMTPtB0VCDdm8+vvFkpAuoRYOliJZ8rfAfYdz88w==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="8" id="sample=1 period=1 cycle=1 experiment=9" defaultArrayLength="182">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="332.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.077996886544" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="21623.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.018483333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="9"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="587.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="587.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="32.699813842773" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1844">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx3k4lAkAB2BXCuWIHJ2OqGTliNra9ItSlubJkS02MQymYcw33xyRjElTbEklpd3WGQq7QtKmzIRxpAjRWmpQNiVCUtu531/v847Xpqe5bw5Ec9KOkNWSIBzeLxJFyoPw2aIqUr8xCDlWj05usgiG0PTqMJsyTOuxF00ajJe9fom3s0JQdqaYlv40BLbGTtWzVegoP6SZm05ZcTQ/cIU5HSZGihaHIDoE7U4SYzod7wXjblWhdFgk/Tsykk2HUV/uBl4HHetXrOz1GaCjSDLVtFUpFLQHkisJlDtts87bmIZi0SvPtcoIRfxMgCKNMuSm7+CkUhgaByv6WsVhsMSe7m1SBhbKq5NrnjEwK3Bu9SfKC8evuGU/Z2D2aFdjglk4MmnsyfPB4UjT7Ig3F4dDYGuhycsNh5bpV/d4RTgKCud8MhsMx89rvqAoKwK+Rb+/m6Q8Pr3A+5EoEmOqqUNrEyOh0S+4ppwfieZmu4QgSuaciWorWSRqeL1pi0OZGHHdq9ifxITJOS8P+6NMpF4LSh7JYuKWF7ux8ykTfzrzhdsVTFhX9Fb2DzDR2Z6D+d+Y6OjW2+SZfQB3HLDKOu8AlmsZKZ3azMJom3p501YWJP1HW56EseCn3TXPb5CF0nGNsc7NUbhpeV1ygh4FlyeGKmuyokCOqjIS1aIRfvAqobstGlUrZdNOamzMxBmUZy9l4/UeKUePwYYTXqnKKCsSHumYHGGjuNO4UUTpsccuyj+Pjfolug0rxTF44fWq1SA3Bp/d7tgpZDHQTU24JTPlYGeTrC3OnAPGWOqTK3YcxA3XvikAB1wljXUNNA6se+7pN7E50IhGiv5ZDgamLpxbIuPAq1nH5SIlq2ye94c6Djyiif8YygRkh7xEK3QJ5Fl+8qKZEvA2nmovNSMgXqdoCbUjIM8cttzkSODLlYV2dq4EzlXx9HMp5W2FRRvdCOx1iAiuPU2gNWyPSsAZAj3OhifLKa3fq/v65xDYmJn3pY3SxHHH8TW5BGYteD91rIyASmxOgJRSe3pm/d1rBE7IEzVPKgiw/4jv3WXOxeQXFndiCxcV25MyGoK5MDZN+948hIt9+xaHmoi4eD9c/nGasve8r3CxmIt+xop88V0uRo4uq7Ts4CLiZQ9h8IaL5aeLtVwpWRv+dmK85cJtMuSukTmJQFEbKzWYhG4Y28qJS6Jruqk6QkRCu1xEK8klYffbiOsHKfUD5wodZCSs9N1ThttJaPmmSdIfknDiZOx07CAx4huwIJayOeyZqGGAxIvRwneqgyTunc+8mDREoir19QU55bIzg48HJ0h0m/5iZj9JYoNK2689UyTG+PNLvHV4aIzTs9Gh8XDJwl48QPBgWPej3E/KQ/NcP59MSr+Oq0tllHURWXWO9TyQ3tc9sxQ8/ONfY2IwwMNDxoPoUsqxtG/OY5T2Td9q1g3xEDL/p6/+lOkOj3cbP+Mh8P5Zs+ApHrYX2Oa0UR6GXuH2tzwEbDPibKXxoX+wuzHFhw/5TCq/ppaP+9MLS4OkfNzmf2258ZCP+tKSrsudfBhW3Njl2cVHnfxj73cKPiLvf7ZWshegT++Gaom3ALrqzkZuPgKoyZPN8ssE4C3JPHaoQoAt7bfNF9UJcE3cLmLpCBEjT9uSsUyI5OcuejUKIZaVtqYYDwjhoCQuMJwQguu2Q6gedhD+jfnFHuUH0evOSQjSjoVVpbLaqexYFFuFX3pKuXXCtd8wJxaVifvXumTH4bXUZlxCaZgijqqlVP+rYtXqtjjYqDXV66vE44f8uIwSRTzoyemr+sbjwTpy57LldDw+Wck9Lw4dxrbdomqasRj/A44qn1s=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="948">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwX0wE3AcB+CLRimMlZYijlovlJfkONr389uWskVZ4VxHLy5qdpo6OTO9eSlhrkRO5HqjW2/eypUaSu0uR3+E0ouy7ipHS1zsUnoel6kopr1aKdJ4mmiFwCSMuxcI3uiEMOa4WZhtioSntJ38vLQsIf4EWbUwBG59japGCxieJWJM5Qmv0Nn0yyJHNDsqDN7yF8Td+h379RyKbueQ35ydLMWhh/40+GLmRy+0m/1QON5Lbsn2GIjLwpdTqUwjCUBYlxEvHwzQ7uB45B+sQvOQEw0anag3opxmIsup+Vwohsor8MZcQWZ1G5pkzpjoaUfkhW807lhJu5SVlF1zBsXqbqxwW0YvGZcp5SYqPTRG7yX3obCUIpnngUsB11AewUWGZS30MgGpbXnssfM0OeR8RZ6jHdO9eoyh2NPsk6wPrS196Oc5ssnV3niX7g1llzeW7zEhsWMtNWjWodWJL8o47EPvj/nQWt0NfNRymMRdJepIbSChrRVGNAno5Pvj6I48+Lo20jS/GiG51uCHS1njv/VYNiuApB3WyDBbo2tSCnNdNUrr52A4vxvOAS0UdqkAdVU2uJIcREuFVzCx8CzWNAXjHOYjq+wRCRR89qetEJeVRYjuD2RDpXZ4K+hDuKWe5GVC2qVJhc6oJ+7nVCSNujPtT3ssD4mFzaoSKIKaMLCRELWXi+s5RCcPcMEx2DAjY/RjlEG+iYeYsPNYt1tMZeLvGPH/TYVTYpoJSsdNZT4WO9YgUpyOBbUf0BAhodhtnbCTd9KTv5tw1+EF1YerkWZwwsrOVjw8UgCF7SKoOFkwLJTSljY+tnfw4VrGY/PWF8FL6Iw2Tg/dy1yCimtRZFbdYZW+1dA75GKurgayQSv2dN9pZG6wZ5zbHtBFpzBLVTx4afGk9k+gixeLscFQgmFjErmYk/D8lgKiwir8BzlfKxQ=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="9" id="sample=1 period=1 cycle=1 experiment=10" defaultArrayLength="118">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="235.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="14290.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.020166666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="10"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="612.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="612.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="34.262756347656" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1252">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXsw2wcAB3Ax2dxUqx77A5Moph71Kqob59vS2/Su8TzNUSS/RIh4/H7yciIpLddu7apJzcZVQq0btXmtnc6rxYazm7HTupNahOrmsdZrXK3c8vnno99TLIr3krFbyhCzIlNxVWOjoyMVG02l0+yKdIyS3REsNw7+2mE42kdx0Ky3e2dEy8Xfu/9oD5gTmIplc+t4BJqs5Aez+AQ8yKWu3y4T8LpbMTejI8DiVgXFzxFYHXAagpHA8p4mp9aMh9TeaZcQJg/uXmvqSoKHtmGLpC0zPo52ObRfo/GR4sNIH1/IROxmUUb480w8q/A48/QtAbw4SUuOSgG2GD13aGUCuLxto640CJCiUrcwGVko8Euf2dVmof/LrKe+pdl4vTpk69eYjY/eGIM9h7Lx+5W0yTPlQrjSOOYDps/ZG9fsDEKoyBzi9b4QC/RYx/L0HNTrC4/66XKgSrzn0x0tQk6xJ3/8jgjrhjR9d58IGUkP3h8dFEHzimNvMSTCtyenEl2NIty+pteFz4vQpk2d/CEyF1SZt3E5KhdC51BmqzYXX68+0J+3yMP9snW3P6Lz0CR55BZ3KR8FG3W1rT/nY4pp637/l3yIdri3Q+gFiG6oiaspKwAxv+SwTyMxZsiwTzEnYUb9F9ebQCJe0uoYS5CYt2zvPqAhoY4u9mWbnvQOPPaqjcSN6nJ3p8cknMStrGzTXb69VZYTJJgRn/V5zJEwPzlTFECjMM63lYbZUPix92Iyi0mB6Jw/8VUAhVmG8izvOAXDhEB1OpJCY71hQwgKzormcK6awvTccES16ZV+5RU7DYVnUQe3XzRQkMeF7Txuo9A5MeHIGaRQ5P3Jws7FQgweWqHT1YVonmkK5mwWotK6a9T5iBiHAtm5CaZD+0dqQ4PE+OJuGHWeI4bfx1Y+n06Kce7sy44YmgRjPZaWpwsksN53LXl+Q4In9afqHmokWBS8F17ySIJIF6vPVUYJEl/6HaYnSBGsHZ0d0UgxbJYZcrNRCuf1/sx3A2UwM24zX0CGrYfhqRdOySDkr122jpdBev17Mw+uDJ3e5NT+ETn8reN6AoLk6L6ZvHSrQI68/WMxLRo5Wqo/aPzTtG4Jyphbclh9KC35rkOOsaCVw080RWAfj10XdRRh++piQJ/pgX89ZzpVxUhTssZOaItBKP1reLpivGlI5zbmK2Ap3KhiVyrQl90+61ClwDey3nt7mwpM5P36U+6cCkP+av6F5Uv4H3vurB0=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="644">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwB2AEn/gm1zj8S371BEqcMQSBU0UI0ExlBKtz1QFHzI0Ju6wZDPwBAQtG7gkCoi2VBjap2QdxucUO8dARAmuKEQSX7lUHbUslAwtyQQY6FTEF//htCqfHVQCeMVkGf19hAgxcMQrvKEUFr39tABTK5QMbjlkBqT5dANYrjQDH8GUID/eZAozJVQVZIQkGhzupA6/KwQbwvn0HIOAxCh7JIQU3s8EDbxkhB2m/xQG74oEABCPNBuBlzQUmfdECcNSRBZoi5QbhgqEC1XVNBbKf9QLUrH0KiVABBJXysQBV+rEAd8sNB/t8CQfRcW0HTbkVBBh/GQYlpJULfh9FBcZMEQVOQK0IQVYVB15leQQ6W5ELUkadBt56nQS5HBkEfDzNCdAsvQi6GB0FstTRADcUHQTuhYkEirTVB/Ww5QV3CuUDowAxBGG6NQQCUPECEqQ1Bb8S9QMrss0G1nRBBuCiSQQyaEkGypxJB76+lQjr/xEDPS5VBhS0WQSatekENAiVCel7LQEf0sUHwkX5BDzK/QcyFm0FXlulBuYYcQTQlt0Fb549BAf6cQdhiHUHKRyBBEdbIQdFzu0Gn511An9AmQYCMh0LJWClBKlLiQIR/jUHIb8dBZ7iVQZOUBEH5CM0j</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="10" id="sample=1 period=1 cycle=1 experiment=11" defaultArrayLength="144">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="275.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="274.021054740076" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="16095.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.02185" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="11"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="637.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="637.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="35.825664520264" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1504">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx31YywkAB3BzUahOLtLznNssp1JPLwvHc8UXoUlK9RSVVXtrU9t+v99WbWuxUByHSinP0Xa4x+EevWjIUXm8O0fl3InNemrea6GNJ0X3++vzfE5M2lYStzQdCcS+hd5t6fCbXv4vp5SHg5WvJAFlPPS/SPdJvs5DZEid9wdeFlqeZbR11GXDPWl6/hiDj7mpXM3Z8Xwonhe/2SfgI3nU7S63h4+1bryWuHECZJxJD13FEuAkM0vcN04Ih5WdEsQQ4veqzMTaEiEqJhNtqduEcMs7PqPxihDPTY6EaD8RqnVJS/YbRCDFj8nLtLtHPdaY+kQovUdErbaJEG4YeWb5Soz117ujzHoxfIWLcwJKxHCf/Oik3irG/AvBt27oc7BhwUP/aKYE5lfn5yw8JsGXFqXo7TIpwi01OySbpHhYZBhM2yFFUH1O93SrFL7d7axz0bmg0nyf3F6Zi1LzjtsWYS4mnhhO+SjIQ8I5K8dUlwfHlFNVi1xksKaZb+qjZfD0e8ocojWGdB+dcFUGV8n9Xza7yJEXZ2Kr/eS4eCllv4dIjqlzw6VRpXLcGRb8OXBNjo1LEo/8Y5XjLa95ls1FAYagXnZTr8CPVxZcGzMqkHqow9vZqkAzd0pqKovAYK9q+xHa28e2eGezCXTLk5/2rSPQvzVAH59IQHL6U/FuWhvb5CPjExBVepycKCCQGSP4+r8KAnWBraEPzhDY0xtgmd9OQDp8KKlhkEDxx7CO2jECP282RCaySIwKmydkhpEYsCRWt9BGEau3V3BIODesqImJILFpbDBWARK/DfhGHF5Oov87p92gJzF76cQSYzmJq1aBe20FCb+Z5oCXtKo1kz+vNJI4Zf6jrL2exGVOj9Z9jITu1LdxxmkUNmYHGxRsCl3O3og9HAqRMz57B2dTYN0X7b20lYLCw1a6ZjsF0wj/bmYlhZZVo4d7aKcFczMutFMILWOmNHZSKJxjCXK8peC+3N4+7x2F07Yif8kQhV0X/B+7MpTweBHKjmAr0Z8bu+dDG/2l8f7rOpRI6WBZIzqViLX9FbnsvRKTDEuKVjNVWOR46clfp4Kupmz/nS4VmI5H88J7VXB+46VtsqtwveJjfRfy8WnmlwJZYj6Gw4Zn+J3NR1aOfZq2LR+rHjhmmhoLEL9p4JaqqQBByTHic50FaH7j3D3mWYiKmr0/9IUXIqaJW32wshB/32PpkhhqBHtpvu/yVCPa52EAQ6mGzXeZf1OlGr+2zp1jalDDmBB7kNeoxgbJ6y0NtMce9YTorqgxVPXsCPudGj5sz80hXhpsfL949CfanYHxPuPKNbhRH1W4ntb7gFNfZ9CgmfOuZIJRg/j5IxeP12vg4hx/y7VBA31VXtaWNg0GwzifGV5atA4FXrWztOhbG9+83KBFzcVZXp20adr+nbKpRRDuOhD4xK5Dh5t/KHNQB+vKo9JqezFqzntlZzRtxevKEa45Uw+VJfsBt1aP9BWvXMtp/wfang2I</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="768">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwVtIE2AYBmC35UpzaOrCNmKZmiVzpg1lHvB7/02NYiaoiIs0FuFMayLDA5J2UlEEL3IUlrk20zQnYTOV8BCJTaJkixaLiRqNpRYNdmF4ET1Pgf8DzhWN0XbAzuzmScqN19Mqd5a++nMRN7bG3lXcJoVwiczGSGXJkWGInw3DY25Dbe8a/KHdZBCEgv+9mxozneRMSUVz8yCMP7vZ4lEVOD0uWnwUgZwlOSvyiVjiShQVzAhxJS4Hro9eEs1IsS/bCpNATHkcxsrTJBTokZD8+nFSZW9Ax9QY3B6izZ14MqpPUBNvBGc0iSjv8+C57iQSY04RVztKdYoStKyXor0vCBcdQYAkmZqPWTG9zsGdGBmmkiYoetoN70MLPHdlNDrAY+PC09hodyA4IhiGwmAM8OxKqaADkfNpJNE/xm4Mn709z2e5JR1UqurEX6uNxA1NbNgmp9X5TlLt7YfuwS3myMuAvsVLl30ZtOOYQcL7KlhuKhC/ooA2ZQJXX2ZSvzIMe9NhCHmaRW/Sh2AMhKHmhgBdlhHk/wpHra8My12L1K8Fil8dgnNWRSbtOOZ+30dquBCxgUpYnGcxZz+Ma5VqmnwSxfgGEf4wMXJMq/TpggN1vHsIMXymrqRSaGxfsJbuIon0B1tOYOzFuomG1GXwbcai2F1G3N1yqs46wP4VprL6rG8kky2grU1DrdUL2JJ0MNFWI9z6CkjrK2DN3yD/djKivVXE89Sg9XU9XZpqQK/tIJNVNtF/eGjqag==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="11" id="sample=1 period=1 cycle=1 experiment=12" defaultArrayLength="159">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="420.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="22856.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.023533333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="12"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="662.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="662.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="37.388542175293" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1640">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzH081AcAx3F0tU47k60nZS4aEV5Rlmup76GxaHl5KpmH7twhnN/P75xzR36eLjJL4kVPJ/QwledVTFnyVK80dy+RterESilqbawytt9f778+H6//Wo7oufuhsN80eHG2H1RDpZ5bt4WgXqAttkUINIcVkp3pIXj0nrdsc04Yei48EPuowjDWV7lX0RUGjvnQ3LhlBBSqyPwK9T4oj5sYGBgIoMhc7kIz5ppe1660EKC+eq1zoEAAjfeOLalCAd6y7OtGGdcclTe9yBJgsDbgYX+5AJNDhjN+WgGW2u9l7R4WYCC6Lal/hOnYUW++1RNC9X208XquEG1TaVY6vUiETrs+4elHYoTHDs0rFyGg5sjF14ydzxoLe3QiHLSo5Q2MipB6xvTzzzLEUKedb7SqEEPYMO5C68QY5Xd7eZhHYcWWhLv7LKLwqLfv+m/qKEw0WOl56KLgLHnVlcmPQUHVB6PVoTGwnWvz+u5MDJoaefPvVeyH9ZfV+0o8YhHnsGHjpcpYZB0TycYM4sBuLwnis+Kx6Ovfe2iPeNTt0DQ7b4/H1hVUXCpLAo1xz4QuUgJHVlmoKFOCmlOu4aKzElg78aw/6ZKAXW5LW85PwNwFe5t/6AQ8v7X5VU5GAkwO3VRMnE7AiH50/nNzAk6VJqUnuQTk5y8sjvQjUJoLsUxAYO1DJfdvCYHGWp+nq4oIjDb1xlyrIyD1caI59QROjth9+NBAIGPnZUvzGwSystfsnu0jcKDMsMlZQyB1Xf43BKP4/pzskY6Ad+07C+thAiX+nCfh+iTKh5/3BnBJ7DltezB1PQnWZnXsNScS/WGXlR4bSOhnqUSZIDE4WPw23I2Ew07/sWHGF+E2y0LdSdQbOXp5+pI4JA3RfhpBojXKfn4KzXxcvNnXCkn0CX0zDI+QWF0dZKJmLKmpzHnMuGAdv0BdQeK1nbIzwiQRHe9OpHc7JSLNQZs8hETUBmuaF9CJqB6bikltSATLszs/qT0R9TMvGvf8lQh/x+SObAMKSc29VussKJCzDoLlThTS+Hd9siIo6AetN5akUzC7cawvrYjCuNFe/TQNhdg+8WygloJ/0/7IyTcUVjXHE5eMpLi+Mn/FbWMpXKy4HadMpKC9OlcX/CJFgMV21YIbUoTHtvbYdkihJBRuN/ukCNa4Dry8mYR5VeNmP08moX3huyiOowztj91uFUOGyDqCM48vw1k/m1wbRlujjzeN+8rgenWrejJChsc1rptyGmX46cHLK3cOJ0O663Y0py0ZZT7b0md1yaC6plv9hpPx1DFG+YORHPFTWu+HjHYxjdkFRXIIe2ZEk4y9wf5C66NyZPr58kor5WhS2bkUNMjBChvltGrlYJ/4KCvJKAVlU1coz40p8D7pUPWgPAVqs5ndrNMpoL8aMrz4JgXN3DUehZYKHLZswxIHBWqLg4q+cFdAGMyV5B1QoIWa2RJYrsC/C4//ya9TILblzrNzjP7iqycCjZVgvxfjHGNY3B4Vm1KiWzoNN8dUTN83iTWdTAN3UcRALqP26cpd9xiL9Ks4QdnpaLl9bMLMggbJG15SnUeD15XhT96nsXSyxD1MR2NJibP9KcaLE+6/po/RiBg89IeMmwFK0Jlj+GM2/gdNuTkl</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="840">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwQssFHAcB/C87vJKHIvlSnnl0fIqina/7/+OSFsPHaIaSyZDWyFSIhxiMelINoSKS0x0q+3ymJPqmjprq4UskXFDN7Fs6PMxO7FGhbkHyT7xDFucHaDA0hYyi+hhfo1eNOKwIHBfXBLozW1QreYlszPtp0xDC6R33absEV928rUuUvoGqEispATtNYTL1oV7rutTWf0wOINJTB5ehOh8FYp7TTEylQ9pxV1yrcpkVn2VLEnPnArTg9nGj+9kNR+NNPVhZv7HEg+UjzAjlqBiiRD4pBhSrgLVAVJodLTkt7+J6mYd0KtxgJ9klRLMnsJezGO7dq/RpGoI1u47mczGDVdP5yCmchO4/Daq+aqDi/W6GM15TuUPRfh1cx+GeflkbKXPTjl5IC/jnDD0Xj59Wx4l+aAHKbZ5oiHgCJLFBnAqHRf2O+1lkiEvyt5ayYyPSXAjTIIoW29yjuBg/GMIUl94o1uugVAUCpsOH7yd0GFpXT4UbNBNZSJfypw3RIe9EZbNjZEbd4i2cE3gytFhqmV/6mk7wCxbTLGZ9w9L5Y/BMy6jnGkBGmcFuJDXS28sQDO2fSR3BCkjpcw5doBWLg/QLZmI6ra/o6apEGoNKmDKAmsoz4eS8nMJUhXVaF78QO1GNXDX2mKhhA9lsxpZa3xMXAmDoGoH5oLqcaf7Cy0F15Nnlh06Mkg4rwwHf1CL9pRIcKpUKPGPoni9FcgTzlLx/VEc7XTE6vQYtbrkCJs6x8mX64x1t1K0uxqwT2Ox8PkdRw2THoi/xMOrxh5wOVrK/ZlKz/7WIDmmFqtqf5i8T2RGslWKCVDARX0c/wHtng3+</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="12" id="sample=1 period=1 cycle=1 experiment=13" defaultArrayLength="150">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="234.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="15892.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.025216666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="13"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="687.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="687.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="38.951393127441" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1564">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxX9YiwkAB/Dph+OiH6LiSqWEp5MKnS70LS3yWxdS2ta7tq5bW++7vWtZOhXi0XN3IVOhTcvS9ZTWHaI875KihH6cqKN6UIeQJNcPz7l9/vkM5D4YpwKjQZxa8tKKiUbBxr/lu4JiEOhvYrfyMAeD1c1pmW48OJmF6LuCeWAsXM/M4PJQEUlHXCuMReTm++7HemIxv9GkbooJgfeHGjtWcQhkzs7YBILAdj81V80nMHXhyiU31ASu5Xs17+4jUPHodX80i48jcX6XR5z5YJc5GXxd+LA+0BZu6sqHDfPlj0I1Hxlv3r15zIrD1MHtB3dMicOHC40KezcBJCM5G7LVAnTaffOJ6RVg2/r7i7qfCyBioua2mAphuVK2anWGEHMt158J7RXiyNMGy0rjzNPCvZoF8fCfVcRxVcfjovJt+YueePTtMU2z0P6IZDuBR0FQAsyHOsKIQwkYWz7mqS1MgHvD6q/bexLQyiu75t2bgKGAf7QdISIURwVQaWwROEpF8XCcCKybnQP6IhGWlSz95OmSCHevpNJc441XX+XVByZi9JAtnVKYiOji4PyYEDGcPLvS/NliWDOGmjdxErwUftXknCnB97TW6YVZEoictVwPlyTAh3MlIj0JjlvUQp0LiS232rMKXEmYDxOb27aSWFs3sb02nERFWGJIOEFiuJlSlRpvZPvtnpCQSL3XzB0+TuLbV3+qQk+QkGRmLQowkNgvtol1bCVRjvqW8V4SawiDlGNNgd1dc2yjC4VF5aRgtzeFAZ1LyVVfConC2w6RyylUTHowAlB4vUxXqQmm8MPnrIAh43r3o62JPAo5SU9mitMpnP+80yk3h8KreeLm2uMUNky2DkaxpNizaYrmxiwpZlgif46tFM0f3VQKXymS/7te9P6AFKeG309Mz5Bi6bwW7sbjUnxR2T+OOiHFa7PlIaf0UrBqBJ6rRqTIeLcp8Bfjqj2SsmkLZJjm498SY/yy7U8xzr4ybO4c6vAKluFW/rmTbuEyhKr4dubpMlzNmt/CypRB+ElUG3xChmcHxT1N52Ww5HQZrn+QoVhbfveKCY2CNeWXM61ozK5zHrDeSqO/5G3ouIRGWHHYNiaDxklz0dxshsZpXcGWbuOl7Phqdj2NhHxdRGU7jbNVZN70Phor9CalHs9ocHKyvUKNj9raKKve0aCrD46zdshRP+j5/Gy4HILsOw5/Gc9x93EU8uQYTXa9ro6Vo3+N5JHXAzkma2ba93snwzBd07bLJxmFd4/1caqSccFCvkzkqkA0U3C6fYEC5iZoeNKrgIO91dh3fQow9ZKeRssUjAyss/bjpUB/30wb+WsKSu6saJijSYF868d7UfoU9Ki5RXXGW8dmPjyn3gfb8L1BVpp9UAvFlbcv7UO0f1XArBVK7Eji3dQEKeHjU+2weJ0SF35/aLFQrcR8X97FdONduZe+dBqfZ+Zbu5pRwtEwFv9zmxJNwlJMmqZCG6vTXUlPxcsPp1Xc3lTkbWjyW/wxFUe3VbbxWfth89vzbjPv/WjZOWq1xDQN94h/J+Ly0vE/gvEebw==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="800">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwX0sFHAcB2CvuSGUl5uX1WkooXm5dp2h7+d3ha3smkOnFVdkprU1VpomyyVEl5fO7lyjUKw7/uCKOmrtrkiJ28ipraWXlXZeKms2pOexRHHZnPcXqo6Yo2ndGxbu5Yu/OQO0feYoMhfFSC6fJdWmLSLTipHC9Ha0EMxlMYoxTDeUiOSlSoyKHdHb9gv1EkcaiSrFUrEBzVIO5YW40oTHRQx+mKL7m6tZww8e1G727M82B3bkdT1WW7eSc3wWvi/eIr7pDqzRatLGdcPpsB89d9WQ0AxoVl+iK0EJ27IY/JQt0XhZIf5pAynrG5cVtCzTyZQ6dFqDaNRjCIq3VbgxHEqB/hs0zw1DpcWWOZ6TIrElE5yIHkpRtcN6ZQ+dN/ZQTkUHbFrtEd22S9TVeBVJWSdQ491LvoEcUcBgNM6O9FJVSydK3PvI3H8bHQF9JGuTQecVypTdfPT06cl77hHlJfZTULIAhk+nEdE8AUGhEANGIVxeCWk9NxazygI80xnoYLUTuyfxZE+8xOxa5BBNXY4ncfZTWs9PAN/ZHR/t92Mt24GFzBD8zXVUXHMMAaoiVApF5GNbiWSZiRRpjch4bCJxpg4Suxc0cOAC/BY8UeE8TPLlbOzwTCJp6jC5SZMocsMHa+9Lkc49RGdOjdGljHESVGgQ1ymHoEsOS5EEtZY0Ut9Nh2UhHaTl4aaOB762nSY5TXinqMKD8mCUdQejdf44Uq0qPDTooZ8Kgc2+nTBIjZh3qcX1ulBMqnNo5fdulPC+UvjnXIrdm08dsRr8B9DX+5Q=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="13" id="sample=1 period=1 cycle=1 experiment=14" defaultArrayLength="118">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="329.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="12324.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.0269" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="14"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="712.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="712.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="40.514221191406" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1240">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXtQ0wUAB3C3JAUvIpxoHtRCzbuUk1fHIRlfHh0REcKdnAiNsTEeDrbffvvxFN1A5mG5xjNOoW0u2IClQBEc3gnymFAIOUjJo4MxEJjkkq24TOz6ff752Jj6iJPhqYg74xczTa8bzVSdUHAwrt8IO3SJA2vc3okb9OaN7IAUEwejTtfPGOlcNEfabTmDXBAXy470Wbg4yA1xf6jOQPVV+2suTB5su+OXG/g8PPjIzRpv4SEr5cb+T7fxwbpvd3Nh8zEeRiY9Sufjl+HskTcZmehKePCT1wEB9v7rFCxqBAj1t+SZlgRQkWk5vGUBrMO/32OVZ2HxLX0ufyELrwQ3K7dkObh2tJWBb3Mw8ndwVkJlLlanePnTA7k4/gz7InRnIfSMdJ2NFmI+vo5bNSBET5PrUZKdhxd1+hcKdR5+7Z0bk0fn4wduvOeH20WIqk5e3SkQIfyygiWsEGFPW/uTGJMIeW4ktd1FDIbe+34yvcyHYBuzxbjrly7yKBcjysE3Ld0Ro6r95uwim0C6W9iRYl8CF83OxFoegZmg9w9s1RAoy1STZ2sJZKh+vC3sIpBmaI/Z7Caw4vvNzx53CBzTprK/pPfv6HpW9ycBarNwKJYhQThrbY7DlmBFzzb0BUpAtcz72OgdceHiy0ES5K9ptxojJcg97zD3JkkgYpgUjSoJPs6Q3fquRgLhyNpDpgeJof5TqwZPElesPTI7/VPPlK56XxK2hQsNo1wSHUyC2J1BovHQldAgOYmxMaVfDf1Ln5Nfs8tJaN4djbZrSBxMTP7gsI7Ec/mx/K/MJMwX3gtIdJJo7o4PV9Ibxb3j3r5SrJbvYyZwpajYYTh+lX65MKX/c0KKf5RDRVy5FK9/8li9rZb+t+nKCLMUiWn6wH56VXRSFTak8DkTe0njkCJqvS1Ux6Sw+VeL4ZQnhUVtvV04SGFhMsteNkPhi9bnW8FWCoetPuuDdgryXX2drzooqGbGTKe1BXDuGp6xfl+AdzpUA3PDBTjxxFsZMFKA6bcfL1VaCmBU77E+vV2IGkod0DpViNQ1v0Z2dxGkE9INlqUIO5IU83fdi8GgdB2x3cWot2f3NNDf8woxxFWXYE2//vKmpgShMhd3V20JAm+5Os51luANf2blJH0yp9bU71+KCaPvFE9TCttk6n4j/dbOaxsRnaU4/Z/f9ZD0c8hQW7z+mC/Do5Y2Bcd+HjJnSNMKfUvTdUbFrBz/A9Kau0M=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="644">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwB2AEn/tn3UkEcyKhAYl70QsiiMkGBMO4/NYQGQT8DOUDWILtAuXh6QPrvT0HcUY1CBxCTQUGRXENx4QRBD/f5QdkthkBome5AcznSQAQTeEFLrohCY/LVQK7WxkGz6GxBMeOWQKQNUEFX++ZBPQPoQFb760DjIilCPpGgQGiB8kCW2UtBn+qkQIqFekH9DyhBg5H8QK6l/UDXx6lAuwE/QQrVKkAOGitBCccrQEEiLUHFKi1BcIEuQYRcW0Gify9BkhYEQTkmMEBsVARBFXMwQKTEXUE1VYVBgonRQm3IMkE5I8lBsMyyQHq3HEHUkgZBfH4HQRjg4UGOODdAbkW3QV1Ht0D7sAlBXtC4QOvRuEAmbrlA/W85QMxyuUDmDDpB0VpRQSAEu0B9qztADphqQcq3a0EbU45ARVQOQdcSvkANYb5AA7e+QEDqP0Fb8Y9AApXYQXKucEHD2MBARdsQQWjSq0EdvURA/2EsQiU+xUEmTUVAnXtIQO5DvEFVG0lA4RxJQDSkSUCwlk1BMeLNQLXWUUH2p4NBZygEQmE51kAmiU9CRnqjQbQ52kCqrKNCLH1aQOXeI0EvoFxBPqJCQjHVJkGkst5AKSkpQQekZ0ByHd1B4eUwQV00ekFXtcdm</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="14" id="sample=1 period=1 cycle=1 experiment=15" defaultArrayLength="131">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="422.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.006388337832" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="15114.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.028583333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="15"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="737.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="737.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="42.077026367188" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1380">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNz2lY0wUAx3HG6fCJcSSaQ8bR8oEIFJ6QUuA35VAywJFSIjA3DsdQ/mMnUyRAEFEfxuyJRB+GzJRMZFxyCRN7TCDdZFyWGmf5RDmOUB4yov+rz6vvi++2xSMRpZYHURZ+0IcZmoCFNRXhWtI//Hd3eRUlQbNEX/xMx8HU7+eT71cdhl9IEPU1hQt2Rt2y0pyLKmmUbD2XC3vP91kaHheXvEvGf1FzccFWWxU7zkV6snb3ATMe3ujY5hvdeNjVnX/+CmmN6u9Vb0oKdmjswuI8UxHEGQjRq1Oh1ZbVtU6l4qL+xn36dCqaQi+l2OenIXBv58qGsTR4PrfzU5C6XW2g566mYeDDt5J7GOlYORyxZOGRjnGbhwyKOh3DN1hSL80RFMSURJsl8nFR/GTUWMiHo42pMvgUH4Wz5zw3T/Cx7tWZgXcpGZho8f0o0D0DtjaryUSYAP2iSs0Q6SyRom5PEWCujunLqBLga7p49JBGgAdPpxY6LY/C0Prr/rNhR6Fn2eUZUo7hQEeCVXHBMfIvGP6cLGTmlGqHKAR2sZnf0pwIFA8LVrsZBKbO1t4+wiawJdz4VSKXgE+fn2SpnMA30awzTioCXk2VRSM6ApIxk7/3XQL6Vrww3SNwYLCa7zBO4CdX5YUtkwS+oPMC91OEeF1QsKeMdOaax0NnmhDb3deeI9yE6Lo+3bjqJ8Smfpfv4gKEYFp1XK0lrcjf11K2U4hYd1Vewi4h6Due8ReUQjzNXXO5p1wIn7YN0sZ6IZxroxXe+dnQ+yoNtepssHTtOTX6bFDr3zszZ8yGejnaoJjPRojB+d9QDxGuTFQ/V3BEYO+kba3JEmHY7VbJYoEIt4+PNlupRHhg7xV1p1GEu/x4wbhBBFdm+1jNY7K7d0PiNCBC0NFG00lSrVG8nj8pQsAmWtr2eRHk1FuG2QURriUkUPN0YkxHvTlUbBQjckGZ5zoohs7Wb7PLpBifJHZHyuwl4Nys92LESsDwnysVsyWoSv4zU8CRYPB6r4pKSFAckP2Oyw8SFBXVhlBYUjB/3hs8r5IiJvFlr7hRio/r7xVW9EjB3ubKa9gqQz/1VdpNlQxPfvxr6yjpvr4Qy1KNDJrTrIRPG2RIKz+95zBNjldtamqWoxyP3BPVjxlyVPNtV5L85FAOtfnTtshRl/S9PDhADre+ZosNPDlK3g5MkjXIYWYUxo075IAVEda6VpmD8hfyEevqHHwwf3kin/Rz64YGLwcFEv+b7otUK+A7U2aeR8qqX2eM1ylwVVm2HDmgwFNlZ7fF4nG0dPwj+810AnGe8njr1RNoVrLWgJOLvq5ng3dMuRgJndmX2XQSLylzjqyYPNjHbdQUj32JR6d6uS2k/wMvu9lW</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="712">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwWlI03EcB+AWm1BatuxNLl0xde0oaUrhdP6/nx9mS2cs7HKSaRaYGTOla0MMXUQthzGQMpk0SYtOMnVGktZUIjJnHrmZscChL7QlWJaFPY97ysdFySrgWO3nDi4EmX6/AWNBDgptEite84bmJ6+jcngXiy+LATfIS7NExrELKiXjNR9B+70oppSGUYqpESeOyljY/Aicb19Q/rubtEqyjFatj/x160k466OQlEly+M/Bf2UjEpZu07M/ARqKEJGtXISMTyJa/t1HAomMLdZbkZOwGZ7CINl3xuB9UjxLEnZBV7AV7d1ySjcraaWTh+gRHjIU25GoT8O+3Fxk7/6LmmwLPQ6IWfcxPuqH+OgXNkPSvwPSQwJ8Wauik6dULPOlCiU/bMx7+Su1RbaiqmovHE8TqbjoAS7d/YZ/ZZ1kDVXjzoIanDYMFc5kpLtOY1Ovhlh4KjWdSYWoI5UGFEacnzCidDYcBTMcxQa+Y3pbLY1aiIQ1hFd5aah1uUl+w47y5y7oJ3pJ3raF6YR7ICl6ghJbPhyFZvzMy6SQYR0NHP9AmpYsutohQs9SA7r0Hqqs95B5zEOfbzlopjobKz5GQ1E9ByNfDG/EARp/KIZUPUp93sPI+jVOSDbArjFAvyEWnQIrXl8bhD3HCnFpC0LnCqmnpBGPYqZp3f0ZXGzi2GJcApTuOkwZTURnTfQfEz7ZWw==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="15" id="sample=1 period=1 cycle=1 experiment=16" defaultArrayLength="95">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="246.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.006388337832" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11265.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.030266666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="16"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="762.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="762.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="43.639808654785" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1004">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNynss1AEAB3AnvSZqyTQrzxBRs6Jltb5xFddRlGa58/idu6Pc/X738zycOxUtZlymdsvuTNSy41LaZE4ep6yuUquVHri7XtYKPdQU+v31+eejrgt4FTFwDHWPcq76702G+UjVmnLG7MDHj/3KU8BpuMJvGEpB/+IPP4/UNHR3an2vpaaD52J5NapNh3+wZstSewIXd64jahjRFhSWSBBYnRDAKhIQYI+GPzQxWtdmiA1nCEy8E4sf6AjQdkqbfyOBSse5a7ETBBaiV7jy7AQY1Ay+1zMOBwaMwUuAoA2DezisDGT+ftFarhOiyiYw3GOcdY5rHbAJsf7ArYCvS0Q4feglN3NchGqLtzvXUwy3G+yURa0Yyireibgrmci9hN5PvCy0NY5sS+BnwU9R7P+QfQrvu8wjYV7ZiOZ7rqyOysbBZO0UKy0b/7Ka1nMcJEhujtTw2RJQ1rjQaUbfkHZLpUoCvUhfQpVJUKkIFg9kSCHs9lAcEkph3qy0zxuSwiHxC8fmQGLSJYWTv5SEc5JizpFNQtdye9dPFYn9EZ1H+00keMOvlRUsCp+l0phpxo31yvynnhT2zcbGP/Km4LK8lVOcQEHh7hkcT1B4XmVETB+FNHKmWMj41/DnlMbC/CP2O9y8ZHAcbK45xljgyMnYu12GVQm/3MWMy5zqqLxIGaQRw9ZzKhmo3rLZWLUM6qu75zWMEW/IxjaDDE+e600nb8pgUj5Lb/ChEaRY6OlS0Sgtzfozz3g/KDbKrZZGar5pxqamId8wah24QOPg0dqQ5g4am3eJwmxPaQzTxptOPjl4+yRaXs94eKQlMkaZg+/HXc1J6hx8NLY0i0Nz8W2MPFtxNxfe+sISrjUXIguLLuzLQ09qlLEvPh/XJwNnknwKkGjX1eDQUYCVxvA7WwWF2FR9eQe3oxDtrPPm3bVy/Awf5dt0ckwK2zd6NMpxAf3W8e1FkNAhoaSuCIZfSR/GrUpMsZu0JeMq/AdXV1KW</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="520">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwN0OkrgwEcB3DWlDYaGbmPNEamptDixe/7IDLyQnIXUl6IuVKzWkuhuZlt5Wq0RJNry5G0vHheyCQlypWWVq6I5Ex8/oRPT30m7bHzdDjVBVfpFXNGR3QuCcZBhJq2XyNwG33PCHp90W7joNx4AdNWJ76H/GBtNlN9cRaG9aMZPK4dN04uzbx/YmO8EZWmYyrZHcBOdhKT139CS6V2JGRoEL4hx0GBkWpyXLSmUuJZaEWt5oVKxnJxXT1Lc0w+0u/MFKOVoUknwptehECBGCM+YowHLVCi5ZcCltTwaosnKnRD+KUbZpQJuKlwR1+ohKSxErKpFPDXJEJexMXZUAVOIqVQ2nIw/JPKLDdPwtORBGdhN6ilGm2rNloPnYbdVANFeTKeDKnQCfkw+vOxuSMDr4gP4f4Wve3zwXqk0WmDN3z16YhjB8FWNf5fgMQrImaRw0LmCIDcoIa5rIAsVWFoFXQhxBKJqI5oDBgcMKeVoe5Bi6zHQOZDl4IJxRf9AVk1m9A=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="16" id="sample=1 period=1 cycle=1 experiment=17" defaultArrayLength="104">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="320.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10428.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.03195" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="17"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="787.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="787.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="45.202575683594" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1112">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxX1QkgcAB2Ahtjx3p1xttZyeqHNd6+P0pTltLX+aXR9L7czSTBJBJBjh+wKCUCRZs3K3FM5yq4xCSvvyo7LTWWEqlJaFy26rSOC0Wpip5bp2dtX7/PM8YPxUl/DLFhx9HiBuSeKjtUTNDc7lY+qNsz+AKUBjK7XMKBRAm6GfNkk/V1vqeWgWoFRjb1vtESBvVf2nG/2E8B7hhC3kCHFm/s2WEb98jBw6HLYkUoTA2LPsCvp5kd3tVXwRynff+jvHLILFkH9qlN6bJfWvGRJBUS399jF9c+JEZPiuAnCj2euWuQvgSmopNdIzjS/i7x8T423H8MBmtxjZvrE/DZCA17/nBPZI8NWkrL2CXjOzYVWOVQLW+g9fG81S/GFffSnOIgXRNVx7L/lnXHblNQUmy2DrqnyYztoGaVTLlX+St8F5y+p3kiXH/gGJlCeSIzp0b4+/XY4ZD+rH5JxC+E4/KiljkPiyb7C2PIJE+Gj9mu3pJFiNT8NzBSTudC7P7DOSYDxLeRJiIrGYbD73oZmEzzEzZkEHCbe4iamnvz7XiiwPiXzn0X0/MCjM9uGght7VkDY9lUMhlHB5ztInX5yac5WgUBCWtjOGS2FNdlSbNYnCopRPrD1GCoS8jBd/nILU0vqk6gSFgCFm6kAjhXlsx5TORkE7O2evoYNC24+X5JxOCkP2wrVlhAKR3W79OF+Ba/8XySdNCmQSp3lyiwLuxU2J1a8VEN4InpEWoUSvQ/3bDr4SQf9dzxablFC4L34e2q9EfFbcAa5XiRW71/bMGldizrHKIP8JJRb13c7g0o+4YkbrXilhN5emEkEqtPduYuxiq3BjReVdmU2FqkQn5e1UQTpxoOf3LhX01WUVvX+pwCTqwjPXFaH21Lnz39iK8DZ25bstEWpoXvPGGqLViKi5Mu64oMbmDMn6II8GxD5zlIRfjL7Yp3F+JcWYkm0Y3m8qhqPkXyfRXIyBX9nXKuh7xQEJz8xafOdbmltu0UIWUvjZeZsWWLLwxcu7WrwnDyb42DrkvXne+jJah+9zDtUYknTw3jEMas06pM/aGljJ3IEvWGHBRIIe3V0hpqV8Pd4PpqxMFOrxEaUVfdc=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="572">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBoAFf/t5lUELyYrhAuK/2QNE1UkLWQMxBZxfEQHOOA0FMx3FDcMsdQiP5R0EmVwhBaqsdQes70kCt8QxAE6DUQK7lhEEowmdBdfBVQqacEEHEyZFAUbBaQYgnlECyLTpBiS8ZQWF7QEEk/OZA44vnQG7v60AhUh1Bii8fQbwa80BqNaRAl+skQcyG+kDDEKhAhV/TQUoc/0CheaxAKSutQK0rrkBggC5AP3wvQD5dW0HQHARBgKL9QctyMEFBGrFAfP9HQdDHMUD/l4hCSQVfQT8WhkEjGAZBTH5JQdWGh0Ef/rRAFwU1QSxONUBSnjVAqToIQbBAiEG75M5B25wKQQvMOUEKkwtB8ay7QLaTvED3fVVBkAoPQizk70GMKRBBUn9AQediEEHWhEBAAK9wQUMVQUCNG8FAxV7EQTXhq0H/cURAXosTQY3I+EEzCslAf4d9QTaysUExCxpBnPwdQWvZ1EDPXtVAtEagQeU4VkDB7FxCAayjQRhG2kD/wdpAAwdbQNmdd0IOoVxAQbAlQabUpkEwKWRB/yTpQFcJkkGNtGlATpKvtg==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="17" id="sample=1 period=1 cycle=1 experiment=18" defaultArrayLength="106">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="332.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="12488.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.033633333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="18"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="812.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="812.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="46.765327453613" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1124">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxWtMUwcABtBauogyBUcgLCZrx0tWlLTKaqYJfAHUKkpZkxEiG45b+rIIvbTQ0hbX0nWJ6Wpti9GNSF3ryNi6QZlDUMOqwJgBZiAywyOA4HA8wsAOkhWU3fPnjNdPDKdnFmGjq8vop55l73TxLcXIpR2O/r6xBGVvbN8dRifwydGWaTl15z7GBLeYgLzzHKeH2rGexygiCFxVj6RUiAjEK72Zi24CYTF3I/OmCTidL/VKmghyYzM9jSXCQfkT676bIrTVhlp9tFK8uNZxZpWaF/tbrnZbKcZsyY83qaPkI7YmtxgCob1hg/p0aGft4qwYrzIGHtwJk+Cp7UxdmkmCte52s3lKAocnO7smXgoe3/rqWaMUpTd2SSUzUtxavjGTbpSh+Q7dt+WRoTBpPELhlaEncS497XM5gtsNyf05ChzjsjOWGhXoTo12X/QosCPvr1A4qwyPV22cipwLqLsWsNDE5VCeb21/3lOOxa7ie7cYFaC7DJffNlVgPvqIroV61vpdu0yohJ/txfuEEil65v4PqSMKVt7Z41Tiq11ar8uvxP6HCf2T1Box735KQImSgsMO3jYSdxcCowbqvTFJzew9JAqHz64VsEgkdAbKsjgkmrwf87MOkRj67PhBC7W5ZTruJEhc4jbSB4Qk6g/8njZyhUR4JGQ+B4nV3rNMX4DE7icdl6reqkT+AU35v85K2H20k71DldCPM5Org5UQaXVz9+gqHJlom0yNV6F5B+vEkkOFkmp7n9Sjwgz74j+nhlQoerbpzX+pwk/1j/6o/lUNQdZlwVNqTuRSqK1bjY8iehS8GTXeZCYywoVVcPRe97KUVWAPvY4e91bhudPz3wqqEfrh0J8ER4PbXPvapkCDvZaM9dEpDc69sPUnTWvATYhljW1pEJzLjuJ9qsW7/C9vn/JrEbpvPPE1NZ/lTrQ+0OLo/DDxy5YWjPfUfZYrNZha5nzx2l2DmFb2MVOYDq64zAsfGHUYPT74o4HaUFg3JnfrsPgwRzhAff5v3frNFh0GmBt1qig9+gR57knq0/kr3Fi7HletC8Gmb/QQp35Li3IZ0NEw+HPDci3C/fOP2qaMWGaZMyRxJgQHIxbMuSb8D9gsgL0=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="580">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBqAFX/srWNkHFt5pBAso9QgPr/0CerX5Cy10BQfv4Q0Gr+8NA+w5EQaUUxEB1OWZB8sWQQyCLaEEl+xVCtpHKQBZWCEDedztBdXo7QRmIzECsoVRBLsINQNqmZkJHyTJBuNdGQVuSKEJfR7dBtL/wQdj6FEDWnDxBpE4XQSP44kD5e8BBSvtGQqw1oEAJUEhBWKohQVqcGkJ8ThhCDhgpQUcAv0GdUwBBmxsrQUorLkFufy5BgOACQoGeg0IxJLBA7x4PQpPtKkIx/8dB6ccxQbUZMkBcmIhCnmScQS8YhkH7cpxBTnHJQbpuM0HZzRJCPiwNQmukNUHZRDdBC8y5QORDDEEzwYxA8/VqQeltjUGftj5B3gY/QK/oUUIQikBADnZ1QRdgREF7ckRBnQJFQHJLFUGfm0dA6GgWQaxey0ComU9ByibQQKr7nUGIplJAYv8DQgjZ1EG/4wVCqp7jQRYQhkFejFdBKrq+QdpkiEEL6SRBiHImQWdzJkEATqpCLHLeQLaK+kEVNShBUTYoQbByjUFInWJB0weQQZFpk0FCympC3YydQVuMfUBpdrEI</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="18" id="sample=1 period=1 cycle=1 experiment=19" defaultArrayLength="91">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="227.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.079547431863" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10384.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.035316666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="19"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="837.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="837.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="48.328063964844" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="972">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx30wkwEAB2Ap+nK3NNKdaJlcJhR1KdHPbSmt7cJ1lNp49xFh7/a2jSIR6zSlM8RRdOe4PskVKWVSU6dJrY+ruy5RK6kuE9I59P713BNSZ/A/phMiS9EQy96WAI/y+tI1OhF6g0PLt5hEcMiqmudkT2AJ53HeVm8CDm8zfrJFBPj5jXGnJQS6LKUr9kkJNPF935lrCbjNtDgKPxG42uZfdM1Ogola7VcflgQhs+IXZ2gbC3XJM3ZSRPMEayVzpKiq/txm9pJhKmTnDIMtg19tj6G3VoabF/qx+xL9znPf5wzKwDeTkd2fZRiRulzI/iKDXaDh6dhcOTaOB0av65djR7i17zzt/pDpkfaaQ1jMKB6JrkuG1RJfWV2QgkxyWP6Yl4oftrpYJisN3K2Dw+6JaThjREYNLx3/Bke9myMUkJ8uan4vVUCT/93plEyBBSamXK9TQDwwZA03KRDBGNr+h7YyzGZ4/kWB+GV3/H7NI7GoxZ6TsZrE5NEYgSaXhCDMjWXsJBGgke55MECCFyVIKGUpkdZ1rawgRglpYYtbOqEE87mzQ5RBiScGjyHPTiUCSqbDtSwVLGWOPHawCiSqvQ5wVZgcvuEiiVVhIGBTWkmJCh7bL6Z306aYX6aTSynctnJ9p2mFfp7svUwKy4Unxlu9KNQ9HRvrCaIwrt8lOphEYbPlYLFrLoWLouSaWdrf/PbbnBcUJt5O3bW3UYiJbYqo+EOBa0t66OZ1BGcjr9Tfom2TiDmuL4+gqzJupYmlhn9H/448oxp64+uKHlpzfG/7tkdqhPp6JLAG1fh72LWYS6uP/rZZR3t/0uTKH1WjdWJJ0hSpQUe2560NRg1yPjK+pvRpcFm88p7nJw0+OPcxfdZrcf2+TRUcrIW+3Xn8TbMWQ62sJPdX9BfKLfMLMhC0kDHzOjETcZWrnp1szkSVC+HSEJQFdmpOYLf4OP4DAxhH2Q==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="500">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBbAGT/nNpqEDM5kRBN7xAQyBppEEDODNC/NaBQI2lgkAQvrNBn7uCQEKOg0ADGydD0X4VQRD6rkFR+8dAWFeIQJCmf0ElONJAfiaMQKrDLEI+w41A2ZkOQIYbREL38tVASwiPQLiuWkG8Wr9BJScUQcPhdUFu/OZAc1YBQg0VSkG1+kpBNIi5QQeuJ0HvTRhCZxM9QaBpqEAGGSlB9RqpQHwn/kAgAT9C6TD/QIPeVUGmxitAzR+sQJsgLUDeKy5B9CBaQfRtxUG1jFxBy4+9QbTKskGsupxBcZUGQRuGB0HohgdB2US3QCxHt0FmSTdAUpc3QSHroEFe0zhAkm05QV8VC0KxXFJBKqC7QPGsO0GlkjxApZU8QZ/l40HEaUFBo15EQP5HE0FacMRAIQLFQC3CE0ERBMVAaE7FQPGax0Dex5ZAUFXJQF6iSUF2FktB41cYQf9fTUBT9s1A+MocQXGkH0FZOtZAr4SMQbWmaUEmRpom</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="19" id="sample=1 period=1 cycle=1 experiment=20" defaultArrayLength="92">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="145.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.013286398331" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="9812.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.037" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="20"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="862.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="862.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="49.890785217285" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="980">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyWlMkgEABuBEbB2zmm22ZYWhZUYt1BIpBy+oOWsLxdkoSgjEaqJ+H4cSlonlmm1m2uVwAmrNNlPTMlq0NJ1nY9FazlIZ2TUXlqNj88q+X8+PZ+DlHMCXouG2JmUZpOCmfdkWU5aJirLKTcIwOZYnOHu9QjkOrnINWH6dwoedvEE6TYGAkUJvWKYCupZkYlCpgMnS/MpuVaBz+vzOdI8CQZUS9RRl7Z7yMxnLlIiTMAdloUqsWfeUE+KXhezwgHd/mCqYuPP9vVYVmvxbVzo/qTDOM8jiP6vQ+DhihmXKhlPqelvKOI2ypF5Lp+U04voZR2Ivn4W4RHb8wN2zuDrijX2TmIOFvuFMVlIOdGana1+oGs6puoSoRDWskV0P6um5eJe1V1admIvgIvHXiKRcDO34WWfLyoXLtK+ZTs9DxnPDuqWsPEiC7axpej4SfMq+T935mP+qXFEDAldVdm65mMB9f9tEsoIAY0ThX07pio8KW6giMFfRIuZVEzj84slSRwOBAbVhzZd2AmPFE0EnugmoRd3VOS4CfrU1Yxs9BG6lB36U+ZHQ3/xbFhtK4q96O9dASSvZsnL1VhK+DPeQkk3iWB+jyR5NQn7lwnBsDInNlm+2bEq2Tag6KiQROdpZd4MyRDxaqqsiIS4anhO4SDR5+fJGpgZebeWsM1qDnha4/8g1CJCaXdENGuwf73CzmFrQJ088Ykdp8dvuXiyRazHY6jiZ8kaLe6X/cM1HPXfCrE/TQaR6IRzo0uEeO090rVcHUhS3YPfowP9VN41JHTp+LtiNlL5H/kqaQI9RQaBg+JQebRdnHWSXHvyZBI6gsQCpPRWezI4C7G/ruXTnZQHcftINdE8hxt//YDSnGzAk2ZVkUxrweq1W8Oy6AT7nUlRquwH5778XP6TsLjLWjlnP4ZCI4zDFGOEN54gWKXnp5lS+1YjF9ZMT5voibN7t4NJmLuA/p6hR+Q==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="508">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBcAGP/lUp/UBtG29BnKCBQsqwN0FBZLhBjSgBQakBj0KNpYJA6rgCQnVxJEFOSUpDjXMEQR8wDUJXUYVALughQhY5UkEbolRAhe/VQWJJMkHRnBBAojs3QW8nlEHb27ZBTovnQBUVM0FiSgtBqOC1QcOWSkHbQ01BWE2QQbFi90AIRaVAygInQCfRN0KuOVRBCccrQCs/WUH1ttlB698CQWdRxEE2fS9AJZ+DQUTgA0HJKkZBHXIwQJ7GMEG/0gRBbVUFQZz0EEI/z4VAeGwyQVS8MkBtyDJBEBgGQctFkUGLGTNBy7ecQYtnqUEbcWNB75Y3QUblzkFW0ThBOhg6QAiTPEC9pQ1BTzCaQRTqP0I6i0BAqlLCQcdHk0FaVRNBXFysQRvCE0H4A0VAyr/GQNRYR0Cv6a9BfNYZQf4zDUI9p01A9KVSQD6i1EF051RA9atVQCk51kHk5IVBrDpaQW/riUHtrdxAqG9eQRad4kCg4etAO7SV3g==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="20" id="sample=1 period=1 cycle=1 experiment=21" defaultArrayLength="91">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="254.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="9787.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.038683333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="21"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="887.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="887.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="51.453495025635" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="976">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx3sw0wEAB3CPqSQV7pJexrpEL/M6dZWv2orKo1V3jfLaIwzbb4/GUqmb5BGSdnGXYVQcnRGVuJ/1dh2Zjsjciqiux1X0uh76/fW5DxFfFLQ4KBqOmshPpymH1JpYSzIatvO9h+KyY2Dh8dIr5EwMfNMDz4vJOHR+MIepKuIxMG9ZmZVVAswZJ9iBvASk2SkPVlEuSizU3dUmYKpH1hD5MgHG7uzsMAseSss3hgfQeXBeMcOuBQ+Z/gua8i35yNeVsdQMAXw3a7jtWgFaGIt6nCoFIG9OCq6RAjAV9I48swA6aTD76Th17e+JUWsh0kwv7hSahVhp52+srTgCT2bNTOjhJCgaPMy71EnYQKvcGV6dDPlMzlgnSwQTI/6iNVsEj1pXrbxChCJaLrfXNQXX2jqvR9BTIOKtK5ezUnEln7tQyU5F6dbvrQ38NExyHKRLbMTIbZ/z6X2WGFlke1fXPTFYoWHRF+gSpF+td+BzJHAPsA21LZEgejTWiUNZrbr68y8pQYg+8VFclwSTztX2RWMSDAo7KviWBHx38FctpxOY4H3MEFOufmJaXUeZM+43+tmHgPtT3TG+LwGu4XiRcBuBP6znP2+eJ+CimvX1NknA0KisK3aUYohckainbJnY7vmXstduo/dchhRrfuz/1R8sxVfNQ/t3J6Vgv+2RqY1StI2fXbtlSoov1XuCzlEeMdS/67KS4Ube3pweRxlmT48wtsbJUM+Oak2lrDMQy0pLZHi9vl8dbJRhMJnTJ3wlg9NjmipwnxzzvWY7J/fJMcuGWeD6TA71GzeLKI4C/yT28b9PKZD5IJK3vVIBL+M/pxGdAt7GvumlpAK3Mk/61Pcr8M3EHTY1H0Xjpaz7w25KRGQX2KiYSoy1Ne1+VKJE/qaGmrd6JVxEVbE8fToO+Af8cC/OgMvk3pw0Stry5u4BbQbum8Yjgv1U8D+kuZy1TYX/VKpGnA==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="500">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBbAGT/pEH4UAXxyhBhhXjQHGc9UFZ3RRBToF5QD7vv0CkZsRCj7eCQIVs1EHFxlVBlvN2QxG2NkGk9/lBoMGFQEdZCEGhO9JA4ulCQXjCjUChPtVA0JEOQXbZXkIBjNZAjss6QvMmlEAgSuZA+vpmQIRSHUEN7tBBg/zGQFE0IEHEqaFABRZKQclfd0BV7SRBKxZ8QTOs/kBAU4BByM4rQNLYgUExKy5AnQkfQjdP8UEtcDBANnIwQd4lMUFsVelBoWeyQFNiC0KIarJAl8kyQY1FkUGcfclBYCwNQpSftUBuRbdAp3QJQahHN0D3mDdAhjS4QLNsOUDHU69BM6u7QEyYakH4+QxBPUe8QPZSDkGwU45AIfcaQkDqP0FeOEBAklvCQD3adUF0jJNB0BBHQAHzFUEImnpB4ItIQC3pr0E9CxdB516AQTOXgUFmnk9AJVDRQf/Z0UGdq6BBsPdZQbV6I0HuqyNBP4MlQQLrXEArjZzf</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="21" id="sample=1 period=1 cycle=1 experiment=22" defaultArrayLength="85">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="180.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.081097987028" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10837.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.040366666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="22"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="912.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="912.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="53.016193389893" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="912">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXss1AEAB/Ck/unhXbqtdC7JLNSpW7PiW462JDdvh8Nx53nc73ceHdpMmDwqjykUyaKamVusSOe8b7HZuTkh71gqzzR0mn6ffz6Fej+EYU6BmGEVcDIQCM3YpTjLbB7kVa6+N3t5mOjj0tuoy9Ibgr/yQhHt6se8HRKKVv+8htaqMFx1as7Y1uHD2NBg+kE4H/Nyrbq3mo/iZUt9zgwf64tL/lH7wnHRwa39Fj0c48PJSWd0ItD20agpn3ohtCjHJEwApnxH2FQtQIAq4c/MpABfWmL6P88L4Jer6nyvK4TphAPPc1qIfwec55iMSHjrc1eVVZHocPEt06+NQiWnYFWvOwrXK8anTgRHQ6ENULlkRcNj0HpskB0LnkGtlzE9DrWmOWortgiyoB63t9Tl6/6xSxHxUH4YWXbvjccmrfK4+0I8qsOr7I0PJmDoxq80m5oE1FllppbLE2BkvCKr0xGDO+piojktRkwoS33PU4xP7fXcHL4YtBYz27MKMeSLeo7l1BtdDcPkqhj3GVulNDoB123HABH103bd7l3qXWH+UjeTQKOtKDvQnoDklIdNnzMB7RXBk3dFBLyXbN0nOwlcS898bddFoET9/Vw7tabwGSeFQUJTdqz0BXWP196MRRiJwGYuW0mQsJxtKTlcTMJ2oMDwZAkJvTyNpcVvEkxarsVfcwlS5LHWTJUENQrGIesVCeqHciqi1yUYKLG68GpDAp/y58tWXonwVr0xU3QkgvbozoD9XCJmm5Tqo/OJoA+t/dR2JUHpVay7NpyEIJX2iEKWjPRvAaKs2hSIppk7LFkK8h/adafJ7oIwZ59PpUsRskc0jJBStGWRjZsZUvhcZm0xHkuxwK4ffUld6N2/MlUtxYaFXSVnfzpYbvORcv49/AcDoD33</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="468">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBVAGr/tq9oUGFDWFA6K30Qgpbs0AuJm9A1a32Px+x9kBD8D9BcE+cQt8Pk0EpjoNAo8w2Q3mgz0Ga+OBByXi7QWBZCEBS84xAGlMJQmSMDkEFipdChQePQdpYP0Lw7dtAJzveQPpOF0EusRdB0RnTQVFckEEdPJVBz39yQY/pJECYJgtCRpZxQiD2E0EDcSlASY+UQS1xK0H+0IBBu1sBQaMcLUFyg41BE1HEQUp/RkFfc7BAb2mxQCyOvUHuzoVBLmwyQF8hyUGI06RC/yAzQLCGB0GFqjVAKqw1Qd1CiEGMsAlBCJc3QMUg/kFi3ApBn1ULQYo/6EFllWpBxf+kQV7pS0IHdkBBtYXAQNi2/EEZ8nJBzF9EQFdDdkGXSHZB6RtJQJNlSUG1BxpBZppRQBjX0UDocrtBmRlYQJ96WUEySSNBE/jZQdH52UDEgvVBUShkQISy6UBx5ZD9</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="22" id="sample=1 period=1 cycle=1 experiment=23" defaultArrayLength="92">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="394.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10629.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.04205" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="23"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="937.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="937.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="54.578880310059" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="984">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxW0wkwEAB3BjCflQznkrktJdrrsoUVL+1uT9Ytx1wuixYdjas2dbZlJJcY68dCRqY8pFudqpiw9STdh1RCnKu1ZdH2SN0C6u/b78eFkL7feZZ+FabFnrH5QIFrF/w+MaG3O/lqMZ19mQc43TwW/Y0Ds8cdazU+GrDn9kaU5gUqZso9IILG653zxq2m95/mXNVQLaLIeFRSWB8csNu+JmCehntvIPm6VBFKMwpJgWPnxoY0NLw6Fi62OB7mm4e+xD1w4aB7Y/Dd703VyMiTOuvFNy0bms0/R/5aJClJRJ6LgwO1A9sGyRDtXYT510Jh0OLFXloiIDCbc/FNk3ZyLSkJ0UlsyDXB1JehXxUKytuuOm5GEzd727gJmNeyx7wZrpfG3pJ/3OHPzjqZwi6Hz4HGkzXmXyMeLmuekkXYBBjmCdflKAjc4x2z1cAYKjnF+u9AowtMZ4vjgjAKfLfNLKXQjVSntOCkuIjgEdmU4IEbNtrc6tWgjSZ7Xv5rwQisanCg6NRCPr8WqoO4nOknghdxcJVLp6vzpIotW1fm/YIRJL8Xbdt0zfsLZ16WKQ0Ov8gt5WkVjQBDBPvSYxOpdVFeghQlQZ44zfsAitmmTViREREvgdvqlLIkTzrL57e1BIkbjYnTYdLfG3eiGi8CjEuDJVSOFf4PbPa8MU2Loyz7gRChZNE/T4OQpUaaTU8TcFJ1qLvdFAYTZnwta/UIyu2Ya/tT1i0Dg1LU7zYij+1pe7LokxFP5YSneXwOKATcXKawn+RMW+Mr6XgOk5WuI5LEX5To5usPoCYn6zvfhULhiBmi8hjblItowsl6pz8e1BYv64aXpsYkdJkAwLP859bIqT4cRYSOiZShmeTWvV+zQyjLYG9OoYeSiVMd3qLuch46heTFPmwUHYJ2s3XTZ3PHkHTY7G/sEIQiWHaKpjPbpZjjhZkbrn/EVwKlpazIMKUOA4vLq96BL+A8zVUVA=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="508">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBcAGP/gf03D/q3r1BOYOQQjVpUEE/JO9Aaq52QK+HcELKFMRAybkCQLC/xEBjVUVBwNeNQxN9FUG14QRB9eMEQUj5x0A86KFBtkL1QPjpwkF70q1CY/LVQEsIj0AWrghCBK0mQtT2YkGD6D9BlTstQXtNGkGSLp9ADleBQSeqoUCmQk1BbCXOQefju0G1sadAvZJHQkAYqUBzE/5AIWVYQRgrrkCqgC5B7kzxQfclMUBu425CgGgyQLvSBUGfyDJBeZ6nQfrMMkDqh4NC+bO0QANiTEHnlDdAcv06QFpi0kG5lupB0rZrQbaTvEC44dVB3dEOQWHuj0Eo8YZCMj9YQVKlcEFCjUBBwTvDQHxHk0Foot1BR1LFQE0lxkDRG8lAxWXJQPfoTUEw/BxBSOEfQYXvVUCP+RlC2awgQT13IkE2mYdBWTuIQZscJEGn7FxBvrWKQRbTJkGXcV5BLQfgQDb4KUEPpOJANeZpQQzSMUEoBXJAUJKkxQ==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="23" id="sample=1 period=1 cycle=1 experiment=24" defaultArrayLength="92">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="205.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10908.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.043733333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="24"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="962.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="962.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="56.14155960083" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="980">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwVyntQywEAB/BedEV6obho1cVWIbeQOtf3cO7qVJpx1+WyfrNJj+3X9lurftQkj7yqTePkahY7LmT0unMUXeZxMeV6rtti4TxKx51xFT9/ff75qLM1CYEJGbj+sfXdt4pMmGV3yaLjmYi3Ssp+Zwrw2cTZ8NImwA22eWi4PgvTuhUXZp0JxGiesQ64EDAF/Pz0NoTA2IlkKSuUQD5vd2GFkMDAHb6lv4GA6vO2Ub6OgIs2amCXjUCatnvlH0Z9pzCVcBJiFudOxbKEMMT5LtQ3iFA3QQ8v04mguOhIedUpQll4TOngexF6A1erbriK8brNZ12JVYxA/+yzwX/FaOnh5/XUH8T7WvrR4YaDcPWP9dzUmI37ZT43ORWHwE4OcKrV52B9pL1Pvz0XLd8SOyzBeSA+Lpo8wsqDikNJBE/ycE1T38vfno8qRyn18IAEH1y0+tUiRp6vbPk8KbqlkWvnVFLwbcd4VXNSNIYZFjWzSHg5c3ZTPBI7DX77bTUk1IsjJjhqEi+2NqWYjCTyZ3RZ7l0kgmzzJTsYj26mnXr/25UfluFcAEtik5j2LUD4mWMmNqsAunHar4ixcjrJKK0pAE896Ghn9EjwiSn2k8HtKU9sYqTCuidOh8oQJ+sv/yWQIUo/tDxQI8Nz0cN04gfz+HbLLRc5WEHc9JMCOVpORUpmzHIgvE0R/UaOq888hiWMgzk8s3hcji7LlzOx03KsMpckOeopnNy69GlLJ4Xr0ZLU890UrnwvztFYKcTPaFXcdxRuz+cKe6GAhrNlXw1PgahQI3ckS4HLS1oHXW0KeNKOr/bqQuypg3SUpYTdy6fPoFZiozz4wZhRiRxriN3TpkSQxDO6I60IhVi3hjYWYa+G2x5RXQznWdJ0nJHUHRK6N5Rgyi2XLWN0Gnl8L725BCGV/oY6VxrePR7p3mE0FmjPfU2xHsYlj8nflVYVPkwlURu9y/EPj21KRw==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="508">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBcAGP/rcH4UDX2ZRBN7vmQWqu9kD62rtAR/G/QN2MckLVDEJAs7XCQIjPAUCFzgZCiFVFQSVYRUAtqkZDAx82QbCKaEETpL9B2+QEQtmjVEA9Ko5Abq1wQgnJMkHZIC1CTi8SQFYnlECpKRRBfiAJQtY7rUGtU51BPhsuQvB+ckGtFkpBZnojQTVf90DJzA1CRxAoQDOs/kDdGatAiG0sQOTYAUHnoIJBSWxFQcVV5kHxGwRBX3AwQLRxMEFwdDBAiVWFQdOhXkHwzQVB3APfQSKyNECWszRBbBZlQaLSq0HWsAlBzR/+QXhZi0HIqztBrvkMQbt3gkGZ7o9AXu0hQoHm70FGKhBB1I1MQm/Ew0DHR5NBWlUTQeO4k0H2wRNB077GQK8RR0EfWcdA4qFJQLvKTED2U89Ak0/RQH6et0EmUbhB7nIfQagPLkJm2pVBAHsjQeFuXkH4osJBB7PeQPYKjEHUk2BAlKVnQJIh20Gqi4FB7LSg2Q==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="24" id="sample=1 period=1 cycle=1 experiment=25" defaultArrayLength="98">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="211.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.006388337832" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11649.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.045416666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="25"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="987.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="987.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="57.70422744751" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1036">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyHtQywEAB/BKkzyaSZ1HmIoTTp1ZR+fxbQ86kedFsWm/tthpj98eTYmhOo/zB8WdUq27YV2Jm3aysFGmRpci5Dq2Na9UXPMoef7++tx9vKYeunbNLtQbh21SvhCX15/sZBcJYe+jVVY5hFhwv7oy2CCCO37wntufgOxOMXdpAIH5xnq3lJLeuqlmQiSBR7Ms3yKEBNreVNCzMwmUfYmx2ilfvml93moggEOl7rMuAteeZLdy3QQYSZOJAr9MsOYrdMuZmcjhDREJ/mLw+8SRq+aK0Z9Sd+mYQYJ+VWNEPyX917m5BS4Joj2lzde9EgzfZYRqXFnwJD5M4s3ZixOMtM8DlXuhcIqsNOM+8FMC2mIFUrCsz01LC6X4K6srIT1SuKpqKvN5+6GNLi/9Trmh0fJVw9+PgSHjtlBmNqyF07oLMrLx49aWrWtoMpzR33BV8GQIGd7eEMiXwUYbMZ2gPH+OZhMEypE8U3Dhh1iOJYwxLPYxOXplM00Ti+TYXT0qTLwsR6p9oYftkGPHM8WO0UAFbH7amtU0BdgyXkrQUQWc71hmC6W86JH3CFMJlym2xXdWieHRi6/ozUoc7HckP/YpsTEqwBfrT2JAHaZPocy5/+LPFcrf81L3cRgkTgc3DvKZJEKmfIhbF0fCzpKEqygTRE7/dSwSvrBVk9QcEmW6rq5lXBKez/puRxOJPzlJ4iCRCidnc+qmH1GB45GmXe1U4XZJWVtIqBr13ZZt0ZFqHE5KXxQSpYZqYM6gPkONQ4JraUZK8zd+ALtTjY91hR25lPaj1oQGyp4V7dz4ITXW7hQvrrVrcLNJ3lJ7T4Ox9uAHPI8GfadmxCt7Nbgz4ghL9mlQnj7ug8ycg8QnTe8rCnQo4vbY9cU6qMY2MP1KdJAu7hj/yUx9180E5z8dVtqedh4vPoCvhKVlj/kAXre72h9Q5js3t2SdyYX2vdgyYsjFpuX6Yq83F1enlpWEc/IQwzZIBIY88DPe9qY25SGjueqgNCofjyO0P2eIDuM//6xrXA==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="540">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBiAF3/rEYb0EmMW1A2D5kQ2glb0At9Y9BlnEJQqwLQkD6DMJAcbfCQS/4w0CJZiNBAhETQRCOA0EapsZAQjF5Q+QaJkErUB5CG6V/Qh3FCEHNoNRA0+WEQbeRDkAul/lBGbBaQVWVEkC7O95A7k4XQM2GGUIovQZCsRSbQE4uH0HRL59By8puQfmPl0H+lPNAC1T2QMfqpEEcYvdAh+0kQcIDJ0Ah36VCpJD8QEVoqEEIwShAY6X9QOZxaUHHrH5B9hkrQN/iVUE4IC1AxJ0DQU+gXEH1ejFAoFQFQZs4XkGvyLFAMBoyQZloskFDu7JB0LyyQIgQlEIgGjNBMR4zQSqvNUCet6FBUhKLQYdDDEEDSLxBPDcZQmOXvEBrNW1BalQOQZLl40F88A9BW/EPQY5jkEFDd3VBJ2REQSn+REDCwpNBaE7FQChezUDJDFFBLPscQc9760Ex2tFA7DFTQMyz1UB/+RlCj6wgQZ+5vkFerCNBnltbQETpXEAhidBBNQLfQPeu5ECMnW1BfqyjOQ==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="25" id="sample=1 period=1 cycle=1 experiment=26" defaultArrayLength="103">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="193.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11364.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.0471" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="26"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1012.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1012.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="59.266887664795" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1104">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXtQ0wUAB/DY5GRdyAFd88pbQGxhnCPQvBOlvsjTcuO2HeqSkXsgj8H8PTYHmwc7ctMGik1enhdDIAiUA4Ie7FQGhtWd1gHB5FSaw8iE6zFwhOjV7/PPp5Fv6hS8dxjsoRxalp6P9YOEPtaaD+t33nvnx/Mxk3LTF8pSIVfj2b5PrcJp3vx0O/Mbj758+MCpQmdONSnzqiBf8wSnvqBG4FJ8alyUGhsrPwtYmF1DrAtmpRrWvAR5UpAG3MDQwmHmpclsX6uzALGntt2dnS+AjDuhcz0sQJG+a/jKr0eR7Y6vvdtSiKEym/sDZyE8wj+bX2kvwiOBe72RuePppcoQRTEGN2eGh50sRoi90b2prQT1t/t5VXMleNF0YrA1XYvL5oHn0gwtlmyvjnCiSpGcsrXu3SOl4OwS/GDwlcKV3Ly4nl6Gm9WBsXW2DqcrSyP/0ejAOtC+eqJAh3luD09erYP3xz0/hY/roIzjitnBx2A98PWY7/oxhAnLzsxEE2j61jGKGAILrRtnX36bwNPFcbtFSmDO02LXqgjsVi7c2OogsEjH9rLcBKqTM56ImLudG9g0s7YvVPLvGIHILkWtKIhE4A9tQxOzpMP45FAUiWUJe8QWTSJ4btuYnU8iRRudu287ifuKZ+b6vSSMHQ1pJVISHlfn414liQe9oZ2zFhI3NCKOMJLCUoS8vz6Ggv+sJvp6EoXu//Zf2ZDKrApr4Cgp7LZ/Y33soMAfviPMWqZQN7W/6V4EjTdzFB5BDI2re2Jesh+hIQr/Ks1G0WhbPTqZ5aAxHPzFpMpN4+Iv70yJJ2isme/X6/00LtxRbxHK9Nj0+m+84U/1qK2q/JgzpUfHz0HdAp8e1udiw7Jfj+J+ruRviQGrlz/f9ZbUAN4hsXNEaUDCTpE/s86APK+S66KOw782rrg1cRz9XC/9e5IR2U0CSuAw4ty0uGKKOeCK588MGJFoiVjJSSrHVVXeX6cGyjGtbYmtGS1HTfiO7+POVSBQkeB8rbUCiVmjHyammYAVRV+P1IQuW+FKu8WEZzvaMljnTfgooy4u12lCfI+saJD52sHZ9+V7zeBeLOv75GQV/geVonbt</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="564">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBnAFj/tn3UkH+Wl5B3bbHQulbs0CDTFpC2bcCQIkQk0GMjgNAanqFQ7NRR0ELewlChaYmQVZNyUABeTtBxVgIQVrpQkEpp6VC2aIOQdOw2kCIJxRBeT3eQNT24kCsUBdA+oUZQJU7LUF3+utAoQXtQPUun0B8ye5A63/yQY5iIkB91SNA7oi5QbECp0BhkkdC0xXSQTmR/EDPpP1AdMepQTbRAEFiJy1AnCmtQMJzrUDeK65BWuCCQUj6NEJGcLBARVWEQQVWhEHcfzBAhf/HQfFykEEDA99A/G6yQOWDMkGTy7JBGlQGQauRBkHYqmBBkUUHQSRIt0GlljdAQe6JQHUwOEFOfidC2ss5QZqWakFpWWtB75I8QcrosUELlg5BXbg+QfKL10Ef8A9CvorAQGBbQkGp9dtBPYwTQVMCRUGBUcVADEuVQQkQx0AnWMdBUyEWQUAxGUFRdBpBl7sbQVlNUUBZUNFAYtrRQckPVEDQJEJC2X/WQNZ5I0FBO9pBb7IlQTjjJUHWcyZB5+WKQSGuO0KwcV5AJhVhQM0GckGXoLAk</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="26" id="sample=1 period=1 cycle=1 experiment=27" defaultArrayLength="102">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="199.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11481.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.048783333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="27"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1037.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1037.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="60.829540252686" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1092">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyGtMUwcABlBxKmyiMowBO1xrcTKCCtFY61bHB7SBCpJRBAsGSh8qaJX7KL3UMiciEY2bAsZYHS22YyygDKywNDqpLRvMBCx1pkGraPGRFZ0wXBYRH/fXSU6KSiEV12ajrygjJSN5OxQdiWZRbTEKXx+dnDNbhZX/lSw+xpprf3afVKuQt6Dmh7usZqnQNGRRwQNJYf4DFRrNSr98lhrN3wZtCTw1/L+M5UeFaLCwdF14J+vqiIxht2UHhhRFRwbGdmDjNP+3raM7IZA7ePfMu0D8qXTMtZXicVacQVBUhhfHKXfO4TL8VFPnK7fuxsWOGJFTvAdkwrm75ZI9ONryNPQhV4t3W3qMep4WzLsZDp2mBWfc3/dQocXbVUQHx6WF/naTNFWyF23d9btfavYh0HNjg2luOdTZwtxPeAQeme38fBmBzPirmSUqAi/ikl+dZj1VsILnqydQ/Ok2p6iBADN2zyW1EojMljfEOwmQXPqfaReBE0++O7PRS6C9/iqxJoSExKUR5LHqI42aaB6Jv8Lm8QtZhb2rhF+vI5FmaW6RgcTzrREeayoJflHDghElidZRR7+AInE5tn9h7yUS3pi8YMBFgrmVHDStpdCVsml4qZLClwPF/tBqCmlJh8uv1bM/UWGZ10BhV8tny6IaKUx4swK3uyjoLoYNyCYprIz1rUmfojDOjRKfZ7UtL/1AwqfRs8gtX7yWxiZ3+P/joPFReLxNTtHwHRC+eeuhcemlZPb6YRrb+qX6qEkaLVlUZsHHOsRc8BTHJelQ5/jb+8UBHd6cvam41qtDd8Iho/+mDrzVP7avD+gwciJxShNZgUFxJOdzWQU2z7iyrnRWIPxOgeobmx7jf7i4Hpce02pBhH05gzqxY8t1MJhxDk3Juhi0uisRHGXwVJnedOEBg5rrInVSSSVCdNY2aVclOi0aXzVrbIq/ysP61XZuqDVQicvGwPc5YgPsP0t+nX/SgKX/KgeXNBuQeDaH4dgNaC1JnlB4DXB2LzlyJXU/Ds33/C6y7EctT504EmHE+VuaD4OpVVhUNmnKbayC3jQnvenMQfS1oZOOrsZ7rxVuUQ==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="560">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBmAFn/t5oqD/d+FJBAi8rQs7nVEIuXoFAWhTEQHUWREHfcaRBWyhuQ5bhhEG5TGlBu1eIQMNZCEDEVahBP0+VQgmSKEKhJxRAZfbiQNZJZkAB+2ZB51IdQS/h2kFIMZ9AiS/UQY2B8kAfGPNAya02QaNYzEHA7CRBghE9Qrdz6UEXHi1A5youQTogWkEn4QJBVJ0DQc9UkUJ20y9Bao1cQuVfBEEb0LBAK8axQGuqpkGmzQVBvc6FQYbLskAXD7NAGBuzQL+8M0Ggk0pB+1w1Qc9DCEGq5zdBiiD+QbwVC0HZxTlBZse5QItZC0GvzAtBtqE7QWSrO0EirbtACLhrQVjhvEBUKr1AYVmmQb7uD0GL7w9BKYTAQJ4fwUC4RhFByChDQY7rXEHuQN1BvsGTQf1rFEEd8l9BgcdIQAsfzUDCrM1AOVjPQb3iT0C8JoNBYPwdQtuoUkBz2FRB2eMFQVcPrkHLEK5BAw9XQKGGIkF5eaNBpDvaQJCM2kBfEdtAfBOKQf49ekJsSOBARj2PQfxzZkF5X/hA+RR8QBiirvk=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="27" id="sample=1 period=1 cycle=1 experiment=28" defaultArrayLength="107">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="238.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.079547431863" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="12327.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.050466666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="28"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1062.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1062.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="62.392189025879" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1148">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxX1QkwUAB+CNVuqZ2EZ0BG0OhAAvd9AsQHfwQ+CoOVFH3Sngpi9sfszt3fvug01GLUJIjORDTjhdI0ldGHSEkQYsYDc9w1E4b4KVgFByjUOY5J10J+355+m2NWVEZBSix+/cuRuFWJ7RSoZyZGD8fONb7gkZbq0uSLG5ZbhGLl2PlR/AKj5DHGASKPm4NTlVRsCa6pddKiaQE+EY/tFOQHQsPiSslUCLLcT34SSBd2bz+uaCpz7bHmFkFKO3yhi+sqEYKZPWz0f5xehwOQZZzBII0r1Xfo9R4HL3i/tP2hXgF3nSfMETRBapc1qBv/Iun1p4QYmvRPzEjo1KeHoCNUdcSlwa63UqJ5TYQRS9ZCAOoe6HUwt72g6jyjCToak8gqeW1+6WXTiK7H3bdl/JVqFa8w97fY4KPCEnPIR/DOnRLWdSWWrUi4Xoz1aDcMkLVAo1Yp/3n5W41Mi5GviMzdJAXh66la3QIKpdcSH8hAbUe+Sbe90aTD/x5a6wSCS2cKURPBKaqpGOcSuJzKxam+ATEudvu4+uHiRRlaRd5DVooaxz1BQFD0uKC/i7tOj+1VvDdWnxRWQZIV/QwvKBYCzAoFBWQ24RMCkken0KY/C0m0m3aD6F3IqVQ9JoCu4BKZ0rpPAgTq9qDs4O/feeZDuFqT/UGmRRqJY995vyKATab/ruWinYqbV9U/UUauclyxUcGqzOkrD24L+4R+73xtBgDK1pWnOQRv5M/PK1Bhq7fhpK4DTSeJcTErl+gMY39x1bDjyh0bZxqf4eRwevKKr++ts6bHjdMb4IHb7bN+uRjOqw41HM412LOsRL5A+GAzrsFM93vc/U4/Bc5eM7mXr0XP3b+1SqxyZOVBY5EJxx+vbFCT3CE5Lj33ioB1Xtt6l+M8Db0O79+o4Bn+4RB84IjSj3s8+/RRphMqQP17YZsbfp4JfRjaVInPionztYCnp028nRiVK8sq4/SzRZiu/HMpyF+SaoOiOZW3Um/HnR9kzZZYK1oc7uHDShIHTdoym+GUVa4SrUmSH1jO+ftpvRuGJ/dXOrGZvG05bnPGbwNjdPk9RxVJ72J0vsxyFYG9t5Lngul9c78tCCuL4bsy/nlyOTMW8RN1vxnyB6aT6lAv8DS+d+8A==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="588">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBrAFT/ibGKEG/DGFA4eWxQHIwIkPjMmBB2y0aQdGBbkKf+MNA05KrQfeNA0A6j4NAssw2QxO7jEEut7ZBkPqVQT+nJkGlg0xBbzjSQInAjUB85QRCzV2cQoSMVkHJJtdAgClaQEI9tkG1aRNAak+XQas8rUHnUp1AufrGQLMwn0EHFUpBr0/2QLhNkEHj6vdAiXX5QHEikkHOksdCXWgoQDcZKUEqOlRBeQwqQEgZq0D5UwBCkdUAQcV9L0I/f69AISrGQWdgBEFGbrFAAsWxQJdwdEHROV5BX2kyQc7ShUHxgQBClhmGQZu2nEG3VgZBd1gzQbLnykHLSktBPEU3QZoYZUFrlzdAk7chQuLKuUBrP2hBGq06QOjADEFvRzxBieQ8QL/fjUEv7p5CxqZwQUdxHEK1nRBBUwhCQdGlWkFRShNBg/bEQMhCdkEWsHtBOWTJQDJZGEGAMcxAVh9NQF9760F3HVJAFaXSQOymUkBnoFRAgStVQZWLgkKK4CBBgRQiQSF6I0GTOlpA1TvaQQ/fiEEXsF1A+G9eQfrUJkGds2dBjeiRQcpFOkG/pKJBe7K00w==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="28" id="sample=1 period=1 cycle=1 experiment=29" defaultArrayLength="104">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="234.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11664.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.05215" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="29"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1087.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1087.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="63.95482635498" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1100">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxX1Qyw0AB/C29ExOJUJIrXQUCXn3SN9tKoc6lblordpas0fW77d3U6lnlOLYTI64NiqnQ11uhEt53RVSDZsnqnnrdLgUzcs9PZ7f55+PYMKKOmlMGgqLWjZFIA2MUK48ZT0fqZwZ+cwDfCzWiZptVj7KNnb257dmgsm9/qmhKgu1NqXPFLoAnZWz8w4JBeDxbJ0tJgEuFU9vT3IK4M03j3tMzbkxwE93E8KeLSBGg4TY1n/bbwNTCMuWkRZfWjYyM+4afoaIsLbae33KHBGu0BmF9SYR5nNLp9HNIvjlt5ReeSuChfVCvrA/B2b7kubGIDEG60NSOqrEeMmMDKntE2P50yRhcvVO8GukgT94EqyuH5nP3i+BRTX8YKlJguH2jKPTY3ehz5RX9TsoF3+dNbyN5+RimbflfO+dXPisoiXasqWwzDnmES6SoiIlfE9cjhT6x3tnlXrkgdfWs6+ERqA3LJ4oSSbQnHFwTCIgcHwP3ex+jMB/kkrXMupiF80qpv7YEzeacJsAuS44UUPtODs13OsegU+xQ7sLuwhsZxgTQp0E7vde3LeTRsKjws1UQx3TbpOvY5LgqRJ8A4NJ6OnljvSlJBLWzPVvYJOwnnv3oySZxAX7qy8NBhJRZ2Ld07tInE7bPG9SlgzpTYmePQYZvPRjPH2lDE/elE0KqJbB08HmR3TJULDhZuzDbhm4cSVn/JwyhJ8si4j+KsOCvZH6rEw5CkbJ913UryuW183rlmNtlvZwKvUDttFn/LAcooJoTTZ1x5GMy1dpCkgq/ymvYylAeAWsOdGqQPe7Q5jxVAFt1BbX/hEF/vDjGAOSlcgxf//Tt1UJ7q+tpxzUY4z4owKnEgPXOxqMBhVivnBWsqpVuFrleqJrVKHMzvlmaVVhh3Vi9LNgNeRB6kH3JWpwwga/G1lqfCY+tlUQarA4TX06vRqkmLEj1amG/fLQYVeSBre8w/SJjRq0vQh+9Dc1K/Crby3182upi0LvaODYHPeh840G1n/dQiPZWjhnlw/xirSAgvFNZ9JCO3DTP79Ri/LJP3nbfmuxaFjpiqopQOZr3dBMzyLoPjepF/sX438f7Xbc</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="572">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBoAFf/gG2mkErDOE/5CztQCRI30INKm9AVFJaQfjvP0HOqB1CAmejQRCOg0Ak4W9DTDtXQb5SR0HSTTdBjFCeQZh4O0ECJgxALCcMQHZVqEFqo9RATxtEQtAh/0EI4ttAiTE5QSHvFEGST5dBrUjmQLD65kDeTRpBUDCfQEf6v0GZD6JAbnmjQTcPqEHOVuxBRxOoQEvJKUCheSxBdl76Qbw4z0EUnoNByJ6DQHB/r0ChcbBABVYEQSaAMEECx7BAMBkxQIqOG0KvyLFAO84FQVNGp0FkUdRBexszQRqSBkHoHB5Bw/Q1QZkgfkHlVAtBFvI5QMYcukCQvGlBSQU7QT1MO0BdlmpBoAumQRFVjkHk7RtCMvCPQPqLzEE1ZBBBT9RAQVCJckFUjZ9BRrvEQJr7E0GOD8dB0AnJQGQNSUC4OpdApQCAQXzWGUGLXs1AM4OAQTOXgUHiqDVBa+ZPQFDPakEXRtFAZ6fSQE6a1EAuq6BBWTpWQWk7VkAbflZByg9XQAgSikH3ciZBkgaLQe+7XkHS/19BOrZqQEsbN0FHDj1B8LClvw==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="29" id="sample=1 period=1 cycle=1 experiment=30" defaultArrayLength="105">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="192.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10466.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.053833333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="30"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1112.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1112.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="65.517463684082" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1124">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxW1QkwUAB/CNu1lIIjj80iGbsvC6YilbMSjlr4HKdVyFgTpljGcgbGPb8+zt2ciBXBAXaNu4EChsjTV7gwZZeUtzMaIYngcJeR4N3AZBYCpCyMXZy35ffvNeKv71nOM418C3ZjRKUM9o7lQNSdAnl/ObfVIwhrPIl8NSTHSdNawzCcQTnJ7FGAJxlqPC53cQWGr4aVwkIVB7a/FXl4xApvVFX7eDgKnt5jsFIQJfEl1JVxgydLXsG+FwZdDP0fFSZjnqnnvI8TkqMDC5RTQxU4HKd3cmi2+fREbSv5cffViJwCs1KxxXFTad2X6goESOefsXa7wGOXIc9s2l3Qow5LvaU2cUOLd7fYMlR4nQ7LFv3s9Vwv9AzG8mlMg/lZe4i1sNxdV6jjs6EazayUM1xLbvdJPSajTxioPq6Wr03vvM6M1VYTnl8W2BcjXOpB7anVChhrPoEKMs+sU07/mURjVGTzx9OpWlgdBPjw8/pYEy0fTSyGkN0rtmR/X1GmjKb816mCTUfEUkLoZEZTDsd20nkenMvvleIYmth9OsewkSP/f4/05pJUHONxnU0Yu1Tlb6DyT2CxYSmEwKq8VFJ/Kjt3185GxT9M9VLX95owueHLlgTKSQneq1ibkU5i5wP7mUQSGWXC/JFlB4Vv4BZwoURO6FcXo/hf+2BQZaCiksm2XKa2oKR01/hhx2Coclnvsb2Fr8FofFzgwtWtZsS0tSLVzTbVlZZVr4OaUpe1q18L09zk7o1mKINdgrHNNCvsYXaVa02EhOOTfv0MHC8tyZgw7XnMn9Wb/oQEdin3gY0iFcMtXYsayD7+69qj6fHnnir4/FDeoha98bc3VMj0t/lD4jjOiRXlD0Y26hAXjh/JXvHQa8Eci8u+kjA/ivHrBf9hsQYc8K7GMGbEkSGba6jDiuyP32n6+MwMpYXpmAxnDs6smeVhp118MTd/posBdu8CT9NFgxGArepsHkWdOEIRrujtcmLf0mBCV2Y++ACZEbzrceWc34vWzPwSM2M1TujQ3XPWYU1IpXAw/MmKIfGzzFrcEIrMn7bDXwzcjCosQ3kdzRrJqOWCDNFx0M9tXi0/VhdvtoLdydF5Pue+rwPwxFe0o=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="576">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBpAFb/jXnxEEJKpVCoiRvQAvpaUHKfPo/7Zd2QolfgUCWt8JAxPjDQBu5gkGEVEVBMOFlQ1dUx0C0+EdBs1gIQUIT+EHIl3lC8cvjQQQoFEAkmEZCUei/QSv8GUG1Uh1BZxEeQfHnRkHEufhBQ0nvQIqqoUEigvJA5AnzQExkIkAZr/VA82D3QGIWfEDhET1BBBp8QXZoKEE6yKlAeiEqQTl8wEFXVABB4+oWQnB8LEBSJi1B56CCQcbfgkFehiRCon+vQDlVhEFMxTFAfP9HQd3HMUESybFAcZQFQZjOBUFtyLJALtf1QWxNBkGJ4F9BkW0zQbr/BkFThgdB0BllQarnt0DunApBcLihQVlWC0GMF7pA6FxSQSusu0DXbY1Atyq9Qd7mXUKtKBBBkWgQQYJfxEBib8RAJLBEQLYCRUFtEEdA45Z6QUJ6SEAQ1BZBo1pJQOfVGUHrCxpBML0bQaxPUUDu1VFBMWKdQVung0G6ptJAU5aMQlQQhkFCeaNAa3ojQRSPiEELPolBV7mJQc/3+UH4SeBA161rQKjU7kAbTG9BQKyXQaOktL8=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="30" id="sample=1 period=1 cycle=1 experiment=31" defaultArrayLength="112">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="185.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11764.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.055516666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="31"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1137.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1137.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="67.080085754395" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1184">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXlMUwcAB2C5whEHsXHpDGNgxxTmZlgRtowoP6CBhm26TihFoBc9qOWVvr5eZEKBCN4dUDEzhBZRNgKbAzIjx7SpoxuIEhQXwgSpB5udgENUUoWx9/3zTXa0pohq9+LQL3ZbV91ePGPrDT8GHsDxjvUd7NQCsIQ+Tht9CKuypYIjRJvYmsysFeL7hWlJcJ0Q3NsnzxJuIZrTF70lTjFSeTW5Af5SOPtXBg4XS3H8rHx6wiFFx+6ElS9vSdEwONJd6JFirkzKeG9DMT4VXTWExRRDrf/Y56IvWTMErWyQYf8lgY/lJ8PkWx5rVJoMIaEVQ+fFcmz7o/tCjUMO40S49wH99c72YNusHO7eqXn3QzmG+oZdlwMUiD7axfxkVoHpmyWOU/Tmd5MeJbGUcCrn2M/sSvz5tLcup0iFIz9k8bYeViGeiv3gYttBLF+d2bILahxrH6NGOGoEHmtP3hZTilBXEz8tkEBz5WnGERaBJOZd3lEOgRq1b9UqIxC6WFTwXKbBGx3zc3vcGjwafSFumtUgZdNU1npgGf4a8XKD/bW4lyRqXY/WItuSoTBKtYiYzH9VodMi+ZCe2NyoRauMoS+ld116cePBNS0Gl1sU8b9q4RM2qT/yI7G2HL7vIP2oJWrqdTSJ3b6sf3gxJHLjYkdn2CSeV1hjtyeScPM6J0rp+fz6TE06Cc80oUEGiegsyeC5BhIVBHtPai8JP89A1a5rJE6OBzHu0bPHbhNlDB1qJt7vP8/WoWGuMsFfokOX6rf5ZPqfmhI5rgYdlnxPg7badHiYH76ayqLwrfd3fw2bwsuSm6fHQWFf8c+ZEWkUdny9s14iprDproCvaKQg4b+yMG9R+JtxP09OP3Zi1lG0RMG+uPBOvp8ezMLIzR8G6BG/M26L0qmHKjOK2Uc/lLPxpT3CAK9gWDFYbcCbT04EL7CNUAmcS1d6jOCKY69Yeo34rC0vhnQZcSH9erjWY4RlNTdxu80EZ3ZGwRc9JhCif6uW6D/f2Fmf7TLBr/lO3uS4CZKw0ftpHhO+GQ5JiKs2I0CQ32JvNOOri2OG/jYzwHUYanvMsD0Oy2H2mhH5nanH4DKj9kChdJ7eyU1R/re/HK+fWGcei8rx9o0Fx0BVOfin1i6768vhnrqjOucox4izv9vYV42BM9SZSFsj/gcPjJyh</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="612">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBwAE//puQZ0G9bKg/WebbQBylDEGHx6hA1OKxQYn6pEJvvyNBp3aVQR2B+T9s3zFCsGzUQfFxJEGwPIRA8B5oQy99lUGC+MdBjFBpQd6CTEHmm+5BPTEJQN7xDECPoNRAVjKxQQLb1UBcMTtChQePQC48tkA+sNpA8O1bQP2iAUHQtyxBG/rmQGD9sEEuIh9BcS+fQcuqoUE4NaRAyoqkQEr/BULXRCVBRM2NQgYZKUH/Ef5ArjlUQWDslkEi1gFBpeCCQZogA0H9ASpCp58DQWB/MEG7gDBBdxvTQXbHsUGwAF9BmM4FQTTJskD8I0lBIn9fQcpD9kFKHjNA9oUHQhRatUFDrDVApq+1QNlEN0Fi5c5BL52KQbHSuEALxjlBsFkLQZBuDUEW4zxB8Sk9QUwrPUGgxL1A8rg+QQnvj0EA75tBI2SQQZIHcUFg20BAJ17EQNABh0FY2EVAg+1HQJceS0EM3qZB712AQZCmzUDUpRpBzVFRQLwmg0HLFWxBrpYdQfhiUkAEp9JAJg4gQY6QhUFbvIVB8X3FQh2YDEIp3yBCfoFWQAS5IkGzKVlBeEgjQWb62UDTYwhCDlOAQM/MOUHOesAs</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="31" id="sample=1 period=1 cycle=1 experiment=32" defaultArrayLength="119">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="195.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11207.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.0572" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="32"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1162.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1162.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="68.642707824707" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1252">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyH0wmwcAx/EYVtvaYTqrGcI2t9o/CK231U+TtunWuDW0XUORJyKxIk+SJ0Xa6kMJZ8bKnFNrtDZHFRtNt2bFQpn1+kJwFWNlsh1K26nOTetlz1+f+35b4od3yAuisRb72UI/jiD0mXxvsZ0I1+9Lbwsi49DOchLwEAfhVtFmHS8BK5ZeJ15BAp6HWPz4ugTMDNSJtH0J0D3qS301MQm0h4v/qg2BGzHfmde8CSgVtoI+CYGp0VLD9FkCBRN32r+sJTDfWH9q3xSB4Kt/eAazJZi+wh8qFktQlOFuirFJRuOpJ5ODPlIM3C/2omul4OVwljsZd/FEzy1WKdTG+MTbtikwdeS7nZ5MAbfcNdDDS4ZLtEl/TS/DxffCv95g3DY3zfL9Vo7d8TN9OYzblxcTRcdS4RDsetoxPxW/jZ6MPsP49zGvRqLuc3Trw90NvOOY4h4o/mDPcQz0tq69zU6DWxP/+l6kQbhsbqnkpkEpO7LT2pOGhbWKw1F26Vj6Ri8bSc7AT/PJ0VnSDIQ5Peu/m5+BMZYf/a69Ao2bysuIXAVIo9HFLU8Ba/M5z64uBbb8SSRv8iex4tly1D2KxGGDfAeXIEFP7Gsy0yReJMVF+ZaT+EXI74xj7HYI2WlsI2HDuXNZaCJR0nE3YbSHxEKgiut2k4RnTvTvfBslljan36tntK5+2iBxVmK2zXj1LFsJl2WLle+tRHVHSO1WjhJCedNwGmPqa+keRsZe5xr9wd1KJP7HklFiJajKqlAfsQpV75eEcmgVArSShy/lqmB/YZw9eE6FjvEgqc+gCtFFj6XVZhXO33sijVxSYa4z9kQBI8ub2zD/hhqZeRVnWD5qUGMK3utRavz10O9jfZIa67Osx75iNfLDV6wiFdMPZk3deWqs1n1R9nRQjfNebSkRZjX2X7Ify2CsFxW+084oDzpUhEU1puTbs3MDKDz4JOLWo68o/PxKaU3zRQoDtOBGUzsFlbOYHDRR4JSto7+HwrigIfaHIeZ/9O/ch9MU9o9FNFufUtC6ljkZHDWonFiX9UZqENT68kjTQQ08t9h97yjUQGhbkT8p1uCKnox5s0cDj8INg2lYA0Frnt0I6wTMiq5Sy2QmdCM/ht3ayEThNni/CMhCRNeQubA8CzdrGth0WxYG2KYLhsUsHLU7MBNGZ+OyRvhrZW02qBJ/3TpjI3diT2CQFkP/rMSmx2hhrsl0Gd91EkTONYdgPxrVb0Ueqpqk8T+YQreq</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="652">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwB3AEj/uKdfEDb4k9AU+ykQKsI4UGODOE/qi3tQLtHX0LDLu5A0yTvPzCvdkC0nRlC884BQCMQk0GGKwNBFFTFQLWSekM+TelB2TMGQcBjGUElONJAPsANQIAxsUGo0i1C6AcPQYR2yEHZlJJA8yaUQIJYUEJHDVBBkSU9QfKGGUDR+WZAPP0ZQJxSHUDfxu5AgjCfQGMVSkK6iEpBeBAiQMc59UA4NSRBvE8tQg0RKECXZyhAOsipQO0aK0DdHCtAOsErQKwWAkHrWgJCnx/aQTkiL0C6XVtBWH8vQPcksEBxVQRBiF+EQYxgBEH6jU1C4QFIQd4aMkAjz4VBS9IFQaCdp0EUGQZBp82yQHMZM0C3ujNAwgZnQSZuuUA3cjlBVcY5QMs9DEEIpKNBecAMQaesu0DnvqRB3TYZQrcqvUHKxb1Ac4HVQXaVDkGrbL5A5eg/QSTm40Fq8A9BYey/QBWm8EEcukFBLWJ0Qb5Sq0FiGRNBoEsTQaiJdUEJ6HVBBkN2Qen8E0GNYhRB/LnGQJ4Nx0B1D0dA6oIVQcAXSUHMDpdB4zhKQKzP30FxZR5BVg7UQMyz1UBBOlZC909XQdWzWUCCOVpBQTvaQBmDJUEoMl1BugZhQejXN0FhcPpAEULDKg==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="32" id="sample=1 period=1 cycle=1 experiment=33" defaultArrayLength="92">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="195.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.011561868436" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="9640.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.058883333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="33"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1187.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1187.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="70.205322265625" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="980">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx3ss1AEAB3B31RZxLooal3Nji6Rw8ij6JidHp9bDmnJxJ3Ivd7/f6c6hp1PRlq6meeTZ08rSKDbmcbRERhrLahGJOkoTRaXfX599YmRihxJ9FHoZvc2yUCEuNL5mheiFoE08GvTJFsLnGbOcThfhXUxECpsjglFhcyhDLMJAW90kv08Efuld+cFhEWwtjjcIzMRgiYc2+LLFeP+EKefSEtA+eYnbWXoCgYvNxd2jJ5BXGbSlb1kizvB5+XpjIg5xX0ae+pCIv/Fh88s4STCGX8uZKEmC2qP401LlSdxeKD+9MjYZDmnc3KisZEi13MtNbRJ07X5jyeZJEd7vZ3Bhy1BbZO5BUO574XfBATJcXTvvmR4ng/tHu8jc5XL85rDPr+XJQd70/zl7Tg6+VbHjWIICX7xk3/Z3KNATD+8dK1KQl6RVNlEK1hzRiw4osUe4oJCIlLh5ryWomnK0m/HVxaBEmUPDT7JCCW2kk6drixJu5rHnYiif8LTbfGkqMIPL2k9SFphv3shnq5C+qsrW3UeFK/MP+mWUFce0C6ZrKlhUzPm3PlZBdjjMsmdahal0BjfNhsCNMUbXVQ4BdqfW6rk3gXsD9fT18QRSx2fELmcJePJ/XWQaCAQWhNQOUIaaUiSj5QQYQ0/9C0cIeDkZHn63IaHzOi2i7yLhJBEPZRlIBKS5L4b0kai7NcevHiYRXkJaOY2Q+Oe3/Y7ZDAlBxHQNn6ZGvVm9NDNODZNxsEpAqJH3hx2Y36wG63Nhxizle4njpk7rVLCero+zOJAK57bY1/NLpxA95X1ndqsGjR0T2T+8NaCV5pTdVmpgbxd2v8igAc8EYqxGg+CIAo91HzQ4kiiwnKNcvOKWLx7WYI1zpupdnhb9B/fOSGu00L+SGhco3+4wqxpvpT64Oie4LA1MVe9RTogO/q3lrr2U19ftlAec1aGnYyS6oVSHH93Wrvb0DPwHNQ5CfA==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="508">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBcAGP/sGe/ED14bFAj7AJQoUu7kBiZwVCb88BQRQVREGXPARAyUcxQz/hBEEgo1hByW0qQeDkBELgw2dCAekgQWNxEUDPPDZBC54SQLs73kDuURdB+oUZQExb3UEOsh1AaTAfQL/fNUFogfJAfwYiQTtjokAjUfZAQWL3QBxj+EA9TANCNxmpQKgBP0HQrv5AX/BDQc4g2kAFgq5AkJ6DQdnTr0G1jFxBc4fRQfhwkEE2OV5BX4+9QcDKskAbzLJAfYcHQepStUDWjzZBC0W3QOmJzkGJ6DdAiQszQmUSC0GGOOhBd8s5QQKRC0HKUztA8DUNQVQqvUGHub5Awe0hQuI0QEADN0BAwmIQQbWdEEG3QXNB+TMSQcd2dUHEYERAH9lFQAQtrkFYwE5A/LQbQfykT0BguFBBwnjrQU8og0EupYNBo6eDQZmn0kBnQSBB9jlWQZ7lhUFmgVZBUTxaQOkRikFe4hdCC+5dQMlx3kCDHStBk3yY5g==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="33" id="sample=1 period=1 cycle=2 experiment=1" defaultArrayLength="6864">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
+          <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="3763.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="395.090204995859" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="6.31115e05" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.0637" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="360.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1460.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="61336">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwU13dcju8XB/AWLdJCVlso2rZ02iLtMqL5TRJNnr0LpT3QQoVU2oNCO21tKaIykmiHFPU7v7/er2fc931d53yu85RblUz9ehYB1KyS9tJRn3XJTtNoyUhKtAmbAJMd1v356H83v2hPoUDsKYzmEOBb6SbipkACZIydKghF+ZTopuQIAmQa8tn5RxLgYqiwj1MUAWq3JQi8R7vKhL74RxOgXuSM4ZYYAigbbTQ4jwp7D64YRk8PHHzcH0uAd1sbo27eIUASdb2f410C0MVeDhSg1UP1OXCPAGE/u/LkUwiw+JD+qQrlI/zXSk7F++oEmuy8T4DylKzRavRZpPivlMcE4PZQ/jCeQwCRYh4H41wCpDAE386iKp80/z7II4AeeYErJ58A6++3jakUEGD/RwVqJBqf7m95rhDXPy1kM42emzPobC0igOwwb6FuCQGIl2c3tb0gwJuYsA2FlQR4oLUmeUMVAai84+F7q7EuosfOkNEnW358E68hwGuBvLgr6Noj/o7ZaBzkxN2sJcBy05BnbRsBCiJSmBvaCbDbI/TITfTqmFOLYgcBbFb3X/uNCpiOuCR1EmD4lqWgYBcB7nvmxJ9C1bIu9ch2EyDA5HVAOhq22562pocAUYqXbcIGCeC3OzvZfIgA20qE1m0ZJoCJs4DkfTTrl8fC8Y8EED/RerUMjWPdCFpEt/FN3ygcI8Djfafb9CcIMLVQlkqaJEBTmaWS/BTus7F14TE6VmAyWDtNgATdF/QbM7i+//zlFmcJIMmJaNozR4ADEYcEb/0mgPEGPcvivwToDzdcsF0iQF7miN0XlLFRp9N2GftktGySiCryi5B3cRHhjdPkdjtuIrxLo9tWoJR3r3e58BDhc2B++zD6tFXL7hcvEVrC3m0tFyFCdf4lov0aIuQfz+KeRvdIj+4GUSJILbdeSBIjQtvbxOR/aF6M8f1L4kQoX9PqsFqCCPrC2pxc1KlAVERNmgjzZezv0jJEMI+YPO6ORmw70NqPTmzI61GTJcL3nFHlevScoQ3VWI4IkafbRdpR04jIx7ryRGiyTbyRjka+uxuzTYEI7pH818tQ3pfW395tJ0KJjZ7xXjW8n9DnZiL6Y2Rp6whaqaS2zVydCEcT/lCi0MelFreX0I8acQmemkSoD3FPeYFWDX6SldEiQt/BTycfoyRIavypTYTBFlHHX7uJkHJYTvqMLhFESh/TBtC0pU0iD4AIQrEskSU04VeV1D09IujsqY4I1CfCgM++zim0+7XMf/YGRCiafnRqjSERag0tGySMiMBRlA7XO04EgyXb/UfNiZAuWqn1Gi11uPJbxYII1OCfDx3Qg3uvMDQsiWCls2y0zooIPuUX66tRLu49vorW2M9Ct3VdqGX46YbttkR4v6D6aaUdERav6nkedyLC13Sz6XlUJVbK3NiZCMr7Mivy0FsnDbjPuBChi/TFZhZdOuids98Vv8+f9i8ZbTY//dXEjQiEybqgYfRSevYXfQ8iPFfhu7rshfcPfHvwtzcRYjxDJVV9iGAbcXBPJGqnxfNcyBfrqb7Vho0aF4TqVKI5RtcnvPwwHyIe4h/RVkK+oWIAETY8WCuVjdaUjh0XvYw5s89JnaQTYffL3NXFTCLElyv9J8giQsC0SkomevRMpIA8G+s0eKk9Ed2Y+WNEmoOfX4nKGUdbHo3vWxGE61C+o718FfsQ90ZzawQR6l7sWv6M0on3hJIiMSdcqkLKUUS4qLF/33tU9W3fzYpoIkxtnFl4G4P52E0NkInD5+crTD68RYTt7p2B7gmY6wXGY5lkIpzaG7ZH+R6eI+aJzyFofk5ZoXEKES6T1H4No/RkZ4NHqUSYu2J+3jsNPxdX3C1+H5+76oRTPep1SIPvWw7eVzSO0JtLhGd+Nb+T8jBn8aMNXvlYj8EHzoIFRFgvkCz8CjXi1m34WkiExJ0x21yLsO/qsVtkKonAkDfNpqE37mWEJaAXJcj35tAC3t9W7VVEkFWk8hlUE+Hsg/IzvWj0H/vM/hoiOOR4NvyqJYKGSoBcbwPm2ebhM/tmIlQ8bnc90Yp1HBRqbUb9jHxUG17h5+fCnIbbiMCOXI5tbce6fovn+9SB66323qDQiee5aVVpLdpPYm3S7MXXrNVjY2hBqbm67CARfjtW3fqJFlC3szuGcD/2WQ83DhNhaH3J4hX0SFUX5z16TMhP89BHPC9f9twvRR+liZlu+USE146db5PRrd25/kcniBBsJjkoNEkEmevHtLimiLBL67+7YejpFQJh+ahrUcK0yjQResIs9s6gHRqJfPIzmGNJs8fn0QTyXFI9elw0cLPALJ7LqdSdF9FNBQVDrai3klTR+mUiSDb/PTeD/nq2OWI1NwmUW3303VEHj1Ipcx4SaJ84+WcQPdc2zCLzkiD2Xbb7c0ESnCE+ONi6igS1dkv0odUkOH3sa/AZERL0Zm7UPrmGBIrBOi7v0ZtPtm6wFSXBPTlnZ2sxEpTPS279gSruUPImiJMg7ceA3BQa8kWSZSRBAjAv96egRhdro/tl8PnZZcxAWRI0LYtZ7JQjgeyTgouK8iTY7XTmaCiaaNjXf0SBBB2bOSNZqKfznNa8KgnWTpDtS9RI0Jd74G24Ogn0D11hVKMx1pa3zmuQwI652ZBXkwSNnwc62lFC9pTjWS0SPF4hSNU4RIKF1/Ir+Q+TIFMv+vM6nJYWOfP2ruijk+KWz1FycKCsgx4JliMivH+gqcrkni/6JPioZKhibYDP/fEhONOQBGI8IrXnjpDAOJ16fo85CYbsPs6loLfy3UvZFiQo2TEqs9eSBPZGchdDrEjwxLTJ44wNCV5eCIUx1FowN/eJLQl0KhwSy51IsPEcj4aNMwkEV1TdNnMhAfv0sm8aykxsVpB2JUHF8tzUMfRD45VhBTcSmC9p/36OHr3k2sE+T4JBAz9m5QUSrDMkDWl5430uuf7c7UOCI74H9iSi8ceT+B18SZDQyP2yBVWLCf6k4UeCT4rjw9mon+DjJ27+JBBdq8aRCCDBeFlmVQq6XqGCl3mZBKONBe/GGVgPpc4ILSY+t1pRzIJFgnbuI5v+oew4rRozNglWm6x4+QTVveA5JczB3BlI+B5C3zW0DGWhqXXXOZaBJLDdVZUlFESCqhfhGQx05I3SiXFUSkpYNeA6Pm+iMPhLCD4/ySBrKhxzIyDuyB2J63IU1iSiO4qtW7ZHkUDYTW+qEOVe+eXu9RgSGO7OaveKxb5eLQnfFUeC0iqScCAqdNnajHKHBPlXVAlv0WP+17K17pFAo1FN6wbaXbI+7VAKCdI32Fqap5KA3msDb1CjlmKHzWkkeL1beDQKvWETzfG7T4LzZ0JNdj7A83LtwF/aQxJkZ2V9T3lEArfnEt5FWSSgStkyk3Iw1+nS7sa5eO7YxNQqdLW74kbVPFyXddvojnwS7HQkNFPReFrdjoACEshVdPN4l5Lg7epLfYcrMWeX5yVy0TN//VpkqkjAyAwcjUQpE6bXKdUk4F3Xx8uowdzvqv8+hL4/t1bKr5YEyStyBZ6hdyzSV12ow7oV781UbSWBVbttmHkbCXwvav9+gwY93tVp0k6CsSPSRkXo2qwd1E/o2U/P4XIHnruLs/OlqMBZvg2kThI8ZbivWd2F51yy96sXmlcn3fjh/7IG+ZK6sV8G3JcODJLgmuyaswlo4HqNy8xhnAcLzhk3P+I5ChXmt/1EgsMcscBOdJMSqKb/IMFw3hXa7nHMTY+wZOsE1snGJVF1Etc3cywrH926rb7BZpoEP0k658/M4F85uwuPxKJrFrg2SM2SIFIm93M7Orfh8DufnyRQf3dPuwvdYxE0tGKBBIU/Jh4dWMQc7Nh2+xbKd6Du/dtlEmzYue2FLxcZdh3RkDrLTYbcU6LT46j+YuLbfTxkEN2U9+4qGhefvH0vLxmc/hYLqfORYc0Z/2Y3dF66bd8RETIsK++9WYmW9G46IrKGDFLD1fNP0RePSpYWUOXAMyL5omSwdysvKxcjg9aU4dcL4mSY8jlz+5gEGZQuJGyJlyTD1iP8O8alyWArOFJwQYYMNl56Z9fLkkGlkmFtj9Y58Q9Porc+/mtokiND7+eG9mR5Mmw3HrDbpUCGkKLk7f8pksEyKZnxnyoZ+iq1PZvR0Q+E1z5qZGD27btwWp0MzvZBQxYaZODdYdPVgX5PTxZ10iTDG6uHmW5aZJgrdfq0TZsMCfqUA/Xo262gYryXDBZP6QoCumR49SjL5wJardrW14UWrT1fnQ9kkBA9ar5GjwwfOTyV51CRiv9KbfVxP+E3B/UNyNC0lL96HDX/u3Cw3ZAMERcN6ncewedpu/gRLfD+fs5D1Wj/k+uXuSzJkHRieKYaLams7XOxIoPpMVGlGtTQ+tgmLmsyjFzIcg5Fdb2eSyvZkOGDaWRnBerAo3pBwhbr1Wxg8N6RDL/fNZ/NdiIDxSAlRNwZX9subwpBz2Vbppq6kIF8fTt7AV04uLRg7Ir7zjMMF3IjwxZqq0kR2hfqwCPsTYbXU3HzQz5kGNNhPg70JUMYy17Zyg/X8eVkSTOqvSv3xml/vP+mcK9PaJiZ0KM9AWSQHmxwuo1qrPg08B1tTa1KNb9MhsWBlFvzDDIIZX1X4mORoX5j0+3n6JrB/0jv2VivJK6fGzlkCM99pmCKfo2O5d8UiHU+IDdbidY9pMnOoRayh0xX3iDDDYOImOIIrK/SA8WtUWRIl5DZUogOPxSV1onG58zk1zahh14fPHs1hgxdPHc0NGOxT3dOeX9PxFwcecH/9C4Z9oqsXe67R4ayq2vmslPIEERau56eRgarWu3bsY/JcD4z4+OrXFzHt/5ZmTw8F28alDvRco1jLiH5ZIi9/U5lBI0z4t/zoIAMfHNVly4X4jlIfO26jHavFtiRUUSGWTeJYcliMqxedTd5RznWvV8yck8lGSbpJLka9EDIh/LNVbjul1t3e6N54zLqlWh0vPqzddWYV1leaxYqtCDS7VJDhs/RO872o4H0TvHttXiOXT/JHEX5o9wUbqMXyvaeHkCvRCz+U6sjQ2iLIuEyqjl1zLy8jQxizEzD1HZ8/1O0nFIHPp9nxX7+TjIkjx7OIKGdJa/+NKO8Jaru/3WRQUGuxKYPPW0r8t6tmwzqRIOzNWjfnhmSQA/287wO4+tbfH51hnDIBzK4b9u9M2qQDM9rvqgPoKE1BrIKQ2QgajUuZqDq3M+97Iexz/wKW7d9JEOpbmPkbzT0v35/00/Yr8gVZ6a/4HncufqH3ggZfgU5Ps7+ijnL/SDsPkmGY0dUfPmnMLcOpdJW02Ro7j2gX4VafX+nqDGD6/WS3igxi9fRik88/L8uCqOqP8mwpGI0v4qLAnwvU6WG0Cw6V2cZNwWueCbekeOhgEfIxa4CVGdAwneClwKWAacTf6ygwKPtK+LPrqHAJbU8y1/o8ZQ/eTvEKDC55fO/RnTYMEhhuzgFOuMvstpQ5gr/AE0JCvQprLeaRAXMrtZ9l6HA50MV+8NkKfB12ovhKkcBjkZeWxsakF2UbCtPgbdOqTQRBQr8uzvV/ez/jtz31VGkwFOZBB5fVFSrdWP1Dgqk7uXV3qFGgevzrok86hTITusUo6D8lMXhAbQ1LbO5S4MC0iYz4UqaFFh8yO1xVYsCWx59cNigTYH9HLWhKfRUbJTOf4cpICy5ksDRpUA9vyJ7AX1w0ETmAVCA0ZCvsUmPAme46o9NoaVr9Ksz9CkgmN4Rf8SAAtUOV9oVDSngyowKjkXbPjSmbDGiQM2FlROZRymQPPNdO/c4Bf9eurD+sAUFFF2bn1ejnVeOwQ9LCixJhX63tsL66+c38FhjXYdjS8+j44Mzg5Uob3vCUpwNBZ4/PuP5E7Wp0HpoaUsB+pTPhnl0oHGqS8mOAuYepUR1J1zfb871m+j8UaewBbTwq3yHrzMFtGe2afSj4+1bzx9woUDRtm1yn9F+G5fdH1wp4HP2bzHTjQJRAUZtv9Bdp3/oEv6jQGD5qdk/aHXzI2i5QIGgqMlD+y9RQDeSvdnJmwK5kTf+rvWhQMMhN5FHKPeIl6qyLwXeSUy2OvpR4Pxal7+j6G+nQD4zfwrY8bW5taLZAS8jvwRQoGzLzKTBZQqcvc1NDmFQICdsnW0xarZrvcADJgWmJlXPWrAowLqTonaDTQF7yddWgxwK5K9wifULwn4XEql3gilQ2ZAhdjqSAqerTb0sorDPjLOue6IpQNykPvgc3ZFR6qMSQ4G6/Wtciej+6La8p+iL1TZ/DsVSQNnd9k4G+uCR+GbHuxQALbAOuEcBldJZA70UCtyzejbfj66+OjV9NpUCttHuPs9RoxDFf7/Rl48UdgWlUWAPs0f7b9r/z0VCasp9CsiMxCWueIA5lcq3eZlLAanQXuffqHI8LTgwjwIV1urpxvkUmDmerfgHFb4SYqxXgHlXKz+dhs4Nu81eKKRAt69+oFIRBZKo+9mPUD9uMesNFRS4+lStP6CSAt92qa7cV4X92OKi0YRqm0Tu1a7GfD3eJZ2E2ui+/Hm0hgKbelWzstF+huBhoVrs+6ENMdfQBi4/89IWCiRq3Zloa6OAu2DpELkdc8Zmtnt14HU/SjV70PEdO4eOdlJAzGM6XaqLAiN9buXN3RT4WXPY9MAg1lvn28lr/5dXiqcXpVvmfbo9RIH4sjB+rWGs1+/LF/6ihzRDvG58pECI9gi35CcKbDzabVKHynUJUKW/YX1cvLnUJjD/cTLstZM4rx7qHb6Phie2MUbRl+/dx49PUeAvPGEkoTLPuXKkpykwel1NLBItu+rgsWoG3+ehOI6g6x4OpA/NUiBGWfuk5Rzm8E9PxBcUNrTI+CzjueRWmH+GUkOGCj6iHhOr5mW5qDDW+It8B93SVF8jy02Ffu89/TGoR8Pfdm4eKtxgcG8no69qJ3b8Qk2EomMovFSYkN1lxs9HheIb4WMf0FW9A1wNIlSw9UlwiV+Dr3s2NT4SpUJ66FjoEPouVHPaQIwKhe+38pSjX2LXKnOJU8Fw7GgMHRW61tV+UIIKG2r4qVXorboVdmGSVGi7UvtZbi0VWk7kGx2XocLvW4thtbJU6H5MoFTIUaHmjHDqDnkqSMdeXeeN5psm5M6hHtza1QwFKtQxNtd9QIfWfn2pqkgF/zsHO62UqHA0LXD97C4qznnBvl5VKjxSDO73V6MCkaQR+wHtvstQtFWnQqWX3w8VDSo4llzTT0EbrEcVZ9Gjq346NWpSwXJmaYKkRQUb/ZYBAW0qyDm2zlxF0x+peL7cTQX3xN/cZF0qzBh3n2oBKqyMK3ovrUeFovJ9njS0MNBNuhc1Jz3X3a5PBbNMyXN9qGCDk/6oARVClwWKFQyp8Ge/A+GJOdaJWZ6+woIKUbfslG6hvIMmM1xWVOjl73TZieboCbS5o1blr2p7UV45JfVP1lTI2jrbu2BDhTXfF645OWG//RPbe9C012+mglywzn2X2sfQz9yNDtWuVLh+/uqKcm8qrB6ceRXhQ4XAvOyyH2h757WV8r5UOOPwyb4U7Xth+U3KD/c78NQqA7V1fSF5yx/zkVByNzOACj+rfE+pkbG+Sd2eU1QqSF5ZXC9Bp4LAeu/vGxnYp1qDhgL0aqtCuwmTCs/FxNhEdGks9H43SkxZvd6ehfuY+lkZzKZCqrqUmxGHCnmnNpOKUJGGV7s0A7FPFzvSH6JfyucM7IKoQFlmfp8IxXy6xMSlRFDhJl/R2TnUW6Ru5FQkFZpfCOyXj6KCvFNMzGOU79itI2rRVJCwGj8bipJox89PoqK6fc0OMVT4ttONpxm931lyTjMW6yWnSkhCi8QfBS7do8K/ayJnAlKowHw5Wnc6lQpe73P3DKIJUoSeY2lY52O9GSnoqyGxZxL3qdCR1HnVCL2z/0dbCxpQ9fWCRy4VlG5/OXMffbGa0HcujwpkWk0tJx+f+ysyeRl96jXWU1BAhQxX04ubCvH5y5eZ3mgQd+d3riIqUO0LFazR3OltufnFVAje2HsluwKvX+y8FFxJhbWaEwqOVVTwZP8+J1NNhRXKP3VeoIvnr//nUYN9iw7gW1FLhbhjASyFOipUbKnsCW/DXPTsLZBtx3Ow9Z9gN7panftKXgeeV/nmJf5OPBd8V4OC0Q3F/QND6JotZ7utuqhw7BmHUY5ubzmdrd1NBaPeceaqHiqs0+srVxikQlPm4s8n6J89J7t1hzDXjO8PbqKNxwky3MNUiKnU5bxBrdRfJ5d9xDz4z9AlP1GBu8lYNxb1WaykfUE39l+yOvuZCnur5G9snKSCryzhwE30oW+ad8EUno9v9NKV01QIcasNOYIu9hhUtKL6j5WubZ7BvL8vlPWZxZzeC1vmnqPCiFS9aw2apC695tw/KgyWbt0UvUwFmQ+nTKS4aEC4MC7LQVeeKHm7kpsG3Ku8dFbw0MAr3ajGgJcGm/pCJPtQdz3KrrVraJC2VbDVC+3zSZqeQ6mtzT9ei9Lg+8bd/qFiNGivp72WEKfBwMb0zDUSNCg9nkvKRRuuqEwaS9LAVP76jPBaGhhESOm3rKdBlotvYrY0DZaauO89laFByxWJo5KyNLi5j2l1Hn2Qx7XzIyqlDzp/5GjwfPXgYoY8DYbmSIUdaMs/p25+BdyHSLQ4GRU/Mm7YhjZbmBrsV6SB3dR+Bl2NBl89dlK/olSpzTMP1WlQbHruxXs0UtWf95kGDSJyLxFltGiQ7n3raSL60v/j6H1tGkz4ff+XpUuDDRWL5eZAg41HjMXO6uG61NZ2FqP1FenCS+gAV22vmz4NnMXjTcfQId+nGo+O0yDH8WJXnTmue8hzSseCBj3GGqR+9Kiep/9LS9yX+K5RAysa6G4MES5G85Wvx9pZ0+DF6KoTP9BjwjOSx21ocGlT4vFGtK22LM/Elga1k1bfMk7RYPC02Z4yRxrs0b4moOVEg8SLgtbqzjR4nydBrUYXGru5fVxo0P/dSrcBJX9w/nfTlQaS/Ef8pN1o4NFbeKUG/bRu1eaaS9jHIWLxKW/sz+/Rba/Qi7Np1zb70OCC5uSTF+iyodNZf18aNP33Xq4FdWHd47fwo0FFnHvNDPr5x+J9gQC8Xv7dujzUaeSUueBlGvx6KEF4x6TB3BuXbY9ZmIPjpzxE2TT40vKKpw3tWvw1GMyhwbhx5TH+QBr8i6rVuYW+ivmp+gOt9cpqCQ2iQfd6na2TETRQsx57rR2Jn1dcdH2PihqpivdG0SD356VCRjT258N41wfUP1SJFB5DA5PU69yGsZhj9enNd9DmPyFfDsXR4HiA8ZkPdzG3Y4PXpe7RwLf++mIv+qj0rp1tCg2YebZB82h+ocwb71Tcd6vI4jKazfM4KCwNX/81jwm8T4OffiOWg6hZ2KDUz1wa/t/cuVszjwbWDkMOj9GU1JV9F/JpkLR6W/8YOmvVsHqwgAZnrZIDdQtx/4WSQbUo/94De0aLMFf7Bo3ai2kgMLnVUKyEBsaJYeoJFZjbhjKmeCUN1vcd5HFENSUsmAvo5ouDuVNVmFevP+vI1TQAIf+zX9GP2w3u+NTQYF9ru+f3Wrxu86eUxDoa9Ibt4px9SYMMe9vVtm008N6nlVqF7rwEd8LaaUAJ2rzA24F10h/8HIeaBa/6y9VJg70qhI7r6P1tCTf5umjwMDXV7CZqObzphUr3//MgVWfUQ4MS1Q0OFWhGxFOVul4aPNUMFO4aoMFhc9M33IN4TkSf7VxE/x4j3KwbokHnU+Lu7cM0eOLsqt6GRiZRPmp+xPsJClrJfaIB7aH9tMVnGrwpZPe1T9BgzT7b5cpJGlSVcYYn0UK73BOHp3Df4S2DAtO4zzVc9tfQhn0nS1bP0ED10tQZW/QjmavmyCxq1kFaQnvHRP+LnaOB7dI7y99/cZ2HPX2jl2igLXU6MHaZBm8/O1zYzkWHCYEE22LUsPYnpZebDukzt208eejAUWm4Ks1Lh9Ir1pLp6FXVlSqSfHRwfXFw9CL6p8hh+pwIHWhDB+nr19BhQ0TigA96Vl5xfgKd8zUK0RWlw2ghl3U8anfUmfgHre7iXCgWo4NKdV3IZgn8XtlVyTi0ns9vk70kHSaJcQOi0nRwCjwWuUKWDhedqfty0ba9Hsvn5Ojw/u/fJx0oz94Vd5Tk6eBx4/gUUYEOv6y8HG120OGguB49H43jD7h2TpUOfv+e3nVWo8Pjb82b/dXpUPdj/YSOBh1kU8d70tCebWZLG7ToUDFXIss+QIco4bu3DA/Tgah3eWabLh0ORSdtd0aln5pq2QLWiZx4IBitCJS+t1sPP9+7b+dndHFwpL9Knw55VxTtmgzoINPOanc/QofskovvvM3pkCR67cNBCzqEKm5Ij0c78m+bn7Kkw4BvssEeKzpYPBXan4H+WFJdOG9NB+v71ZJP0BS1IsMBVEXlvdQGGzo4+LzZ9hKlF4yHnjqB13f22xk5Yf1jaxXdnLG+9/mVVV3oIBl0gPUc1ZhLyjnkSodbu0dMc1CBz+bNm93oUHPPNngQNSgaI11wp0OlL6nY1psO64N1h3f40GHrvVq4jD5O+BVwB33Ofct/AG14MbnltC8dmpUnP8v70WH7X5lrbHR5S0m+nz8dhDi7y36i9xXWy58PoEMt6+khRwYdvj5mbHyHMlM3Ncow6aC4ceOnfFTe9JrjDRbmbPD8WQU2HfRzFYyD0IoTZ4OUOXSQ8opf8kWfGnr8exWI+SpN1T4eQYd994UOxKFHh/nm5aLwOuoenTfoKZsart3RdKCOtahcR6v2R/Oax2D935ZJZqNnBxOn/WLpcI2rktSEqtTD3867dDDJPNJ+/h4dpjiz4h4p6FufpV/oZNEaGlcaHRj66gWN9+mwxMWQ3faADit8n1Q8QQ9U8T4My6XDSsGyv6vyMA+/5c6tLqRD7o/iB3Yo7d6gxxhaeFhhrX0RHcLIFRMtaMxPw7HNxXQY2/SR/xHKFf9G6t0LOpAVtO7vqqADu/Wqfh3q3Xxr/mQlHS5/ENt1sQrzcSVrqRLN4rkkvK6GDuJFF64drsX7Lk8WFaKHAkY/JNdh7qiKHrvbsQ8uCnUv0fCkTZvXddChPSh9yxjqP3TXeXcnHW5+Hh2go/qBUWt70fpL2c6GXXRYyI8xsOvG7ztsqf+EelQc263bQ4djL63Lrn2gw07XKtb7QTr0ZfDj34V0cPTyGchCl9u3duwcpkPnx8o/C6hCGDHN4CMdMrK/xVWj53hbxXw+Yd5uLlRs+kyH/B+fNgSjgtS/dn9G6TAuDLz+E3iO/xk+7EKPnPlpxJqkg2rcqOks+qzvDZ/FFNZdP+DQHzRrmu72YpoOm37agO8MHV5MyI1fn6XDvI/JUa45OvwNzHCPR7+5T6nuXsJ51+tYKMHFgMV6+fNOqIUoV2MPqv9lkdrKzYCKQfH3DB4GtNvIvFXiZcDw9r1ueaiO2+wvTT4GXKvRCalewwDLzPgEB1EGyOablcehwhq/d2mKMSB1eir8ojgDrsAUcQFVotwnhUowIK/8mvd7dLfX1DpBGQakvZWa7EA9jTaUpskyoONxioWVHAO8N96VLEOLPRRvHpZnQOXb16VFaKGJflCaAgO+rmKzNyoy4P37TQRPVQbcn8xJ/oK+73rTEK/GAK2AiRc71Rnw0FMqOxM1djoUPY96HXuz64IGA5r6taUFNRmgfVBCpxG98eJasIkW1kHll7uwNgPqxN7NpxxmgF4L0NbrYh3it3/PQMP386h2AQM+bD/4d0GPASKKrJgkfQa82h/sImDAgKl39PFItPnqwUJ9Q3zOyzmuP8cZsOp4fkSCOX5/ofPTKEpNPaD92AJ9IXDurSUDTn59ULfdmgHPLXtohWhmmSanyoYB85daV5XZMmCWJ+7dK0cG+DsaS044MWCfdkZUqzOuW3k58o0LA24+VN0R4coAvguhL03csJ56h5IeoAvqbInJSwz46dV3qcybATPBa8tyfBjwMrMucKUvA1qekJL60Z/Vj609/Bgw1mm0bRHd6RIWGO3PANK+mvdT6H3JFOmCAAYINh5NV76Mff+TtHCeyIAd4WFCrkwG+FTMZH9C1xTX6ReysK98E6xkNgN0az4263EYID+zc3oRFb9uF3M7kAFnqgaPdAfha2pBzFQEA8wUHKdSIxmwbtXDQwpRDEhoqFaoRFX2ZHu4RDNAzUzUoQ71PkX/Nx/DAMcVmSYxsQw49uFVqm0cA662Z4+sSmTAHCH+VgdK2X4oSOMeA3qKN1iHp+Dz7jf1G6UyIEdJlF2J8uemx9qkMSDxsAPvg/sMOMp3ar/cA9y3hcWlVNR4Ony9Wi7m/L7dydo87IdoT5NsPsr3s/4hKuA1z72Amulsvni4AOthej7mF3rjg5ZyUCGu/6sY/6UiBvyDbSqUYgYYfbkVMlWJ+W1z6idVMeBv3Rt4im6yOWTnVc2AwyuvTcjW4PvGtDfKtQw4Vemono0myxSflKpjQP/7295e6OkgTkof+tdcpIP6Evs7qF8k3I75Sm/cfb2DAQrHYtKmO7Gf1P1/WrsYUJUR42DWjftjKz5IRUefJCXa9DBA+ubbr2lozKETyluHMA93R1LT0K9RN2VfDDPAimDQ5fER8/hse73dJ+yTqYFACRo2092rNcmATtHi2ntoOH/kG48pvL9Pd/UCWsr4VXF3Gq8LaJbpR1XWyF2wmGWA6+1ENf05BhTdilh8vcwA1ZA27yguJhxZcXDnCW4maP6o+LOahwleFtfqTHmZ0B5cxTLjY8Jprh2bvgkyQVlvJLlDhAmm61dE7FzDBD4W54KCKBNir+UY64oxgTlTc6IcBb9fv9eLM+HBfJ5KKSqes2OvpgQThEpKyk5KMmFHVVyX5HomuCZu7xGXYcLNtMi1BPSnnIboDlkm5CqnWQrLMSFL9g08RItOhq1XkmfCIkUi9h26I0VYz0eBCaFbfsUXonEcfSdrRSYM2czk6Kgx4ekJ7oVfqPq5mxnG6vj8zfyQh/bFvRqU1WDCE1P/N0XomOeLCyKaeN/G5XdRaLid1hxHiwmeFqzT3tpMyCCeEzmqywTqtrA/H1HZ06MrJYAJktwO2l7oUMVmSg1aw3au2KfHBPm+h2rVqHfprTe79Jmw3iNciNuACX+/W6uOo2u488h8Fkw4/I7e8AklqIwJF1tiHZdXG8lb4ToCNO+Eot+i+a7+QgMXTz4Ls2bCmZzg51I2TNhjts5W0Bbrcl5z4QyqOpx61tER73dcTbzRiQkHv2xr1nZmQl3pyn5lF1yP5KaVUSgPv4qrrCsTBj7UTaWiDT2ObWOo5KO+S9o+WJ/UgVUafkywsjIwnkMLI/Vqh/2Z0F2dc4gcwITOqvrz82hVw5PP1y9jf8V16H/RtXIlAq0MJpS9azP2ZzGh1lk7RYWN+8r8u6MSlffefNadw4TqjBW/X6ERKxTsmwKxLz37Vc8EMWHcIH5tWQT24VoMb3kkE9hGii5bojAX7vek+KKZsPJvY0MEOsG9bDWA3tSfO3cihglRHJpdeizmyd+yWzyOCVc1bNQ80F/K3zRa7jHB1oCe6JbChPwjpmPfULfk2YljqZjntetN/NOY8Pu0cbjzfSY0mxyTN3/AhAMrL2bfR9dLnlix7yGuY+q71nQOE0T+BbVsy2OCPn8mXzv66zBhKTafCf7ntp6ULmDCcbKIsy96XlpmfRE6s/DU82QhE17L3V4nXsSEG4XW6eloxqbs/nXFTEjwLTC6iX6jRzcLlzAhSHto8EklEySejP+drmLCPP9f28s1THi7fzvPrlo8d2Tu7OI6Juzk5yo2fckEGUPTarUWJtR3y9Hr25mg95FPMq6DCdkVxY5+nUwYfC+7076LCWGeFqdq0DfaiytWdjNBxe4k0QSdP51km4V+uedzS6KHCRwxU7V4VFeoyDbgHeZWSFynZQD7aHbMt/QDE2xMhFLZg0ygpcXbqQ3hufDry6hECySaGmOHmaDmavXm5EfcV92r4g/oCPcW/iOfMUcjj47tGmfC53YRT/Yk5tRHbGDnFObyWUTLCBpheIjGmWZCGzHnl8oM1vVd1vOf6PmE8CuXZjGPN1d+M5tjgvSKOvve30xg+Nz5vJmLBYXHFjjuKPfNKwJ16P4e0iEVbhZ8d79TFYNuKP9zuQr9A6uVpHlYUH5px806XhY8vZggsIqfBQ9u7Ax9ixp9DnlZJ8AC49vPmyUFWdB/VH6Qg14wWZm4R4gFNedf255GvYPKWjPXsCDbLsWjEm0rN+yeRVVPm8zsEmUBX8WA2Ul0n4AMcwTNN9N8qiTGguf29sZh6B0vDZ1N4iwIeXUnux59OTZ1mrWeBau1E1I60bClj30rpVhgMp660gSVoTZ/K0ajX/1dvW4DC+dfV5AlWrDyxJ9ItHhzSX0Dmq/ezecvzYL49QRjZxlcVx3+a4iWmAl5dKO3/4nFbZVlwXHztdMn0FVdj2lV6IZe54tWciz4mRp//zN689c5fvJWFsQ6vWsR2s4C+S0m0Vqo5zPraVf0cgbNLwE9QQk+2Yeu2flzy29UunSw5uQO3NfF/mOD6BnyLZFNyiz8f5UrsEUN1xfwJVlJnQU99kvhY+jvIwM5KhosWLB4eOAkqntZJzEdjecx6vqHdlP6y801WVAX5VBRsRffF7T88x6NNgkNk9iHff8sR/REP5hIxWWj1mtDz63bzwKRKTnZCyj9r13QOOoo6puqeIAFvX/CPPXR+ZxhBgGt+b7g3qTLgtaKo48EAPsunfrGEg0wf03IQR8OafNx6WE+HBJnjqCTlU/9ElCLsg8mc+j6TdHHDuuz4GTOxx+d6NNjGf4PTVgwUq48MoDuySWulDrCgnePNK5yUFOhEJKQKQtsv+qLOqEyEm7dpajmf//WLaKxd0T9dI6yYOnM4sR2CxbEjS8Jl6FfEtya9S1Z8OpOaFcoOhjvJVSFqm80ubSEZs092OtkxYK0lLn33ehBSRk9I2sWXPyyVz0YdVx9vev8CRbcPVBKy0cPn7bskDqJfWm9tI+CevZKaFeiuaHrav6gZfrdtaKncF9PtOfr0V9CDz+tOs2C8C3GCRao6MWF60+cWHAg98iTFc4ssAnO9XNAV4y+2zKADiQrju12YUGRxbAaGYVuQe1y1FFo30CdBwuEp8Sfz6Mpa6wCjp3Hddp+23wVDbKJGCpAl5IHFeU9WUCkHuGKR1ljDVzV6E3W862f0d6hlJX/fFjgEHFJ87QvC9a+tp17hW6y1Vy90g+fH392awj6QmXL/Rw0RJTcJOzPAoXebe77UbvFaCUlIgvay335/NE4OFgjSGLBygPT0RfRLosPWpWoxjZTa34yC8Sad17Yhz7qLx69hS6an77BQ8HrBXi45VHJX8Gf55gs+Bj9rVKSxYKNfXeGXdFFXgvVGNRg+djSVzRm/0ryHjYLqvT7WpjoiKBP9RQalEEzO8jBcyV61Yp0DetLZYfXX2eB1HxtxbVgzFXb/pZfKOug/3PPEKz38ZbGG2iEa/jSh0jM5SaN6qYoFmw/zNiuHI3n0W8bbX8MCzg27/6du80Cccob/38o+f69UoV43IeGaupVNH8He+4duvtz7C6BRBYc07Mjn7iH/Wqt9LuFSnkdft6AHlbS+LyE7v2j92xHCgtq31S8Dkb7X4Rf/4L6n/aZlU/F/Hg7RF5CjXXLDdpRd5t3LvxpuL4N35dNUInB+9lBj1hwLu5wM3cGnovz7/6wUJ9TOV/eo5TFz7uFM1mg9+mGggt6zfqDUQLK08492Yfetf8qLpzFgtMv3rx3QTMTeRIpqARZ62ByHl6/t+9WDfpo8X3+PJppumfoZD6eB8UR9VD0aXNA6SOUtLLHehQNkwkJOV2Acya5dF0uKvl4S9AU+n3Y5odtIe6bx739KXpAhsvi7FOc27O/MxvQJSXhPYalLHD12n2xHHWe4nE5UsaCbTE+pRnoS+EfHaOoz5JZvMkzFlQ4/VzXi6r8/lV5vxLzddTW6jVaGzpdrFHFguUOy7pkVHgu781XNH22cd/Javyd4oK5ejTa/nsypYYFz5oUUl0bMHcOTekP0G3Lt7++QZP0r4QIN+K8J/YmKaIbWrjF01CqHd+wQBMLGq88nTdF/7mPSsejOyRCtsygN/QpEfR2rMtb4rHH6A/L4LktHVgvsWOBiegZY7ejX///Wo3nuUUnC/zq60jmXSxImLxNY77Buaz49cSqPsxzZZSpCzq0WFEXifJqjQe1oebJJf1c/djPQwNTHPR3TIpxA/rqyeLdrW/xeyXWBlGDLFBjvlyhMcQC2lPpnTfQC05uqVuHcZ7zX0w4iTbt/Kj5HPU+qbha6CMLjlTrHHBGFT64DVd9YcFVfqO5HSOYj7i1PYyvLBjm6LntHsXfOZ27mx6iDo90ndvQfRdGdRW+4e+U+78rMWivxVT2bzTuyGFN2zFch5R2fuwkC7y+l8o+RV+0F3lyT7FAbkiEtQXdKqzS6YuKn6ffeIHmupiPDaPvFX8FSU6zYNdao1MU1PaxxolkVFVhllWPLha+XFg3g/UKyvho/psFs/ZdBDYakcjDXYzqStl3vkHJo1lnZebxd23Cvd8SvVq6FByBis/cc1lAbaZWUvf+wdy+zThsidbdEjlXjnJIZlOj6L0HOVNhyzjfysraq1GPiMnz8lxs8E4NJDmgJ1951N9D39xwevkP3VKzwDTnZsNKPyFmPMrFPRQjwMMGm1un6EH8bIBVhKb76FHDayYf0cYvvJ/2CLAhOiHkUyXa+NJV6bQgG4J+LtRHo8x/22XXCrFBw9a09ewaNrQ6yxjeQj0eCWpWoDuf17AX0fe8U18URdlwrJ/42gFVmpXrfIl+fZnDOSzGhj1LursG0cxH3eWm4myImXVnPV3PBhetJYkJ9D+yqZyZFBucR+b9SlA5S61Osw1ssD8QqcxAr3yJDhpA36inamhtZIMT6w73pAwb7qRtuukui/vpvO0VhlJ0EpSq0azdsZlr5dhAzrxZ/wDdv0b27FZ5NphvG/pwAW2wkOyJQf+8rHqvto0N94zqmxPQJsHvAV9Qsd9pVOHtbLhQzAE7tC723p4sdOtmVrbtDjaEicuHh6INuR1yT9EzW12+iyuzobRR71kAejeBueoRunjgoAtbjQ0bXj0N+owW/me5YKHOhhnt46aV6NWKnmdLKFF7OcdAgw3Gxztu3EFD9QjDJpr4frq9Chn9Hm/3ZBxNLq8ykdViQ35QyZDSXjYEvLQsS0K3Vc81vEQtHJXmN+5jg1eMY8g31H7LyZ5t+9nwIbU51wc1En95MQvtbOa4TqMxr2Wnfhxgg0OJvWOALhvotuG6dWjNZq2PM+il4gAWAdhgkKFTXYm+mmkNUdRjQ7EYTzQL/WB3bfoB6vbv28ASmpa14n66Ce5f8/vDbpR/T2Ws2hHsU9J6Ixf0Uf2N3GL001JDyW+01dRESsGUDTnhqy7ZogWZvBuvotQ1axmD6EWtvOMGR9kwXjLUKGvBhmvt9p7XUamj7aMrLdnwr/TE/iDU9gX/u27068DJDgUrNqzaJWfRiR45HLbH1Bpzdal/xP0EG0SCC6oXUQbrsrLSSVzHCiObeJR/S9HRIdRrjCdL9hQbXv5iqpaggp/vjkyhW/tlGg+fZgOp6+bdJpRfQ5AV6IT5Z8uvr0fnrnxcOYJuTb6go+PMht9TykEcdG+d58QLdO0W0yFeF3zfbYvmPjTx89g+b3RE4WhsC7r92XyAtCvu4/ZctRma00Ie0PqPDWc9e7lHPdhw47eYgM15Nkz1qjLPoTMR+3VeoK4/K8O3eLIhNdrW3wHdM5gmEvN/b+hKr7zAhh81pr8t0LnVLOfLaMcM9/wrH5wP3HsUT/uyYempKbkLZSp6aW32Y8OTJnsRI/RrQecIGT1sefRTKqpy9vDlebTmybcVu4lsCFx1rrsPHauLejuPhht8JziR2BB7VWLpE/pUZI+7MBnnhoyvogv6LvXEPQaq/Vo7YAH1WukWqE/B53Avmcwy2VBUvSJEn4Xne/c3fQI67jozMYHuLr8XsZuN69DJ+eKNqnQ81J1A/Suntm3hsKFebPS7Hmpw92gLAbUv67jbfQ3nnMJwjst1rGfQ/KqfaGWEncDFYJxP4y3PKtCHHXaZQ2i3W3aHaAjOm+P+5wlofqzQmTx0a1u10+obbFB7XKtkhl7k79sUgyZxijpsQ9kgERCbGRTJhufqVh8m0e/zRTuPR2Eegh7L30VvbdZ89w1NHkjXUo5mg3tl2WtfVFbL8+VntEbd6KJ/DBsc33P4XePY0DWx3+3ubZwX1V4wh7IOeCauisc5tvWb10n01faPcw9Rhtvd69Posg1B2CYB15XxpnQa3VcjsmCYiHO7/El1LZrfJOoyeI8NMkZy5KYUNgwHJnySS2VDWdNG35PowKBUUwR6S3fHmkq0hriXrZDGhukonV4r1EPB/TITvZv9PSb0ERt8J+Q7mtBXHVp8whk4t4fvvOGgEWy3Px3o3bsaffqZbOC7tfNuMPq9sS7iMbp1obv3G2otv1H0fh66kzD4Fz0O0nPsfDaYWPu4PUHbeuWLP6EViXf3iBXgnO47yH0M/WXZeT4WPSjHcOhAhdrEhI4UsmF+yoRGRfdrU76nPmXDfZFXWWqlOP9EH1Gp6DDtllwNahJ8/s+eMpxP1VbxXmiTo+W+FvTBRztN2Wd4rpxWt1qibhU3xrzRR0drD1Eq2WDp7WH3CA2VSWvTqsIcazFe+KCOJ1m6A+jOr1yzf9HKe2LXdavxHJSqsy6jbme/Oj5GM2dFRfpRIlfRqw01bPAbyhI50MAG+YDx0VjU48QpHd5GXOeXzYeNURvvwqYI1O7EwoNyVJNrPf8U6nf0IS9vE87JmsB7u9EV4T6Zaaic1Z73xs24v9QS0RPtWCf+6IxJ1EO7bWZ3B+6jJ/ItBWVuX1q4g9rH2bus6MS/D8bM/4Sj/PyHorPe4HyrSBL/gMaEjptv6mODslkF2x8tPiQAOahDZOBRoX78vdulcdsMfSX6xj0MVejI2zCNRlc2/rJ7y4ZvDcZMn0Gsq/226ddoQN9Rpu8Qztc/anczUSKZpjWJOnmaKqgO47xKW+t1G/1xYGjq4Ec2PM6XXMwbwXPOW1vi+RXzaDyl+gCt7PHZ1omCydBn2VE2KDamaIejAw91E9+g+36enub7xoZd9kJehujHAit910n8/VB8lXsDTW3reqQ2xYafGRvyHqP+RV0+f9HrEy1jGtNs2EybVaWiAQd+5TxA193jk+pAgxdpm8xmsC+VL1c6/8Z5KehwJw0ViZI9P4J+fvBNfsc8zq16pUt+6KLziGI1Wjha93AZ9WsO77H8g+c6Z+lhN+r+XCfrJ7pu8gxJfoENLT3fDpqgKk75DBZqNBz87tkyG9h7uI2UuDggdD2J1Yr6LSwd/Ye6Vn9LPcTNATU2K+UKquOvvqMclTz8xOA3Os68PrCLhwOUYWqgFao7NaDewM+BLGmes9ICHDghqcTNQmUHY0u/oR7n20aOC3Lg5g7Vi0lojNCuFw1ogQpt5hfq1xccpS3EgVOJJ5+6opbzbclmaziQr2sRno6eXX9JRVqUA02a1Q8NULPujWHX0Gj3yI4RVCdTaIuMGAfqNzKveKLRz8vvNaIXv49F/lvPgZzVzr07pXC9t+YMAlE7s2TXLNRZZ42H5AYOFBHcflijk/9KCqvQl19u0Ndu5oAKb9yHWhkOHJwfJ/DIcmAmX+rBWfTWh328cWhwTAexDd21OvGHiBwHQnnOi59E1ZtHFcJQXX3XD33oQHp+krgCB7puvy3bup0DvDvusqLQhV9nxH+hkjQNC40dHHgbRfGMQ/8Zz+7rQyO2F+pKKHPgT0DLHW+U8U1b858aB64YHGs1UOdA+Jmv4zGoie75kgl07/KlfQc0OOCwdjkhDE17VfSwEI1Tclnk0+SA50orLl3UMqOxTHAfB5QP2kvFoK67zzN7UDP5ni1a+zlg49M2GYzWi77meoGmLTdZ/kWt1WhShw9w4Gn1/tQUXQ5w/lVtWAEckIkryQ9CZzZee9uI5kgLTG/V48BrkdTrNPRd0bXnxeiGs38N59GC/Xsu6ulzIInl9jrChAN5Q/cWBI5wYM9MhlkcuoHFjj9qin1pXROcgZ6JO5s0g7Lb7hdIH8X+vu0oMkXPpqnM8pphzoz1pldY4jrEqoe00UZtdaVAtOher+1TVLY/J1bIigNtLnUdl9EB/UdX29A471evBKw5kPzP7o4Guuro33tUNIK25CZ6ggNHSbcUnqI9UbOw6iT2y4H6IA/13hzH8x7dfPmQ86pTHHCUZ6wgo/q3DfYPo3qf877KnObAi0jTSi5nDhSW+UtYo0kTIvsj0Pd+hmLPUI+9dbu+oiFCLW5bXLAv8TuXzqGTN5rWzqIq5Vs3HHHFvLqv9NjnwYHD1TsjL6IXJrcqpaHKZuaTU+ifdy+ztp/ngFjnOsUEtJUVqTCIGh6iddt64rp6Yr2o6DsBws189MjY5r1+FzjQfsh6fS16ZeKmpJ8P9q2ryW8WTZfwr1X35cB8vvcPK9RRVlSG248D117kWf2HFp6SkKxGN0y+pmj7c8BF7qOkL5ED62vrGsZRc63BXQYkDgQ5JfcGornGyidb0K307f2qZA7w69Qed0QniEkG8eiWqXfG+WhYaFWDMoUDBx7rcfujeoO7l48ysa97W8fr0PSuL7OqLA7s3PE1h4iuDPHd8gndFsMTqMTGcxOrvisXFW1K0z3C4UAU2U0jBRUNzNi1OpgDShsbD2xD9bmyHqajsObyZ8EQvL9F2trD6Hi3p3MDem6l3x3VGxz4+KVr0Qn9E37js1ck5ltf8H0G2rH/SdMoOqLyrf1QFAfWLq+tikP1XUxfD6Gmd972aUdzoGW1dqU3apl7bmM32u394tz2GA5Y8LkabY/Hvh4+ddoa9R7cm7w3AeeR1JByC0rgXH+1J4UDdd6bF53RFser1nH/fx0WMi2cyoHtO37oHEI/njA82YN2SWZxVNJwDopMaDAeccBN6PePOnRU93HmElq2SufvoQysvxqP7R20/L/bKxbRtycaOv/LxJzwqF6qRX3PWNfyZ+G5EYs6dQjt7BXTvohyseOMxB5zYHGwxsk0jwO2sfahA+g90fGKLfkc+B0nonAalbJq/L2hANcvnKvlj4alSZPq0G1aDc/kC/F8Z+/bW/cU56WNJb9RKQe+2TcXXEL/Hl95hK8M66BNWDqJusr4htxGuUrqizrRRo/kJLtnqDtXzeFKDtyRXdfdjz7htinRrsLz2d9W74her/uX9gDNFJuY5KvmAO2FpYALun/Llu/tDTgvB3jrzjRyoOreVFwD2qb+c90vdMn0pEhIEwd8/mXsS23mgKZ8nP2bdg5ovWYXGXRwoORB0R1/9LqkRSl/JwcGI/NkDqNaXGa+59H2vuhvj9BA7eBD8+iaHP9ahy4OrFunsBTxBufVlfyd1eiXk4aBP9FkCas4nz6sz4dD2nnooOBBh0P9mKPOA4sFqNC1UwNz6IPDUkrH3mIdTOY12wdxLvNKhuwY4oDghnnDKDQ+q/TAFLrn2ZjP4WEOVKTrLt9B50M/X/+BMktu7dL6iDlPTGPZo3+jvuQlf8XXxm92jKMJ/7Rz1UYxJ1cl5y+gxHoYf4QKnL+z5geqFZWmwPeNAz/td9oeQvOiTA/GoenuutZf0c5P1xJPjGE/Jj8walDOxyHn8EkO7H71361FtLHLs0JnigPupYMhwWjInbqLItMceCj+4uIVVMgo7e7/KK7vcCzfNg7gaBiliAqVUMmolE2qk/QTqayEFg0rFaWsBp69rJY2GkhCy2gYpVBW016VaBJFIu/3/etzPPc8r3Nc9/EUwLkv2QXjfkZTpUL8rgj4OcjK5EE/4l245cv3gWj68uzbW63BaHrfOncuF071G+4e/wd5XTPw3BJ+3DX+KQO+L9KT2DGE/jo8Whk1iu+9ZIORhhiDHl+pnRYGVQtUh5Lgf6VqT9rhN8nKzWvFGVSlWr/yDbSVKVN2l2DQq7xmzSjI8vJNugXfuFTNE0kyKMJ0i/V7qLeAcVhFikEaHnN6eXCRRm3mANyxWWQ+Q5pB/x5P9VgBw82OjDsOvXqXHayCZk8XGO6SwX2uUaHXYGw/p+riZAYtkTNUUZBj0Ft7+/n+cOzhCMlkmB498dQr+Kzur+4EeQbp1AzN9IOb5tgl1MFtrG05y6cwyHvxAved0PYfXRFNZ5BM4GPjFjjTR6FQWYlBX9e5pG2C7Pt+oyfhWT+Fl53w7flsE19lBvmoSNhnw15da3crFTz/B92Mms0gXkFKTAE8r5y/QlKNQYPj3w2shVsET19dgxUzfkUPweAX3ccM1JEfHdm14dDJJYH5GOaW6up0wKfaK8dbaDDokuvWCYbzGST9VTrLHmrcW8d5BJkn41xnazFoutejeY4wsi5ymghaj5affwB3SF579A/Wlc34sF2bQTvfKNknwZn8XdM1dRjkzHn0Y7YegyTMd/dy4VubWZK/oXXy9kDdxQwKKI+x8oDTDCZtklqC99vI9C2BPlXThQy448ccu3JoWxTju1SfQe9nJ6fZmDDI2HneiS9w83Z/z5WmDCoL91jbBFc6PDXWNmNQsoGsUzyMXzm9ZaI5g763vkpygjceXtuqvJRBukmTFgUQ+m5K3MQByOsaE7LYkkGa3t/W+kDTNx7z0qDZv7bU4NXIc3FcUAvseqx+PM2WQUvnzHRogcvm1X7xtmOQ4bRPJ5/CAbuMuf7rGXT7zvnBm9CgZ/lERQcGWU26NG4XPGD5wSgGunU7SLY7/P/5ikekHRkkdbt13EkYLt95vxsyfj1eOMkJ72ugwA0w5J21AWcjgwpnvRo70w3H6xrnH4L74sfq3IAb5r4tbYOGTSsGFN0ZdPTkYQYLKlSIdl2AaTXdAV3wpeLuM6s9GJS0fcPj4m0MuhvTL/EXbnF8FeXiiT4uDTn6Gl6fMedXiheDWl22f+qE59/s7JfZzqDXNz76DcMw5ZvPnvgw6KrdT0NVXwbtP6Hl4A09TT8pnoBiMRPfzPJj0OzeGJV+uCIsx9LKH/VR0vrJhWPdQ9J1Axnk4DI7Ohie8UozWB6EPv2v6FMjXLPVs3YYcs4plHTtZ9DuiZvHJYUw6PT43o6doejL1DXxsXC60ouFhmEMerA0vT0Mfn7m1tsO2efdbouOMWhC6mJdz0j0k83qDafhjSITjS6oEtrzzCIK+XCiP5OiGVRt5TqRB41lgqY9jf7/c1KeOHAZ1Gdir3UfGn0KF1nzGHStdGfTJXj8Y0faKj6D/l4L7dwPb8/fPO4ijNypw3wHXzMyIz/GMsjV6dpC3TgG1R/yKLkL42MPiGnHM2jicaMDV6CEydmbw7B9qt0OSmDQBblhjsNpBk19ZC48C03NAkoq4dPVXg0dkP3Ac+yCRAYt/2a6KALqf1awfwHfXDR3nnWGQRmq6arO8L5uzF8urBrzK+4PlGXa7LiYhHi7+Kn1UPan+Q/jZAad3PnCKBSaOOksfAQ3nn5TNwytE05nr0/BPH9cp2+XivmqSrf8Bg+/UBlMT2NQpbmg5yN8dkDgpZKO/fiXlUUFrM+LyFW8jv782/lzYRb6u+z4yIxs7F/PWLuPQJ9tDYtL4M6rP6Wscxj0c6Xnb4lbiGf/7p2L4dVHp1Vm56Fvr+Vt2QEvTh64nQCL47qm1cKVSX9HZuZjXznz0XcDrPpj/qQSlj7evkK8gEGZMSbWL2BlgefGq48YlFK+STyrENeVDJ9rhaKwkIOzixi0tS1pXiycV99tMbYY++6so19XwKrE7uQj8P7wHc8e6J26ZrJqCfaL2m7H9fDlu4jEm1CaV2Ed+Qxz9zq4qB6+e2keJlWG/UDc7dhMmDj/a0g3XCn+bv38cvSnjKKJC+zWst0XAa/39935Bj+E3fVQrmDQLovj/kXVyGdy8e0+aOJr+F2thkFFhzJdqmHerKjbqrXYT56Kq16BUe9rH3RC7XfpVwLe4fk204tKYcNp55D9dQyKK5Kd8woejA9RlK3HuqTktf3ghEfrns5twNydK9ztDy0ZctPWtiJfT9c66bbhOaI1e0Lg3H18jy7YdG9wx7x21PXZY72NcOXEU49uQcvVey80QI8fJZdUOxi01zrzazCcr9pjc+sTgzq7Y/N3dTFo+Mrf9myYouQn3QJ11L95y3ajDjL/5tjCtoWjOhqfsW9e/inYCd1b38SZ9uC+WU3vCuDk8oQbQ1CX+cvqWC/Ov2h7aviTQY6ufduPwK6QlQcEAwwaNclfGjjIoHG8U8N3YbmN1OVWGBkRLpj8B/VRODKyGlY5bjd5CPsrW1ZoDGGeM8+xvaHB280CMTEm1VH5mz1QJzPf+gHcqcQamCjOpOlByplHYIH6qeuVsHHKs9XjJZjUGWjssgQGFY5ZeUySSZe9rryqhIUnv71cKsUk56kD5A/PsUum5EHbgAk2k6WZNMtg7N//4FiP3IlMqNrc23Qfapq1th+VYRJ3oadLMfw91iDYSI5Ju1vu6znBB34p5iryTGo9Z5/sBjevetCUAY8+Fi1thB3ixz3cpzDpsCRP9zAM9KqvDJnOpJUDrw8VQv97mmJzlZj0VpG16T/4a1pu4DXYM2DR0gPD1MtPr1Fm0swnH9SPwYI5HLcX8OH0KLeO2Uw6U7BPfZUakxh3/5UnwgBZH21xdSax27bdCIKS3qzzpfCzxfa/L+czqexmou8ELSaN6zc5sRVG5vLN66BeYkDxBG0mTZgVaHgeGgjP5I1Ct3cV/nZ6TJpcXOnSA/P7d1dvX8wklV3PvOWXMGnLQFORK6z+d8UmA44PevdrGAbriGrU9Zl0z0TiiSk8EJaj6gif6x5j+ZpgvcmVv91MmdScmdr1A5b+7Vu6yAzrSOha5AmlYu7aFsHT2UEG8uaIy/OD1iGoLbj4deIKJoVfu+LhB598n+juQUzKU4zLuAD7j6kkPoIlEyLluqFL6uq4TZZMSj3Y5FkIbdPbFWdbMUn2tHbTStju8k6+CR55OFbvsA3ybizVngMX9Nan2a5mksf6k5KHYbHqspPVMMDcoUHDlkl9Gcp7ouByOSNXkR2TnPbWX76zHutP/xYldEC+DkQck3ZkklHAE70tsGpX5dZk6C2hFXIXKhTsKPsCt8Zucw9zQh3vjDmxfyOuO5+x7DTcvZI5ZaYbk56W9x08B8Pts1Uk3Jl0vmnulX1wzuLf6wrg0qqc7nbIMLxc/ciDST7e+WZinjifNHmiM5Qr+XgnALboFDfEwu5feVY3oPlCn/IKKJs84aqyF5OW5C5+7QQ31Af1HIIRNclKL2DdPJeTA3DuXt94ni/qId51tx0Wnr/w/qAf5uPXh2uDME52WnK8P5OYswJezgnEb7vrewPg7uW/1cthyoRZnlOCmLQ2XV4tBLI+JCWVwNm/Py+esB/1Upt7yywU/WFy4EcgTEsM2J4Kr50ySvoK30s1xESEMWmHeWFLI3yyLVkkHY7jltWTBDBt8qfQ2GNM4g3eXNwJm5bUjZ8XyaT4X6a5YVCMGXF5fBTiENsZsBLG7zu97Rh8++xE7EO40PvFjfeQtUkz+EI0k6L9/35/zkEd7XUuW3OZFLUlsykKRkxR/5gHl6m4MubzMB97K+96w8H37tbFcP2o1/NRWKDSoXSBz6RpGwcXj4/DPpG1UnwDnMXw6E6Dls3lZj/hB0f3Sv149KFB2fbd0KYr7qVMApMmxVRbT0lkUva3+e3roC1zXt4dKO7Q9j7sDOJT4b57Cq/6rlh27xKT9k1ze6KYhH0rds1IIZw2jeuimIz+84yIM4YJM9dJZcJZSwYOz0lh0rr123fuhIqrXXVaofJCWTm9NCbdlvy0+zp0bmHbD0FJM3LXT8ccybKMA+CpYZuSR9C7YaLRwetMuhHkMvVSFtZvEh9inM2kPV988s7Aj6saLr+AOl/HVorlYJ8zUurQhVkfx+U5w9gdVW8fQPmBxRu1biGuyJ+LfeC9LLMPNfeY9Ej0bWlTLt6rolU2O49Ji0WD862hlqJ4VyhM5db/boOVvSPzJ+Uz6Xrkti2HYM/mSQEpcJcgo/sh9FeYNdmlgElreoxOZsMvB+8Ej0DNkV+BDYWo19XH4pOKcF2dd5Ub3OazwSITtrxSKO6G35++ohPFmO9aOd4QvD/p0etHJUwyvXtyUdpjJr2KVlihV8akKxnJPqfgvf6Lb6rgaUunhcNwldodVa1yJh1ymPzdBQ5fux57Hq4zserphPU1J+rnVzBJP0usaUkNk2Lu1B72+79HH5YmwtJOk1VZ0LQxbGMZ/Brs36lWy6RvW0/dPw5LDtrk/IUXh8vP1L1k0k+nBBXXOsQfoKx+HUbbdm/oh5MKm3W967GvHUs8lwr9Znh8kGxgUsWLSd+XwIGjYuI8GMlV6CiFHZu25s9vRR65DerPoXWhGtOhjUnH79RP+gDjmSqxiu1M+uHm9dgBBu+bsO84nBRe7doM37EaG5d3YJ9432ah2MWkXL7FJh586q7jO7ubSeWnnU+bQhmHVoON0Phbl1EiPOUi+akTxp1pHhf5GXk8l3vY/geTMgtcclb14Dv2ZvKEV/CpWI2iYi+TkgceflkOJWWEjr5Q1Le0OAFKh+4+0A7fKHe3nfqJ+//WWD0awD4/RsxMcxC/Z4lVx0FuhKf0MJSdGWrm9Of/x581/4Tbbn2883IU+dsmQ15iLOpuOj7jIRxvfrB3njiLVn01Lr0Bby5ML/sB++0Gji2VYJHunbmZtyRZFOex6aWrFIvEW+2fXIXnbu8JmyTNouNeMW320Fv58+p4OO9zpfcXePh2ZPNWGRYt1fm3zWMyi469k5zzGDq+jczSlWNRw+eyXTvhhjqnRgV5FgmDd/DXwvkmlsVsWBKUr/8D7rDJsVs9hUUXz9vJx09n0dHRnm+v4JjO3DGGSixqvxivyoXcX0kVddDSeGDWXGUWLfJfrO4AwyaE+rHhcP1J789QR3ZB2yoVFmW/zjTeMJtFoeOUff2h12s9+RSYGiVpUQdZ5+32TlJjkcHe5xmukKuddyMTXs6qn6CmzqK8yoKUIKg+eiGjBFaxYi0sNRC3j9j22vksKhtJnBWlhfWZLO2ugvyAbG1VbRadtssIc4MNpYyXETCkZGp5FpygOZn7D37MrB410WHRrbWrow7qschs1Pd9I/z9qHzRzMUs2vXjTWcFrE8fIzcCs12ez2AtYVGt9owFebDE5o7qH5gs/3nVIn3EJZaYJWbKoksl677thFPCxYbT4JN4y8eDsPhS0wIXMxadeDld4RLMm3CppBo+Sn676KU5i/a0zjhwbQXy1FPsOoFYdKis6o0jPOf3L7IDjtxg+P5nyaJvBm0FKXD18TFrpK1YREIdvUaYpb8yus+GRcZ6mg2xq1nUpDzu0BuY2SGdPsMW8VU9W+IFhfd27LwJX3JL1Iehss2p59p2LLr3bXT5DWgbHHh743oWrXkwXjod6hj1L/VwQBy2/y3gQdP6K4VtMH3Z1EMqjixKa2+b7QmtljyZewEqPAzfMwBzxPSPNW1k0Rt+xYXpbizabP/LyRc27HxfGA/fsM8OSbqz6Lb/+VgL+LtgjclFeD69ePAhjFFx9ZvmwaKo3oEFSXAMcW3iN7PocXpz48Mt6PMyzX1PtqHuw5yPv+CkikJja08WDawwmNEPTbceunLSi0WBmtZTPkOnKRlddtvxPh+BBseXRSvyX1x5AdeZZVr6+LHIprf7ZA+UCJmgLueP5w2Wm9+F9d8Du8wCWTTolvz7BHyx05svHoQ4D8flHYJnd61JuBnCIr+t0qX5oSwy74hjNEPVMB3NlWEs6ik++JgDDVyM/fvhx38uvhqR6MPxO35VQYOHuiNeUSxqyfir7RDNIqPquBlHoNi84KkcDot+TfW/psZlUen8pkVnITMn/eoglBjIO6rJY5GFVtqPLXB8ZsDzV3Ba8IjxOj72F9elT6LgocllbpdjWbQwsLJHOQ55kZ64KgIGnek7Mike/agY9YrgzMrdu4MhvXGcmgM/DLx2b4CsVb0t0gksMlyV3DgPDqd/rPGDJ6e/y7p4mkVyKr9e6yWyaGKAVysD/rM0cOyE/ZM9U5edQd7N7Yd8oa3BrdQMuGNB0nyJs5iv2G1CNbiI1zn3NPTPk5czusQi9wfX1solYd7STr9mwyVTJ92flIz9cfRi4yuo79ehoZ3CooTy0flPoOT609vcU1kUbLje8TZUevvZSCUNdU+PcPGClHpy55h07IerHsdmwbOPtrjUwE3N3e3jrrNo/+tsh3tZLDri1nzCLJtFWkbx6/nw4tgOjRG4LTZ3xvYcFvVd+T0mFcbGi3dV///3omST27nIm3fs33/w0E11iSV5LHpwcM9oHGx8/qf8L3RoTxjelo8+8n3y/Dm0iAnOlitgkWLkMn42vPK+1LOkkEVq0q6vjYpYdP3DPn+pYhZ9Xdkt6QZrJBMm98DEI7JndEuQr8bsnsBn+E5o6dalw6uqUQEby9BvQWf3HofmliNrvsLwlVvyFpXjecF7ejdAlyMp51hQiSbnjKtgUWcn/TgEDTUvHf5RzaKKzbeNV9Tge2Jm/OMELD/4Z8ZbqH1kD9+9FuvhlxwehEzTXo+MOhblvrh9XbKeRRcGLEMI7g+Jkm+G/xk/uKTQwKLosvD9XvBvtnrTpVZ8r/ZXaiq2sahSt7B5J2xwX3mmEd499i3Eu51FRf21Su2ws/e8ibAD9xcNPO7/BC/IdSR2sWjqB4NHDfColvaX3d0suvbVveY61Li/TrHwB74P5k+Kinpw/uyj19TLoi9FBev7YOy8/MSWAXyvLo1huQ2yaLti24/XUPbG0qFFf/D98JsYJoTyqyZt64R22t/X6ouxiRM5v50Li+T2MSphTtXbMgNxNn3vWPQnBw4MnJKYLMEmxy/rdx+Gk2s7a1ZIsen5ow9/hND46ciqOdJsOmC7wH0zVLzM5STCCJ/R1CdQZU7b+8kybMrYETfdCTa2b9b5Tw7XcQws4qFqsM6uVph8xGCysjyb1PbIGibBdXnM+A5ocGLSeqspbPq7PNhgpyKbdlx9V+oynU33w6vTLZXYtF7Gk3Eb2p9/aG+szCb9OUd2XoAM8fObR6FE7lETWzU2nV3qb1UGU48cHTdGnU1SKle3z4T3lDWXp8JxP8zz9TTYJN1lmzhHC3FUKL3ZBTmNX7tLYNGP5wU22mx6LwqIOgalKwycb8D2rrePPsK8Ao0Zk3XYJDIW7uJBNZfxb/r12GT1n61H+mI27fooG9oOf0fSz99wj8Plnr1L2KT+V5F/ER6cOKjZDCWe/o3X0WdTgJJUQLcJm1aJje3zNWWT+QW12VJmbLqY65+7CerL3PougOf/Bdu8hlkt474/XoHn5Dx6IEZs+il1ctdyqH9VTOskNFqyoeknLDjYPUPHEu+JitwcCZVvFSSNwJg28Yz5VmzaOoU/4SaUog2LpVazyXt0as02GNeVplQMaennVjVbNnmcqj8TDIXnJpy1tGPju8KyPQ/nvSvVyIF9PZnMV+vZFNa8M+KxA5sSnNvtxzkiromLg0KgR7OS2gWo1rV55RDMpX09a53YJOlcemVgI5tumR322+uGvGlLKlXDX3UbrWXc0TeT0vhxMPW40dOvkD0ub6qDB5vmXv74jwdTXf5ENm1jk5PBhsvinmzyHZX3fAaPjkmPCPVCn6jpl7ptZ1NX88gYDgyzf9lz3IdN2e/nOJv5smn56pMlwTA/OKPlJWw49vBAlx+bTnzP6yvdxybLjpgLNoFsmt54v7UZrlpUdcs4CM9ZNtNVCMPLbJc0Qdev2Y20n01j4ibfz4PxkzcNFYew6dpmhpJdKPqq5UYhBy5xnbLcNQzzFT/R6hiMt5wx5wGcGbJrTBvkC+Q2mYRj7oY+mH86xqab7+Zf2xeJ51/8ej8DfuO6WGlGsanuzRYbN/jY6+jPG/BWhz6rG55LcNjYEM0mzRPtR15ykMcVH8ymc9k0v2qu7SmYGhTX9hHqe36PsuWxaYLcn0VKfDa5J4QNXYN/FhRfdo5l0zJDCRoXh3Ue8nGOgEVflZWXx7NpcdGtK+eg+1LP7T4JbFrzNlI+LBHzuithZw6cZFHcOQqnBA5IWZxh006FvOBDcFX7Z/lJZ9l0LG2D7it4X0/tU9Yl9Ef1hhzvJDaJqXx+fA7uy9tO3fB6DLfPMBl1LZ85uxbuN/izVjwF+1Q6z9kNKkT/vfo6lU0m6eOfRKex6TLx9pdDrwfpv3XTsf981noTAd8abWrxuI48+zkte5qFuY8fLvgHb8/cOXZfNps+eo5R6IS+dOT3zBw28dR21R2BWxf9FHyCRtOsFA1vselQ4P3Pdbl47sdnOTZ5yMOkLcq58J7KzpE5+Wx6GHpt9xV4/nirsXwB9q3BdakBUKZiWXo6JPkZ2Tvus+mfasmV0ELMoZJa494iNtnGBJy7Ae/kjoidKGZTdLfAYgAe3F2hcKGMTWPLvrIb4S6u2+Xj5WxqLrC0fgMd2x1r4mvY5GK0waILnovJWO9Ui/2m7X5zPOxQsTn1DP769G3F2pds2vuY532/jk1XVuzapFDPpgsPBy97wLnzY31OwuOBOd9vw4xnGSvMGrC+zFzdFOh3+4dqFxxhBCeltLJpqcTiNE4b+pkj5lEH5dpIW6MddXO41hoGZympxGTA9TWGJm4dqIu51OmIT2yyqxNzn9bFpoUZY+TXwraQUv4NKN5mayzXzabNFWtko2FVXW/ybbh0/+DAR1g8cfqk4s9s6t05z1qhh01DUXZLOfC9y/2efKgzkHPzD4zyV/ik2Yv9y/xZUii8N1je+wRuiit9/RN6KZupqQyySXv3Qt/T0H3+tPv/4KHDR5OV/yCvpwLE8yGpPVuvNIT91ba/VUaMQ5qvGC7rIW2Q8fsMD7ya1mctziEr/c78s1BRtieBK8GhRy4Zl8aP4VCWhd/0eCkOVZ/IeGEozSF1Ne1V+2HfmTtan+GM019yBuU4tKBhzHcLeQ6dCB6eGQXTvcKKcuH02e5RgikcGnacprNHiUNHmj9pdMAbCnUtasoc+ngrv5wN85z15z2EOxOjJL9CV8V/CstVOKSiojvzLBwMGI5qg10FO418ZnPIccWngj41Dt30PazmqM4ha2GvGwuqPLErJA0O3RMdUDsBQw+PY9bOxzrCFmt7a3Ho/mxf6wrYOLP81SBseKG1OkGbQ/2Fv/2aoKHJ90ujUNtpU3a8DodGl5Tahy7G+aDLRwrg04RNW+pgvCv1jkCnm1xN/yUcetfUmXoX9o0Rjqroc8h9/Oe+I1BjdvCt+3D87MvHJplySL96Z2wB9F9p1tYL3fYsmaVlxiHv44Z3y6DqydRMtRVYf9KHjkbi0KYP2v2Wlhzyia+IuA2nF09N+QXlODP33bDhkNKs56mvYKGeT9681RxKXZ8x3AvPpl/ikS2Hclev+sKGP5qE415DLwnjt1l2HOJlv53ZBb8U2El4OXCIv1Dw6zRc/O/D9s9QPanytoUjh+Z55Eg1wVftn54vcOKQjOPVTzfgjb7+b7VwXPiq7uluWO/V1blu8P2XdSc3uKMfOn8bBcKZdf7ZTLhshcX1QvjqbOUsOQ/kcwNf5S40bZoR5eXJoQrLZskWuMBop7KRF4c2yn/J9YJ/riz3fABlzzYe/AKfRk+xSN3OIc8MgXonTP9ia1vrw6F9a9wzvHyR77GZn//AEPeRGA0/1Hlh/g4GjNojCpniz6EYx/e2LfuQf2VGwLFArP/nodZyKBXhstYmCMfT1f+GQ9XM07ufwQezrDVn70f/a5B5ewiHEo0W7MgI5VBa/AeHsWEceuzsaLwcxhv9PnkEZv6KSboKfY/+mq0YziEJfuOYBZEcOvQ1c8JhWK6TcPRkFIcGSsq+zY1GnDaHv3RwOORR9umjNpdDfmL73K/C5a2znz6H8j0pRh+hTbjeq2Ae8r5EPvghnBocNGjCxzzdKdARQb250So9sRzqmSr0j47DHBarnLoOBUemb/wOyyoG0mQSOGTWfWZoO1w5Z1GgeSLmJnRzfgtc4acTo3qGQ0FFDkpWsOiWyadD//89Xk//PtzQaD2sfxb1XxbjuSoJ+Xjr0iKbzKG75pOzS+CpTUucF6Vg/RnbSizTsJ/8LE/7BU3jfOIPp+P6jiu712RzSPjFT3gF9nTcfiubg33mluoqU7jtYF64I9R7tvP+OXjXjDfcDOW/rbPWuIW66a7LfJXHoV++Mxb/hJP/sU9uzefQotkvUkrhWe1Nj/QLOCQ57evDh0UckvZLuPMTRjqvrzAt5pD9uRPyG2DDg/b9d+EqjXcu40vQj528B/tgVDnL9GgZ8vVejNME18zSej+nHH1dEVhqA7+Glx88B/dOLHygVoH4BqT++cJrx6pnvYCp4T3CiTXYPzb+yToA2xo9zDLgl0KdAw3wfqvO5+W1mLvw5qlRcMGi1Yat0PDqMQvFl6jvrKw4f3hFtUXuMswvd8lbW4f3erUNn4K1Yv2Wv6FFpGyrXz3qNvrh0QNYPu3iVMUG5N2L7/cTrhZk/x7bxqFA5ri+29BqtLZeuh1zNMN0lyX0ilg8ehaajY0XfoMphiLbmC4OJWg+rKqHurW/iyd2c+jNp4iO9fDZveNlp+BnX/o9/TOHmsUKZtzo4VD0xn93xvViHpeMs9gGJ472+SfCT+1tm8/+5JBD5SzfUpiswNu/eRDv/7ncPBGmLbN5Xwabtoq5/YPua9SlDP9wyGhDpCELXtccl9AL+xIlY5KHUCdDiQUFo5jDGeOZCWJcUp6s0a0mziUdhaemfbA4tLBypQSXgvwfdF6HFpI7SzdLcXHf4d2fYPlfgy3zpLn08M+5K/3wErPSf4cMl76mv77vKcelKqM7X1iwRu9M4UM4a/hF+FR5LmldWsleDYsezJnwB/7ao6b/ZAqXHl12Vl+qxKUtTsxP+fDd823i85S5tGnoxM3r8MHc5Pof0G3tdeXdKlyiiNkuSbO55OfqZbFCjUuB91oN9NS5JLV2yYWTcOBE98BXOOZD/5yVGlySTbtTEwg/98aa7tHi0ivv/85kQZOAiedma3PpYIjTtzBo/9Yi+TFkPHbvEdNB/Pt1H29ZzKXsirXupTCz8T/Wb9j6xHDhuiXIi7OYwm3IaFnwaKo+l5Ji5wuXwX/TDoxxhpfbBjWE8Juper+MAZdOCI9tvGbKJSWfDQqaZsjDd7EPe2Fq8uZj1+G9crPgOnjQzsmea84l1lftjzmwJ/2CuORSLnWPnzXzM3FJpsjmt6Ell26rnMgTQp27w7I3ofPmq2PnWnHpKK/glBtckzrGtQmy+m9UPrTh0kz++r/LVnPppPW8WdWwY0PTn2O2XDowFNQw2Y5LgzWLOixh8MUx9Ufhvq/D/O/rucSZ6HDRz4FLUYVvO7phY4pxKtORSw5Z8zTr4dWQHX3GTlzaHH68YC982HrkpPVGLo33tpQugPY5t3WL3Likfc498Jo7l6YJa8yneKDvKq0uxHlyaezCJfJv4IjgkGSwF5cmXH5+32E7l6wLXNKm+nJp96XSuW6w6mH/uRfQIL7nr7Ifl2ymqhw+AiPu2+h/gkuXtTxu8OeSWqfxouZ9iH8BzXwVyCXjvVYOWkHoF835rI2wSWu/ezqcktrc82I/l261yPz+L5RLi3yULz6GMn9slimEcen0YIWvE9wUW8I+A0/OPSJRDj8cnBwtFo66WU8tdIT7tt4/ujWSS4cMD9SNi0K+nUe/rodNl/u8zkPnVT+u/YWhPs7Gx7g43izSUuRBH+Vkc3hu2k7nrVDy+XzuSXjB4USJHp9LbIPWdW2xXLqx4Zrz9ji8562Nzdp4Lqna24UJYeOWN7OqYeBH5QNzElDH48ai96e5NLVe9nZCIpeG3Ixqxp3BPBx78H0bHDw75WI+7J7/sVTyLPoj6+TxdvhUK7h8TRKXanOUF7RAk6V/GhYlc8kpbFzgAdh6XL2yAL5buirCJIVLpV8veO+GVV6KhVHQ5tPEJIc09EGai1gNLI2ir0NQEPh3m1U6l5g7jy/1g049LedL4NFDJTVi17lU8rHbyxvW9AdGP4CXBsd2rsrmUgrn6fyTOVwatY7d2gEvz201XJPPpS6l7Ann4MHTi/a9hLJBFcbmBVzaoZ6Y9KGIS89NIxQ3FXNpeU232jX45nt+QQ/UCptySlDCJc3JfYP9kDxHqpnPcJ/v2XHf4bkJmuyrZVxay20sHoLzx66NdSjnEvfEUiP3Ci6JUnfY34O7tiQenvGcSzO8b/7RqUG9Xtaum1qLvjnZ2eYPPywLeJkLLdbpXhyEpldOL+a+RP1Sxc0N6rB+pTrzABh0s7nhPRStkOGp1XOpMm37gTENXJIOKJmXBmWeHpNMa+SSo9sl5a1tXLq5NsEwH3Jedk8chP3qRaXO7VyyO2h2Wq2DS+NS7O/5wWiNoPxzMOPyh6VvoXy79GTtLi6lb9U7zIeF3jFXK+FcsYPSe7u5VDdzzoM0eI+dy2uHBsIdNvM/Yx9VyDXu+8GlnS8Ppmv1IP9vA+oDYZ370bnZ8FSTHke5l0tPtlzusoQn9mieTYAB+/8IsqDzqXCb13DZjkN79H5yKbf7gtAeJk7ZHf9pAHnNT4q6MMgl3lQNmZA/OL9et8RwiEv7LVR/q4rxyO+7+6ITsHlDy+LPMOT5+ygvcR7N3jsvoQJGbn3fbSbBox3f5jZeluLRrh6XtTLSPJJXoRIBvFfzatcr6PK7achUhkcnNeXeK8vxKOdWiIUX/KD7blkG3CGzUqwMBg1Yf9gmz6MLYgOKRbA+e6YKTeHRcM7TXW9hd/OBJZpKPHJ6HjzlEpx7bnH8P5j7Ot7eVZlHzEa9j09gi92DLyoqPDJasemrI3wbNjrDH5plLZkupsajUVV7aXeoNd37bCeU3uQjOwrfvNrw3151rOuph2UJfNP9Uzpcg0epa6rGtsJpWfJHTs3n0ZJFTUfEtLCOQ9k/q6CP6d3D87V5xDm81+QhZI257W6gw6Ofxgd+6yzm0b+vu1cWwasaHztllvAo4eG6Q07QSttAtwEGXtAPGqfPI3uZqrw4KGZ3OtrCBPmX3KTZB8/9KZgbbcqjww6x0v3wzrN9QUVmPDI5fsV8jjmPOhq8H/TBQ3ViMRcIdeB3dvXDhpW7Ld0teVQRLVv5A2bp/fq40Arn7+SqJkJx+8LqD6t5tN+o7vclW8TxnxKvBt4y0TP1t+OR4Tjb/d9gQ4Oaat56Htms671504FHI8+j075B1bX+uXaOPPrPOylZ3IlHj89XvHeFwXrrDibD1s6305rh7i0dn1e58eho9trhQtg8tvnlJHceNflXem+FgwvPNKXBb7V1/VXw1gm7RjcPHlVbv/yu58mjP1/4u+NheZbPuVpo+VqjU8OLRwG6H33d4ZVctV0dcPKSSHm57Tzyde+xcIVrZk7UbIXjS8acW+jLo85Wja2ecGO5x/hrkDvlkbAPStFiC38/xLN+X3uAP4/a7V7UWATyqDaQuSAIRh95d2ZSEI8W9IUZb4HHFPLlE+AeulhSC7vH8G++CuHR4l9PIleG8oiR6x4RCCfMV1cdhh8uPSg4HcajNpMczz3hPFpqH+sdGMmj5/z1q3SjsP5dx1Qj4YLvJ7eKRfNo0UTdCE+ol2HbGMXF+ek2Zk1w2qP4Hfo8Hh3f56oQAY9kTuYXwD1TItx28nm03GHP1hJ43m3OkptxiDP9QfHseB6Vqtr4e8GUR4FvTsP7LcnrP8MR3qal+gk8ktHftlbmDObH9K+NKwxm2++Ihtn2b3xeQcFc3hSJs8hX3ax3D+ETdZ93iUk8km3cYlgNJ8n/OCORjL4uDtc8Cp2PyK8ahuoRjM7sFB5pK33ZtzqNR6bXx9SHwVuSCmuroHCJv9PmdB59lRPFjsCqY7cDfLPRHzdy1z2Hh8qZY+bmYN4HMpuOwOaepx8GYfdLvs/8W/j94dcKFlyQfTPGLg9z+OFR5nX4T/fAjk35uG+qaEEavP6jb3Ev3OsaOn1NAY+MjYv4j+A7hePiDwtx/9aMXVOLeNTrUVrlBnWK/huMhc9nSFhVwpHCwffWxTzi7U8eJ4CGmxedKYbSb4pk/8LV9w2uWJagv4/a7D0KdVcr0a8yHvXkhaXyyzEXeayNmhWYU8HM5zzoOvSrZnc1j+b8V7zcpAZzfebJfBf46ck8m1z4pid88x9Yb8BOj6rl0cvG1SdfQf7T9ZP1X/LoZpPS4vXwqDJjygB0cfxdyapDv4xOc5GqR/6nvVBdAzcmXQnzhSYyJufOQ6mwcwOmDTwKW3Z86l/4otba4HsrnrPRyXhqO4+sg0cHg2HDpOmFrh2ov0ituu8T5ocpGVDdxSNPo2u7FnXz6Me0L/dS4b+iOMkP0M/h4073zzx6UDnxSWoPj7xPmPbXw/79MVHavTwKF2Wq8uDNM5Ma63r/38f52+f8xByzTGxcYO1WMwubQezTDI+H72B/obvOuj88Ulow4Zz2EPZfsfp1imJ8qg39eyUIjqb4h5RB997WXTXifPJfrqr3Dx4MqzSwkODT0ZwbV2eN4ZPhlmXG4VJ8Wjmr3uQyLBnd3mgozaeBx/llB6DlgtUP78OPHtKHO+BsTnSVjwyfeuWvZOTI8Uk+MeOQvjyfOq9vzGXDmICN6+vhLJachPsUPnHFNvf9ns4nieVfR4OU+KTGa7g7U5lPoVLvGx3g+RW/B4Phij2DY/ug0vdHs2VV+NRhMrb+62w+aTV+3eWnhrgsoy5YqOM61+hNQpg+pLHFWwvxtbo4FsH6+q5+PW0+JWwNvSC2mE+elhW7DkHHUfn7Skv4tMWf8VIAHc9rdhXDgQXL3H5BkzffBkL1+XTseUgDx4RP55bmtZ4xxXsmSbn8hNbtWaemmPGpv0/cwAq6nxyaEwCfyy2+1wa/j1yUT1rBp8GqX5Vl8Lo5z8CJ+JSZ0zeSB3tMXoxbasmnqL92jDpo9Sgzf64Vn86cjgjbCx8ermoLX416jSZ0qtny6fFny2MBUDJwx5Pn8Ni/V9GRdnxicif78xz4ZKovcZHlyCeZ0H+a5XCGXMm0JU58Ginq36btxqen+tlLWuFeL7ftuu58mpa6NmQXXKWY59YMv8c6lFZ48ilNx/C8sheftDt3hIRA1aEXY1LgnfK1VgOwMUu/k+XLpwZmy8Jv0CX17YytfnwS2XQ9Hu+P95QNf/wCb3n4vS7ax6ebHj1f2IF8WjY/1k4riE/i4Q/l9sO26n1DEvv5dCHTtPUftFi9buziUNRppOaFP7x+qn5BPBR+eiacGcanrLV7019DBeGaXzLhfNK5eHKFK7yy/UekYyT64IX5x0twb6nsjE5oFdc/9UYU8mnTu1QrGn3xjl/5ksOn0veF5+S5fLp8S+yQJfxaeCu4Bj4vmTZ9A49PM5eteqbG55NT/br2vfF8OnBg6GUNPP65NVk+Ae85StcewJissT/mJ/JpLSdnHOsMn1IPH7D+ALtd4zZbnOXT/eelzj1JfLIJ2aq0P5lPGw6VKX6Cau67H01P4VPV9WnOe2Dn533/vYAv/mM/ME9DX7skJP2Cj4x7z0xN59PUe9Z5W+DYysibeXB+Scbh6OvI/3ND2f3ZfDK2X5jwFkrp6d11z+FTvnPc0Ym3+MTf9M12Kxz6qDyFAQ992HbZ4DafGGOdLNfmYa41bVUHYPCh47lO+fit9ObZCfix7nTpO9j70kM7pAj5fXHZrRp2r40xn1eM+j9+dWolVLg83zMFbjq/KHVqCZ8i/edabIGaVy+OXIb3TfsDOsr4tDv/X71sOZ/qnsUHucKe1ztSC2Fmesve6RWI6/BGjU3w+KX0L5o12KdMzLUfwUWmDKkm2H1rnF1GLZ+erdQo/g5b1vKrg17y6ceMhxP16/j0Rj5xy4R69JOz/R4PWOrPzSyEV7wtcyc0IJ/XmytXwf5LEYsmtvEp+smrw5rtfDr19f35Q1A9VEHrKTybfi5dooNPb199KDOGLa3er1d3Ib9/b0vehGrDj5YqdPNp6c0HXzzgxh5GRQ4M/7G8avlnxG2f2PHtB5+KynrivvYgzxbp7Qt70U+XQk/HwVfuaQzxn3yarLmg0LyPT0d8anZdHeRT02vhQtk/fMqpyAt3hEfEf9/YByM+rhlMg6H7r+X+gS1Rn2X1hvj0s10oGwHXz12wPV5MQKdXrd5vIC6gBafOakfDZlf7T+4SAnp77+GnJkkBbXl0/fAKKQGpO87VZMIZE6UGb8C2G/3xmtICWpf8KeoYzNw2sqcV+qay9yyVEdAz/eg/TXIC0t3zr26TvIA+10geeArvTtp/zn2KgGaJ77gboySgqhd7fJ8oC8g4smqZpIqAbMcOFSTAszbPzmeqCWj3/H+pZXDBFt1l39UFJElMmd0aAkobaxJprSWgqbHCX2O1BaSo+HX6Svjuyr/rV+CYmd+eqesI6EXLt+1pcLv3I/NGqOu6J+v2YgHF+MocHoWFv1KNy5YIaKK3b6WPvoBkdjPiLkPz5WfKn5kKqCBohYe6mYAO3s9dFQVrdh41vQpLq0c3S5oL6MHsR77DUL8q5WEoCcjpbOvGBth34usqN0ucnxB2sB0yUpzenbJC/B9rL9yBs+wXKnxaLSD7xz/zhuHMDw6KBbYCet1dPINrhzhkr5hVQ9vdDQMXHASULx7wxMkRx82r877AQJfZDvOc4I6FAbfh3gC99M8wStQ4x91ZQKoW/y3huwlIOKVkn4K7gI66hH98BWf8p7x6h4eA1j/5r+IwTHGyzbjgKaCtRkJmO5QwDde38RLQ0i2UdBW+9LBf2A7/RKtIqm0X0PhFSRc3wPQKL/FdvgI6xeAkl8AdQ/+djPQTkGjZ7x0f4az7ggxLfwFFelPYvkABHdB3ysuH1aNXFXph+MyVD3WCBJS6cnLFUbhOyixXb7+A4tV2TXt7QED93xds5oQKaCgqlzogUzNaUitMQJ4G83/HwO+zJ5X/ghfkHufKRwjoSElD7PdIAekEzt26KEpAX54b9bChNKM34HA08vNd76UyA+c98zYIuQI6nG/2tgp+lto+dh9PQF2LFGTT4Yq4X5UN0FX9pLk9H++ZfqcmDTrzpfjtsLHsapVinIDeHNjcmwAvtb/xnhmPuj7ZMMELBtoNPrkBWcpHGGoJyOuLuiu74YTa/vP/JWI+FGKdM2BKooVA9oyAbtdvnpsMnxXnvP4K1eXdjh84KyCpY507X8CZqiE3ZJNRP52k3+1wr8WelAUpAjJcPKx6HZ7T+qPeliagizf5mtPTBfjOS/14CXWO7Kl2v468e35avyBHQL2H+w4nwOvSji0/4MuI4TEutzAfWvuP7s0TUM/dgJxK2FLexZ6VLyC3q/ssRfBNx+qLRXBLdXbWX7in9GCfVgGO3+8fDIOZ927ojisWULGHf74hvDPxyZGt0D1u2uWb8FaE9rHEEhj91V31Ma473FqoUY48z+0e3gs5lza8yYUTM+TzZ1QISDY2Z87RGgGpVRwNV6oVUGXG5YQIyD2Qm1sOjWN4H6e+xHxtG+z0hjsWj79lUS+gCL/zugy4MtL0wOoGzPce6d9/oe70CWs/tQloycZ5fy3bcd+eC4IC+D6r0V21Q0BBpsI2Jpzh5iNd04U6PXZYvbob/V6ZOT0ZGt0vDP8CfcSeeNr2og8OnJM+B6sXeC9e8xP74MAx6V1/0EcKVRavYLjFtUl9Q4inwlvziLiQjri7F6tLCPE/9EIaG85Y+eN90xghhY1cVPojJaTMhdZvZksLaeKVV792wJsqa7fdhHOMjV3WyQvpTp66Zix87rp6Uz1c+djaavYUIUV3NU0LgtqNjKH9SkLynfG2+AycPTz9X5KykGS3xc2bpSKk+WkpDU1qQnqg8fnAHHUhdTYeqN4L+fIFF29Bhsy9IR0NIZn+ZBxhwvHH/t7s0BKSh1Pup83aQhp0n7g/FZ4ck/lUUUdIf/n/TGmxkF7fcpbrgQ+7DZOzlgjp2vfL7T3QMTTl+xJ9IW3uueLjZiokCdcfTovN8B7NPT5xcORVrfkH6PdLWzDZHHFMStLzgMP/1bBE0MFdz+64pZACumq96mCaVWnkVCshSa4ZnJoPVWb0vdRaLSThQnJYbCukriXulhXw9iSNW//ZCUm5bfOs3ZCLJIw4IJ8eGlZWjkK6Fe+9swjG5zx4EeIkpGDXZZK33IR06dNw90/4bsE023x3If1p4eX2wQLHnyVbPIQkUMjqT4Ctd5cr9cEz60N3S3oJaXd6muQ6+PuRhnfIdiEZqhl9vu8jJA5fdiTJV0inNT9SC6x2a5xo7ick261OJvnQToX5U8xfSBX5Qd774KXHV5bdhOI8CQe3QCEZbxCVDsGlH42OVwYhz3FOHxfsF9LXsa1tgfC4wtNTXaFCiuqttzQNE1LP1CfRXZCyHGzlw4U0Zcrtq/7wzKB3djxUSdv5pAo+XpZUrxglpMS321L9Ya5R3vNS2Hxl1rIJ0egLhYabDjCpT3naYTi+Onx9GldIBhUTzUN46IOGe/qvYergUlt1vpD0V7uMXwYLyrMvR8G2t3s25kIFuSNnIuKExIvwWL0uXki/KkdCI+HVL7+YDfBHv6/qmwTExXba/+2kkPK/c3RPJ6JfFu2dVA8va174q3BGSNLjRzftg+2Pbw5bnUVe9JXV42BmTPOaU0lC+ukWu+UvdFDQVnZMFpL1Jt2bl6D6uB0+zfCQeeTA0RQhneuNU8pPE9KE4C9OQ5CXFNDvki4k+byVJ97CtjZvqbTrQir1vHg/Jxt9ufv2g0k5QjLSE17whtWbsrzG3RLSljPHzJlQvJp7TiIfc7b1OWsfnHiEN7MSLqt83GlUIKT7d0un7oXP/sx73leEeH948T4Uo49vLuN0lQnJqUW7dlE54p+wvicdpugZtw5Cc0bKO4taIamOW3DsA1xYsK329EshFZUOVOTXIR9hSWtm1gvprn1I61a42e13Zi8Mbz4rLtcopLmsbK83bZivsa+zLNqFNL1x2wo+FL8W6iPZIaQ+jwibHZBtsXA4vgv5lH2w6gt833h2Zkk3+qUx8YnjZyEVfz4i9QpeH7lhfL1HSBqVq/5J9gppWnNAiCe0u3vXLAOGack5/4BDza4dq34ib70X5zHhpN9rb/EGhZTlaiO5fEhIFhfGMA/DzTe4xyb8FZI3jQruiIloXlCqm1BcRAdtbnq+gzecTyaOQCPVtGonCRGF31lklAXX5sXpfZISUcqG537HpUXEvv/rrp6MiCqS9qf5wozN8UVJciKa8db0yix5EX3RrY4TwgWqN4+XwZaGjA9yU0R0c0u2jhUUHNwYFgofLWg0nKcgou6rVX8eKIko0UlCIkJZRNY7+42q4YVOuaXXVUS04ZX7s/ew/WGmyVh1ER19OXTJCErnbshMgN8SlcK3aohoTXTTggLoabfwwPQ5InpmcnqPmLaIxifejt0M795Y/ncArmpyum6vg/hHRpddh4e5Zw5XwAnisRPGLRHRyl2mCSuhwo9dAbsgV17JrRYa/BucOF5fRM4pnkmu8HawdX0abIkrq88wQx5+xf75AW8azW7eZy4irf/4m3QsRZQt986qCzoMPdRdaiUi85TakOc2WMfvez7mtiJ6sb+9hQX/ZiiJfYWrpN3UDO1EJLywO0LaSUTue75m7IWVM9bfvw2fRWv9q9+IuJ6sE11xExFjdNRyrruITLrzV/yAi1bIfHvhISJd2x+Tmj1FpKGzyS7AS0SLE9wLZLaLSM18jt5DWCIvkSLhJyK3PY39Isi0n1m3zB/5dPg3422giOKPWi21CUIeLOWj5faj7tZO79fDTdfKJhSEYp21wytUwkRkv0rhpXK4iOqucUVcaHlZ8+DrSBEtv8GavSBKRPpFgceq4UYlZ1WpaBEt+9TCvckV0fzzo7JlPBHNbitQm8BHHq/x926An7ZckGbGoQ9erlAshjs7Fj3vj0ec97odZyWIqE/NJU0E1z1rcP55+v99uSm2IlFEXnfWL3c9KyKlRw8PqCajf8ScfwXAa9nP059C1vgUy4kpIqqOti5bBce0/9cRDgtfhg5nwRlmHvGiNPSF5K80l3QRSW4OvK1yXUQvzT4PfYGcrdu3tGRjHszCa7fmiGj4gowgFm7sHyO55xb6Yt9P99uwJfnr45E8Ef5PjriY5aMOXT2h/bDndYP3vwIRdT3cIr6rCPlMD1XogpVPVobLF4vIarbFuig4p3+6r1GJiE6cy9sWBHs7In3kHotoSdIz7pkyEf1LNBZOKRfR5rFTb7+DG2PjbrAqRBT84U6qwnMR5Z0hmTs16IPQ2k/7a0XU+d/qR2XQSc/43ghce9Sh/95LEV26tXR4Yb2IPiwaCM6Fm37+PqjQIKKOzuYREXzVGnIsok1E4y51uym2Yw5nxBS2wZOJvxfqdojIbEfMejYU++1i/QIGfwx/HtiFPpxpeqQPXqtwmnO+G/H9XTavEqbua/RV+Yx8/NDtj4BWTyYI8n/gfQzx4K09InqdV+rh0ysiw0CJpCa4erq5isdPEZmWt0afhw6K07ZFDGK/Ms6IH/MH9dWxn7YL+tzarNQG/eb0tSQNiagqq4GkxGPoF2fXHCsY8nOdOxN2j9nn2QU375ofe1AihtxGkjY5ScWgT1+NXoX1Q+vXLJWOoeecphcBkG3e1t4LX89nbUyViaHbO3z4A9DDtMG1VC6GIt5OrnCQj6HTcXK3u2H1qsqVelNiKOuS2E9SiKHRW6xQhlIMOd7hbN2tHEMT5EvuJkKrLIkwRZUYuqJb9nAjfKeccqgTPmotWDlPPYb8y2TztkMr+7IeBY0Y2rQ802uddgzVTpixoxJqqKxoG68TQ/bVc+WM4OQTnufq4ZnJcyucF8fQ1h1XRA5LYqhOLqx+tn4MqTesqE81jaEb94w2hJnF0Nnld9cpmceQqGDEe8/SGLKVqboeSzF0ymed9Cv4doqMsYtlDP3dcHR2JTxqZhq2wCqGHiu23tliG0PmAfa3q2C4c8PjiPUxtESmdttchxhaNzSa9BjW0iVRhWMMaao8MJF2iiEzfpHdemiYoiBn7hZDX3dLf9Fwj6GZrmPOjveIoZzxaxqPb42hY6tDR9y8YsiIArY/gs6/w1PjtsdQcfH1+G1+MfQmNLXxEjSpDNg0xj+G/pgMP1TdHUP/Tm/N2xMUQ6sWXS3IgDY1UXY/4bbXl6v+hsZQv+fupDVhMTQvNeqIEAZ2j1/bCQ/JzZXZERlDDR4frifBOQ2Pjb9D2Z0f1kRHxdADg5gY2Wi8R3XDrg3wuK2Vfha0+LM0aCwP66a3uw/DZYWKRcv4MeRbGOB3Ji6GCv87aqEWj74zEp/nC7cURl17C/UOFeavT0BdNKVvtiTGUIdS9UjpGVy3dlPz6rMxVD7ZzSMYigu3Oj+Bt/xDL+YnxdCMKJ0pCskxtD+pfgcbpr26zfwBZUIvJfimYJ0d1f9U0mJIXinKLRPqjiwWiKXH0KyWmh/PoOdS40We15HvH7fub8pAnXcpT52Xg34oKFv3FH7/X0V3Gg9l38UBnKJbixCKIqSyV4gS5SiKKJQlRNYitJKlVQgVsw8KoSJJURFKWSq0KEVaUEghioQken7Pq+9nzFxznf/ZLt7UgabIv/CJgPMb75twnkfSqxL01b3Or1tLEcdcdk0gfDGauu4nvCa+1VG7HHGXv49bUoHPxc4eKIG5EuuPTcB7s7eVr61MIGGNrPrzcPncjLpTtQkUWLF2ZNaTBLrzQqOiCN4/wrcSe4q+yufKG9YnUMqVbPcVr5C/pWkrU2CI4yNTyXcJ1NV8Q/c6NMwaktV8n0DrP5Zm34TyG8P2/fqI79PmSSd9SqBS/rW9P9uQ5zzfT8HtyPuCqiH7ngS6veTNvNtwcaJf4F/4Nl1pK/1MoJqu99K58MUfYynP38iD3iOBB/DfPnHHFaO4n/G3t3zo2J4VPf1PAs1deuvPFihpcjR180QCrVzmpDMI2/9rWHtLgEFy5qZZKoIMcqh1cA6H14Nnh3TDPruAXycmMWhMd/qkQREGuXRuzteeyqAWmbE9fKgx4O7cCf3kf+boTmPQnfPFjxKg0sZiIX0JBt2tbZPJgLbW0c5DMgxauOOXKEeWQWkixm/fQFnTLiMtJQZ9eJp77xzMWC1w+gssfpE4R3IBg94pyN7LgufXCYhtUWZQipjq+0pVBsmfNxCPUWNQ60i/0GF1BjVvd7o9rM2gJyafdGP0GOS70srHRJ9BOqcnhU9dxSB7SaNwe5h2xXL9RTizVsPqjgmDFNbVixusZZBbusWnaLiA61itvI5BP956uhtYMEhw7cdvcTBy37DrR/j504EpKhsZdMZ8ZNccWwb9Vv9x/gG8/CXrv1Nb8P704d1btjJoSv34Fc1tDFIsarD4DWf//r2c68SgQ0/WOwi4MOirrvL9KR4M+le5R54JLy9OMWuHb2vHYjM8EXf1SHivL4PKumrm1Pkx6NpQmtzS3Qxy1XtqHw4/X8reVAGd7stMmeyPc3/IzF20n0EP+nxEy6B86xxl1wMMKt0dUPU7lEFL7r74fDCMQR6HuYca4fXEVb2O4aiPCuPq0ROI427kkxfwdKW0vV4Eg1bdSFtzD0o++8mQPckgszyzSAe4anPNcBHc469eJRKH65qTqtfBzfczzargw80pCyadZlCt3K3hYLg2vFOhH86fszdai8Wg3Yrr9LMho/xC/kd45EuV2xI2g6I3Ku0phcHNotev8JG/nNHRa0kMchbe7V0DnXT6qk2TkZ+T1Yod0JTB4JieY1ClZ4XEcZh5ecHr1gz0ndDYnEmZqCMvaelh6FDuVVgI31xo8Vqfg3z2TGmRxBPDYGvSnTe5DLpw7rHcvzzk4ZzMZWY+g5p+pQdoFzBIYPqfN9Nuog/VK4csobeCu/3DYgYZHr/jG1vCoB03I4OvQL1Z002nlTLol0TLy1gYYLJ26rYKBtHBvYPKlQwq6drlJFDFoFGP9VHLaxjkuSGr3qkW55E6Jin8hPH/f5exciPk6TedS4IS7POODvUMag/+cOoErGFIO1dCg2fCrkqvGGRslhC/EV76KhGYDMdfJf54BRcPdwu+fcugvLoK58B3qNcbuS+L3zOobRHXrxVuFEpbuKCNQWFvlyzwhAucZey/Qb5PVMr2dgb5pBiEn+1CHibfteiC11Vbw992M8go5DdbsYdBFQvLNmyAoe1POh9Bc+v/Tof3ow5b3C7WwMfWn7NcBlDn7yVzX0Nhj9tChj9xzqGvBREwPKHcsgq+fGW2kTmKOFf8PPQZTvJotQ3+wyB1Ye1lgQJMMry2yPkxzDr/WqcH2spxj0oIMmn5cTyn4cura+6Fw3usrIZgISatPGlXoyLMpPYZUjJxcGpNtt81WLr2+chvESZJzFJlRs1g0oOVwyH50GhFzOa/8JWzbaiZKJNEtwcFxUOBSNNhJ3Em7Tp88UEMvJ5wMioLHjSQK6yDXBmdsKUSTPqyKFxHSZJJ9o9SxwulmFT4OkFhhjST9nw/r6kMPbz23d8CBd2evT8Ihf1/cvfJMKnNdIteJiyKeVlsJMukv5sft7rAgVoGP1yOSd5d+ffTYES1AmcAzln649tyeSY9H2s67Ay7v6T/FlBEfIs/eflBMUdhbUEl5EnTPXIJLK7enrtYGedNyPyksIhJXpr1qc9UmXT8ROa1KWpMytx4nLcbLjxkoRCsyaSRkdD956Cp0/5d/6CM/gxjDS0mLTocI0pQR3nXkB8ccjKRSVrGpGOWfcVDcPo+VquENpP+Y3gUqkN5jYv7V8K1t1ojzZYz6bZpePo2WCs38e4sjLBjNdXAyVf63MZhxn9XMubrMWl+X0/dSnjIdmec60omRek8Xx4D15qs0c2EK+J3jdbAPCP20B/44JJvzlwDJi0oFtxN8OCVY69SjFAH3QjfZrjA4l7KVUJdk7qPjkKJu7V75EyYtG7k+yYL+H3ZntENpkz6lFxx/wxcPz9E5yqcbbRnk5AZ8rIngEfQOOFc4kG4aH3Ck0PmTLJe+WVlCjQxvOz1CG7Mii6Xt2CSf97tJXbQWTg9lwvLZd8fcLFCnoQuHw+A51YnZdZB71NjylM3MWn3tS0zNGHofNVJO2DzgIR9tg2TPB8HGD6Gb57fKpK3ZVLYk87HP7cwSan2xLEsOya9E5daUg2btDoax6BEhdoPN3smzTR5f2TlNpxD4bhiLDxWn3E8Fd5M9fr9Fr441vlvAopIRoybOzFJm5NVHwVroyzWntrOpPsc9VcPoUjs3Xlfob24XoyMK5MiAzav2QAtovtfKLsz6f0BYgRC/u2KtfHwcvnyjF/w4CvxUxoeTBou/XfzqjeTWDZdc7phkqXxR3kfJqV6P9QwgizDsyIrfTEnI0KzxmHZsoppNn74PvJzmx2AeLu61eNhapiuQi5sGpDqaIYHEqSOigYySXJ37MPF0Ez6RVXEPvSJfeRoFZST/bHhA8w95MgW2M+kcQd1/31BTFIuDBJNg8FNjEWv4LsrIjMHYRJ/R7pKMPpjpI2VE4r5PKfOb4WR5jnt/yA7nONFYUzqXBah/PQIzj/1YbPWUSb90XDbvA8Sc0/xzuOYm4mOWYEnkD/NaP8iOOul/671EdgPeT6/3aKwh57qVj6CakGjip+h4lkzE+tozIu/5qPgWCYVzDWSew5dNsi0CsZhvgOt7NfC3pE1Z5acxXlKpbPcof2dsx8q4bGXR/JnxzMpR3L2UmOYNm1F8w4Y+kxAexkT+dT3ywuBqaW/Kkvh15uXRD9DvqTV7zks1Cumtc0cZswXmrwb9o97HP/DwT6d2ny7gov3V+1YMgzpaGb/ah6TFAylju+BTk5hqzOTmPQh5W7dHzg1XcdVMplJAcc77rtDn9fDDIsUJqmq7Q4rgQUz73nNTWXSEcfu+B1wrOXJ883pTEqf+X5rKjzzlNf/EnaZbmTIZOC+1lPKTkCVc683RV9i0tON/zkWwPoH+4+9hW92n3j132UmtfQ79mjCJwt/Ht0Dd7ctCrt6hUkh6pkTajnYTyajPX7QZ5t/vk0u5jc9zSfkGvaB4OiSYhgTPetLH5w/uTnUJ49JmofnbrfMRz5Mr4dlweLudeUGBdiT6YcDGfD7h4tTPt9Cv4qP/Wu8jdfrzt6ZVYjnRtm8a+tg467mcUYxk7aed/2UD6d+E+G8gWEFKkPLS5hkqXasXOwek/ZGHr/jB/1O3npxHE7olwrchJMkZSW74S5GyOZVZdg/gqfMAmHIuQ1aHuU4pwB9iocL6yy+V8NfoTrfvkHvH2v1l1XAyb9yLavwHHFYWD/nIe4jbmCyHxoecv2XBEtdvMea4Nk9H55k1jDp42vvYz/gotPaK8dhtZ6tpGotk0azIuaEweCSc1FuzzA3l7Xep8DYDBHJWjhQTjtGoczDX/1az/HczY5P2wRtVA4OXXrJpGejEbzXsKJzZK5gPZMavpjFS0Ct5Ta8tXCntCPfFTJaQh6rNTDJUV3KvBL+uOzZM6ORSX3NrVM0YOCNrY+tYeeBN3UsOMJ4fFGhCftrvfEmOxjQl1K2/y2Tpjjzn9+E4qFiD7/Am3Hxw3+amSQbYrpKoYVJm7cN6XM/ob+FD/Gr4ew7/wq12zB32sIj62F+r8WNUphlo9Xd8JlJ5/eltKh2Mkl/8gjbtgv9mZ17Jg7G7YiSfgoPNF7Q29qN+Drirx6Cowk3DZJ78fwzr2+6D/ddPKnfCrVUNacs7kNf1Oy4drUf9RkukbIcYJKBiInTGfhf3dbxnF+Y02TDSZ3wyP2lu0fgD6WmkAVDTJrWdUnCE6420pk+9hv5PrXuruEok+LV47e5wECnc0tP/WXSMvej0dUwxvn38DgcePxfies4+oRKBmsFWLTmjkq0vCCLxg6mDBvAtXuWye2Bh41uK9wQYtHQ17H136Hp+SaVucIs0ul6t9EYfkgcLDoLj8Y/aj4PqxoH7j4UYVGSfH2K7FQWPVo+RdwcfmPape6FHrGdR8/AsLkPbC7MYFHvS2dNSVEW3dwYn2cKe9eIfw+CLuYz5QdnsqjhfkOZuziLltyUy1OUYJFjU/0KR/jr7qxNyyRZNDv2TKKLFIt+dq9oLYcRf0262qHbqPCEjDSLRtkGkzfLsIhtsiakE37oLby5VJZFOc1iu7fAgoJJdl5yLFoU+ae3GJ68Xn1ISR7n/HGjdDNkNo0uFVZEfP+pJr6CqTLbw+YpsWjQQcZgC6TEhJcJC1lUx/lu1ACDxdq/tsH9FSNRSxax6PYtjzobeG/KpOphVRZ9+RtyQ1yNRXGqyS+M4IhwZme8JosalW4qvIfVuv9iZmqxaMLBcaYfNEuU5UQuY1HI7SWf0mDMuij+FxiUPBputpxFTR/OaqXAc6NbisqgnOlG9144p3Sdhp4eizxnKf4Ohj+evzJ+voJFanZr9YNWsmjTTTHV+3BdUPdxNQMWadQVO5vAZqu5zUFw72hH6ltDFgl6Xn/NNEKe5sY8/Q4/W2Z9o9Usqrn1cOA0PCS650UesciSjn4bhvHia09rmLDoCaP66zY4dGTWzt9rWZSZwRoNMGWR3bRI0WroXtqs423Gon+DDIM4qJYy9dBzcxbVJme/+c+CRbZvdIS84UPu6WPJVizyL/Cc/QR+q5/T8w86Sn46aW7NorPaL93P2CBvA9O5ArYssqet03xgcs+hCh07nO+MysYzUN1fcEcJDK/g6bfDynQHQWF7fK/72IAdrG3Mi3sL/yx8fmWRE4skHwo/doSNOqOpgq4sUhpd7KwJO3w3Sm+DM0tnbL/ozqLtQxf5zfAuZ3CpmAc+d9NJo9WLRYsfFai+8GaR8iS1eiEfXBf2Q8UIBu/TTTwBd2YNGl3xxXwEiTk+g6t+zRNqhh0qYWpT/Fik1WBlNhvKqthp2sFb6TG/rP1x3XSuQ2EA+ue/0lUGgSzisz75n4VyZLBUbx/yMuTxMwqe+Ro64zqMfTkzbQR+NQkXUNnPonE7ic32sFc1ZOxhEPrj1tC1qcEsmpH/8ZEa/PXcpkc/hEXF16QPuoSyaKmMn3gSTD9YX50Hu6X2Sw/CzGU7SDaMRSqWmfsN4UpO3c3MIyy6nP5a+gM0vz6bJ3uURaGb9i4wgq/7g8JfnMB81v88/hnWL5pV8ROGp2p3ro1gkcH0O0ZPo7B3Omp0fkFZ3/tJa6JZdD+w69hOeLCJXbsilkXCzudCO+AVKYaJTBzqFevCMYUbnvbEhMHOJwrup8+yyDc33ekBrDLI3tkPd55f378uHnvruffHLCaLxBbyMJbIU9RQ+SZ4a54tczf89rf40XYOi/y8hdWuc9FfP8LmvoH3VaVl/8Fh8SW9moksEhgLF65LYtGFbV8zB6GVQ6G/cDLyz/HZrwqH5PpUV8Hfz46VnoFyzgcbL6Rg7lhSt2rhNHVTNbVUnHeyto8TDOYtTIiCZyT/dU69gD38ddJSdjqLyusG187LQH0WFmxbCfXbF+UdhmnHByuMLmKeNp/rXHeJRd+HQ32b4OZmvpzIZfTjBXcJFbhzv3qnNXxW1tjafYVFIquT3lAOi2wYjOY4GOZmfbP3GosMe44Pi+WxSFf+tLs6PCe8/p8RvHN45FQoLLlubrr+Bos2jhdYNuSzSPr353Vj8LnUHjItwH1N5K/FwwF2WsrIbRYds+VdNilk0QmrCP2wYvSzm01RPYxVK5q5pYRFxm+Pf6m+x6L5LdXi41BQV3dofhmLcvflXnWCT0sK6+ZWsGje1UnGq+HuepcfbnCW+GkPwyrs4RNzX0k+Qv7nlR13hJkb9kaehzH5DlNewFijvoqSGtT5mYP/T7hdxWKlYi32zfTYQ2bQS8N2nudTFh3QSeEXPsPekze45PUcz4nkS2O9L1kkcfjSHsF61HVxiIARrCxM8w+FF1ft2Hm0gUVvP0bnFsJGJrtXsBF7KrrykAFM/RkSegz2nTX+yYG16vec9zUh/yeMPK++xX70/yT1AOrqKCX1wmDV/Flj8KzfnAX673BO4YRXJ6HGA4+B/R9YxOoPObqzmUWfBtd8PAsfV7xzLoEzolxjZFrwXFA1mW0LZ6ZobNwLlWwcvs39iD0i9bab9YlF1xVqxAvhsoLvEu/ht+XW/QvbWHT6mvxlC/hhj88VX7jyvb3UOdjzpeGN52fM66Krt1Pgj2tFU/sgIyGqQ6+TRT6LN3x3hJLuy+9fhtOE9aY87mIR17LcXLAbezynapICzBA+IrcdBgU0dsbBLXijphd7rl22tx/azz9ss60PeyxC3q29H3MlWWS7aADP801JlvYwJ23euT3Q0udxm/8gnhfCb90P/2IRZ6fmpkKY3vXhYT98t+lOscIQ9tSN6qCzv7HXPmiLFMNbw/Vfv8L2Mv2CVaOo152J+IMw0UivLQaWvle0z/6LfaFdGP0PSly3W6I3jjrYPf14CfpoV0X6/ENfWOoIPBNg0+Ah7qX/BNk07W/Dx+Wwsf90cYIQm+bOXvi3ClqxLCzb4YWz19t1hdm04l+pRCJ8nbLtYzVsW9D04KUIm25LbbwuPJVNi3MenBScziZjH5WzOTPYJPbHL1tLlE2ev480mkMtZtJrX3go3DXklTibJi8NXTYKj3REPl0jwaZ1IspLyqQQ17mnwT+gm7hA6SxpNr34my56AA5OCcxYPYdNei4BhRkybNpfLrfnM8zPmKY1X5ZNx2NKb5bLscl0626tHzD3jWXsdHk21d07PdMAMg4KqHrCfzK3LxyDLyYeZHUqsMl9V8RYpiKb7C9fPNICLYbG/morIV4ddf5pGL1sYpGWMptGsk0fn1nIpg8Z4eVSi9gU5/f9pR2sPrlOPBweuJf3plCVTXN2daYOwwPGRY3Gamwardkw5AlNtrne5Gqyye61jYC0Fpu0z61Y6Q8/3LUS5ENNm4LH5cvY9LdtnCGpzaZJr7hnlkMlDR3tMGiaL7xt/3I2KdD9v/Vw3mcpry7opVrmJ6LHpl/W96bpQvHyx8OB8GMw90DBSjbFiz1VfAyvWiV0tkObS1euTTVgk7rsI9HFUE+pXCMYZh9c43kKMpcmtlTC8oSRrclGbFr9wmTxOxjjTVozV7Np2TrTjq3Qo0RTspHYlOWr3j0M41ymrXIwwfk8ii4lwp6qmG+lUO5Ujpa1GRu/TzQ7+5uzaWLhUXl9CzalW7zs2AtPu3ptYsMX1+fE7bJi01Z/5T3V8MtZy28Cm9g0VXuj6wLoN/lzmCkMTr2v7mvNpnClFx3CtjjXzj755VBvTl6MKTzFbm52gQe/ea2espVNM7l7xDTs0I8JtMQVLs/6u/MVzIrLkh2AKtw3Qer2bGr1GEy9uI1NyUrz4trhgo31DXJObPr0oTvSHT6xKBhZ5sqmghdWVlvhf1tW83Nhlb/PHrUdiPfosJi2O5s41x65zvBAnjO3jNyFLe1T9t/3QrzDjbJiPmx6/9Sn9jBssLOyJF/UaczwYzY8PvFov5MfmwactdjJsHTEe/OnADYdbjL6GRDIpikJeBztY9OGl6eNnsC81SH/bPezyWF9SHQaNFp93kfiIH5etcUjKAh53ZDQ1QOzIhI28YLZ9OdX7Y/AUMzf2iWxLPiA5ag0Clfx2mlFGJu6fBwE3eC0RYs+Cx9lU+2PP++PQJb7frXrUG2D5Prtx1GHaZsKn59gk0Hmlgf9UCvB/d+kCDalqShLK8KPmyxnhEaxKXZNrol4NJs26mVWasax6UyY8fldcItu2IDdWTaFZXgJnYSmlw7XFsLAcvMHY7DtxCwj6Xg2qSY7/POEdbkNhqfh77yF7leY6NMf99+ostgke9qw8wSM7FWfXMpFndUdLYdguWdmlzSPTU9XdejrJ7JpdsKmg/uTsF/E6uplk9lkKHYzlAO7zp293nUO/XhZMHjheTYt2d5hmp3CppqLHY8+Q7P5Cf3zU9k0ozPsw044vFiu2eUCm/Zti7b3TWeT4sl5/lxYoTj3eDU890RxYnYGm3bf9uvxgW7zN3k9uIT73/iT0QfXuqoP78lmk2SFYdD+K2x6l+3NuQkznCaMRuDlX5cOy+WwacfeG97m0EookZUJ55aZzc6/hrhP8qd0wbJ5bMF1eWzynVtSZAOrtH93JsLxVXl8bj72or19QDm0E508OAGfNFwtWVXApm/NtwdcIOd7VHHs7f/viZTrDXDzid8X1xWyaaGmSHYwDNwU1vWoGHuR+y1hDPoe/HF+Swnqv+Nuzoq7bJLZLeibfg97QGWpXDnkflqe8A3uXPHgn3UZ+uHtk2Mh8ITxTrdMKOdx+GJ+OZu2q381/QyH+3cNGlTgul+mqanwep9fy9eHbPreI9M0/xHm5WvFFzv4YHByQ18NmxY97c1cWIv5uuEgYgcDjDYx/WBJRO6zaKi51SKq6RniPPzlnOJz9H+x0UwrmDmp/07hS5zr47Uz7+G+GxPrZtSz6WZmq8pmuMtgSkYIDGgrSD/UgHgbdGY8gRktp/RXNLFpTZq/eORbNl1rC/x9G/69s9lV7B2bmvv8jZZDdstSMx8Y215i7vUB7+uGlzQ0s+litNihP1DMzUpItwXPuUufinZAM51I8YOfMFe75Xsmt2G+U/ctXQodHQo3xMNfHfIGQp3oi6KtjLVQdMEDo2jonhjp8uUL9rDY8zfSX9EnSaWbA+HpGS36FV2Yz0vJy79D3dVfL0h3Yy//aGtzhGfmSGgVwW4FbfUV3/CcrvGUfNuL/VekYCjSx6Z7sacvqEFvxUDlLXD2n+qHfJic6PSovR91K7v3ymsA8c92si6H/4y1gt2H2BRks2+15QjiKJRWURxlk4axfqQhPPr5y6AFfHTzDysRDj8eb675y6amYBuf3eOo/6fd/6Lgr0ODp+8LcOjgxejFMwXhixM3V/7fTVabw+CfQO3/WFBze1+TsjCHjKUe2ljDZSpJovFQM326B0uEQ7M0utw1pnJI1uStXCLcpPHAkDODQ1es195fKMqhXPVEp5NQLkLJPRXWxncIJYlzSIxb8mUU/rctW8dMgkNrLotWpcDsvNC7rpIc8ujx3xUqxaFvZ40CPsHOFyu6ZKQ59PKpj80xGGt72zQRVqZdWWowh0Ov9t7f8FaGQz+c764ehKz5jDZlWQ6Fxj9adgHeGVEnzXn4vGK+xlE5DulJLT9ZCg9vXDKnC/paxrjqy3PItsHFwQX27A+syIWen2oszityyNLLPKsZNn5NL96qxKGkPO/WFLhGwf1G7kIOPXQ+kTN/EYd+KSdM3wXVur7MiIHh4jua2aoc/N0tKHEFhlxayhRU4+Dvl+eS66B6nEJJEfzFeuworcUhHZ071yLhDJV5IweXcmhPd6JeyTIOZV6T2jJVm0OGu6zez4Fefl9vBcC+0JxNCrocEq1K9pfT4+D3oY1bDaE8q1ozfAWHWlfP/8tayaG/xUyTfmjS+XKhrAGH/LqeP/CGPfFRGvFwvu/kqbeMOLSiYfvLXjj7V7fsydW4flZl0sgaDvlLlRkZG3MoULJjYLkJhxwMUgfkzDhk+t3nijEcOVNi9hp+iFHeyTHnkMjUwwM2FugH8dncQ5A9ZXpvrxWHIrTZSww2cejp3Z+eu6HEBiuv1TYcKjnV9+4J7NXmRCracihq9vyHFvDfscYtsTBraq/bdTsOLZDeWfcGjnK6/0rbcygl+fBXS5j26Kc+BwbZvlj4dhuHXlj31a5y4lC+jneDJ3zx84pwDHyw8VeGiivO1SDf5w8Tfi7ReAKX+p03F9uBfraYdigJnnIrlKxx59DaLpG+mR7I05SJswGwPE5t40m4rjhk1nIvDjUVOiy67Y37WkTfboS1WmPmCj4cqhq3SrKHZWJrdkTBe5eVflT6cojR8Lh/th+HNkQ9MtKGH5Zx3EzhjqWFrqcDOPT9qKLlH9iuf6todiCHatz7MjZDK8ZJmTOwW9ThcAo01c60WLSXQ3NCR77P38+hCavEdkM4s7zmTjC8PZW/z/Agh8bfKzqpBHNoku3iOxvhshbthyzoo+Tv2wYfbT3rXBnKodOBHnebYMXL7HSZMPSJ3sEGX3hmXsIBvaPoX5HXz5zh+7r7t05CzglbwUvw1Yi5TQW8EKwsIBKB6xZMrNKAKw6LCxvBU1FPVbbC7OCN9cmwIOLNhuYoxDH6csP6aA4ZPTW47wAlhEyz7sHRJX5XW2DHRHJzZCyHWm4FuYvGcchG90uBLdTX6+m4D+VX8m6uiOfQW+HRekEG9sUWJeUMJuZ1s/YhNRb2WFOsUyH0yKvrCuLgvB7bncV5HKp+E9ZqBv2fuwe18znEt/5hnp7EoeeKJllD0DrmmNDCZA417N5yIBhaWp5QKYXzbjm7Z6b8f89UNTTArq70uTNTOaTAiJiuC3eNv+jYBU3s9L1L0znUrOizpws+M9HesSwDffrfSL8zXCbQqBx0kUO8Wo2ctEscmrJt3qYHUEA+baQdzr/0KHrPZQ6JH9HZtj4H/XJrQfFO2NpyK+saLC9tat+Wi71aZyd3E4qdOKRSdA15vTBZugeeDD9avCSPQ45f77e5wDsautoRUOW67OhjuNvz2pEpBRwayI4e0oBh52OvGt1CnyiuupwIn4XMaI26jf2j8N79Lkwr7V8uV8ihA7umnfGH5WnPlM/CR8fMmfnFHHon9stAuAR5n/1rvRW8HWGXlQB/fX5b2wInJiXW5d3jUPC0/Hl1sGlPfrtaGZ4Pn6zW2ML0/SkDeuX4vKPQgUp4JCl65TeY7vR0qWMFzre3dOgKlA+++XXXIw4lT8sQGX+MeTPrFN9XjT7s2yRkUot9Y+xxkgvvPLWZ7PkU8euvfhD+jEMW51Pel8CgjpbTM59z6OOlEf91MGlv1p+YlxwqbtRfPg5PPKh8HlfPoclavM55jRwqnWpRvRnGjX6sOALfOL+XPws5GgVbApqw/+5Kxz58i/r05k9tgYXjO1sU3uG+C/YqbYD2PY8GAuGlomi50mYOpa6s2d0Jxf+5e9u24HonkepgeNgif0S4Dec6rF6oCld8ZU6yhUle+1LcYOJs92NBn1GfKsVwPpw8Eij1DT7rEZ6xuBPPwTUvDTfDn+fGF3Hhye+h3g2woN7foaiLQwaGNx+rdOP8jycb/oPGP0rTcnpxHcOw6DvcHRMRObcPebKybHSEz05Xl++HB3wSRO5A0R9by+q+Y47vlJoM9CP+73amigOY14F5o3th73D1fA7knPFyav+F55djxMsZQ9ij0vnZBnCTr7y1D2QfqtPfP8KhlXImvTm//z9XWW3j8N4sV5Hdo9hnG/pMRcfxe8KTEFEVeOhG4ikneGtS6XCLAJfa3V0clglyaUvQ1govaF3nzokV4pKj4/GgdmgqWqU+T5hLTx+2DDFhjs75U9OncokdefnWehik9Enw1Qwu3W1IMfsLWxZen6QuyqXT7eO+Z2HsCaeMdzAi+eY0OzEufbwfLB0Kje2kEn6KcynxweAXRQkuSWyT7bGEGROXA3ZCy3kaSXOkcd9nZ24bwR99nD1+cHT+co21MlzK/mas0QDb/oSZzpHl0orGK6sILp/g/XSHO1s2psfJc8n7/scPbgpcGlpcPOujIuKhyOx/8J8iy/OIEpda90lxDilzSZEXI7J0EZf89tyaYwI/vTBPjIC7Ai2uzlrMpR7FP/KNqlzi3s/L1FbjkpzU12sXNLnUNM/hYgusLjKpDdLi0gL+w8AqeK5qeZLnUi5NP2YWnguDLc43RizjUpjkyN1n8O3byXUi2lw6kLe7ngGvLwxb76yH/O8K10iH797FNnms4NL+3GnLWlbi9YV3VSsMuPQhvT7ZC9rlaty7BQdSpnq4GuK8w8nXeEZcWmh50rYTFvrWvzRZjbzqXu/YBy8+mjNL0AT1Hnpv7QRlJQpvB8NBw8g1VmZcWjywzSESvv/WJ50LBTdWVjpa4HsDn1Xtg4+TJU6VwaVN1Wd8Lbn0Wa73cLQV6v44J2AAbq+Sk1m5CfVUGtTeDnPS170qgJM1zaYqWHMpQUX5b5ANPm86O+cF3De5LWO+LZekFh984A4HC/WenoXf4u91lMEPH+7wMrdySVuPXdVqxyWf/BebPezRp7mVZp6OXPJMkykv3MYlRmxH92wnLjUMKu07C7k1+/2vuiCfXQEB27dzyX1J49IJmKVzLGmSB5fmNcg0L4ITgy41VlBMLTbxLKx/5/Q625tLCp3b+6rhSbOr7HU+XPwdk17UDU1V6hd07eSS0grNgTRfLq26OTuoDIomq4c1wk7Hzcdn+3FJTS39xh7YMdV4TyoclhYatvDHubQ00u4EoA+5BxrHYXjy/f2agVxyVeJ2e8GLv9aeL4DpU3fZXtnHJfXabtknMG2dta/Mfi798uiaMnQQ/eJqN9EaxKVoRykv9WAu7Sg4NHwV1qQKWAmGccl3YsaftdC2Rih2D5wiWHn2/hEusTZbW8scRf+tPzXdElZH6rTxYGysXd6aCC69Tn8Y6Q9n8xKFI+HS8yR/Hb7t0nz/NYpLrxwWP5GLxvwZ38heBz/IvT7iDYtVnjVnxXKJ7xMRsDQOqo+OOUJfVkjcqngueT1uXeoJ54aNPT4FGR97OsVZ2AMiVwIecFCfBcza6TwuVc66u3k53JVtqlQBeyRzulYnculm12fj3bDuQrT3lGQuFby6+i4M6oeuj22DRzvPX8hOxfnMyJEyEH+bnHUYPFps09J8kUtFB3fLbLzMpRGfNyNtV/A962aGWeVwyWDnZX5ALpdibJbKmV/Dzw9ZLlmRhz59lb+wDhpr1pbuv8GlryV/7ggVcClF5tZ5PXhn+8PPnTBhVCIl9BaXLHJez2q6zaVLz5p6LQu5tLf1t20w3HEhgPkCMmgx/08x9oC8qJp0CZf+hnT+sofvTEW+H4Kqz+YPMaHhF/nNtTB+Ws+Ri/dwn51xD5TL0K/+HfEO8F3YqEsIDHk4YZwDh9frpRaV432upu03OPlhtLxSBeo9/WnFeljv87JkJ3zUdiXP/xGX9Jzdo1lwzEvPrbwGr+tSLrnVcslZU+xzGXw6NVLs9jMuPfwjrfAP7tuh6Wz7HHvGjfvi+Au8/22nc+VLLim3z/tPop5Lta15riuhT1TcBydo5LPO8zpUn3dkWn0D8tZlpCDfyKW1tS5POZBzWlnL+B2X1t9Y9dLwA5fOyG1gD0Jn8aSVNc1civspPkEtXOo90cJr/4T4R+SNxNoQz83L3DPwdmzQ3frP6OvnwsLqnf+f5wTZY3BK2q308S4uuQV7S1h2c6lq4benMbD3yU/Jpn4uuVwTmDl1AHvmqKucI7yVunlVA9RbffpU6OD/z+X5pfkX6sV/kas+xKX5rcpSR0Yx3686Ai3HsAdYvB0x8MjMb+T2D88X5ZK9bAEeVY4tKWiF24O61ogI8qhgTaaVFYwdvWIRBqW+RXhWwINmUtr1UPqQdm2sEI9GTzPy9wnzSMvr1PcLUPLM2I0cER69E9baOWMqj5YsuB5sArt/7napmcGjkY2RD+REefR5QWSuCZQ60evdANcF/PPKE+fRla9XrUdhtVdkl5YEj3TfOeXZwa7eAkf//78uLp9qL82jkFPL6xpkeJRX4C4+XZZH37rGxTXhiyuvtCPhmVyNhfdhxn8hB4rleMQ6XGfxDSpfcGUqyfNocPR0jwNU0svihkDLnQlefPhg15rbYQo8Sumc9O4N/DxQtaNEkUeq/feWz1BCHLqVs74v5FH9koQvSxfxKCIs74IDZEspT8+EW0RcnMth8zL5slZVHvU4laVJqvFoTO+/vtWQvdv150tNxFmwV0VJi0fTZx+dGQYLH5atfg39jkW9rFmGeNjhTiraPHKMyP1+ElZP2fywDLLS996qWs6j14tCrs3X49HcFAMvD8j3XcmNhBvlXmrkwZN3ojY2Q73WSrXtK1CHfkfdZyt59Eh136F1Bjzi+spb5UIP6yPhaw159J/nGcNEWPTLJn7hah79TpUVdYO+nfFimiY8eho2bcwOChUa/qxcx6MDcxYr6ZshTpXCzDr45c/n9ec28EhxYYpSCQyVUrEcMueRjdlBeQULmFv8zgw2PLgWVwV505Ik4ywRd8ij79M38chfxm2+EXx8167iEtx8TuTWeWseKUhErJllyyPG1q5EFTj9TkJqAKxJYqyLhP7mp3c02qEOqjV/F9vj3JyAV3sgZ84qrUTYOuvNljOOPBp6knPHxgn9aXe/7MZ29C2zlPERGrzlXpVz5dFyK1GPw9C1vPJdGtzTXFF7fAfqGeie/dYd8zB/met8Dx7mVPeZGewxVz9S68Uj58FTzQXePMo1FTL7AKONwmZp+PAo8LKQygm4tTuu4CrMt+vsa4P12iYtEn480vhT66oEr40Le4XAQ+2pqoMBPDpXLMzVD+RRgJfvcT+4wTyw5w00b/i+aMde9LVA9m+R/TzadePGO3M488a4xtsg9Kna6cQ1wZiDywdE9sH4x2fTCuC6GyEN46E45ynxzWfDeBT08ata4GEeffQV+GtyFPN8U9fh0nEe6ZR0P18SwSNvzW1+O2FC6PmZBfCp3g5zj0jkZTykTTKaR69s3CytILs5KuoTZBakuVXF8uh6qfdEP9zWOcxRjsP5jQLmHYAtW0a358B7nrevV8OoWwNnys7yyHjNp3+8eB51/Ly66gbM3xWyoo7Joxm7BL5PY/HoQn2Fmz10+nFUfB8s3luslA+3R6uot8Omyw8dz3Bw3sFl4iVcHgXbbH4+Dq+mvXdn8NDfyn9U7yehn/9tNNqdjHzcf2I/ksKjKc/7B01SeSQqNmPkMDxlt5VzDppd+OfidQH7aAqzoj6dR08UFHf1QIWo+/OXZvBoUZnjhr1QIePngXhoZTagf/sijx6Wf4l4folHJqU5JWOwcs2TMonLmGOunkvbFfSFhaujew7yWJSzJA12f7Co6rmGueTaWO/O4xGNRTkoF6C+UjeL9sLp0dXPJhXyaJ/htNoPxdhHi3VzhUpQX6l8WR14rOgPyx/6m3WvroHVq4VuxdzlkYXS+pJSOPn15dqgMny/qH7QXRh3ckVcXTmPrOfcWSdZwaMfoZ3r/ap4NOyd3fTfIx45rNplvR9Osg8aEX2M8++eO2pazaO9q5xGV9Winl0BIW9h5QzBiyefoZ5n+uoH4N30DQvVnv//fxBqd3CCTuEhkV71PNqp89U3Fna8cgmvgh9v/2149xp76ufjZ8caeFQlpNuT08gjsS0m3NgmHv1svD396FvU8+JB3iM4Y03je+t36O+gVH4m3NK6i5n/gUd3vghbs5sxTy5Pbs1p4dHNnOTlh+CRsfcdBfD5B9OS79Dp+diGl5/w/Xd95s9sw76+3jk1As7c9CP6KVyf3DDTowPnjT34RqQT8ffP3eMNhyR3qp2C/kmKB37ADdHd2x2+4v3eF9Mnd/Nof4tbtREsOXhKbA+0ikubzYCfPVWPy/ZhXx7sF9GFW8o914f9wDnFSzhzB3ikZtM6vBbKaD6Xi4VCZjqBXb/w3Bneu2vrEI/St2+5Ew/nly+36oYnP9YkHhhBfbpPWx37jfktUq6uh8UKdxROjuK6vQsHyqDQRccG9hj21E0Lha6/UOZhvNQ4j3LGt+w9Bn/Yzx0uhIzCFD1jQT5NmzAcOw6za9cczITOvz696Z7Ep7Xnlmrfm8ynC5HzJCOE+KQqaDBeD/+bHH/WRZhPYu0X3S/BoLoTn36L8OnzQRkjnal88pWbX7QdGglel66ewac4/S9Oy0T5NJ/+TImCE+t3CJ8Q59PP1wXCvXDtx3JhMwk+nePabkqFUUr8XfJz+DTYvLJvRAbXG9eec5PlU8r2k5518EEOU2qGPJ+a3p2xPgEj1n2aFafEp/PGZQEPYVZt9JdmOG/9Vs/2hXzqezXWrrOIT7sOme/NhNOT/OQmqfFpceKPci14qFYsNgbeTdouWarJp9xe6axFWnxqsbFZGw6Hzq1cmw9lg/yPjEKt1pv915bxSZe3NXWPNuIZmrXwHDyiP+y0TJdPmtO9vS/AaavP6lYsRxynLQQV9fgk4Sv45yAMDjd3ew4v2/0n7LGCT0pCanMMDPgklPSygwVrmmY1FkH7f+ZKrw35xDytJSqxmk+3rynWLIPRh166suHMvPkrhIlPHPmfyZ+h19IBnSkmfAotmhdsD5OdtzwLh38/vCqwNcP5JujNKfjkzVs7zw18ap20rDzBnE8lyh2SByz4lGekKdcPz9kubb1nyaf2CoXXQpv4tOnoilgFuEs8/bIzdFhZyT8Hz7deDhqArndMO9du5lOPW2S2mjWfHm/mXZa249PGl9ID3+GcmFs35tgjPz6rXRJhjt3cd92wXm+f/TQnPok3nLeLgRYuHj7lcEnUFIUJ6BPZoivmzKd3zKdDsS58ymcKpd2H72fPXCHpyqcw0ZN/TaBzSlxbNlwUJGfYDJ3WLI4238Gn5xGxI2/c0deqbae9PHC+X4M/r0G+4knNSm8+Nexcoj3fBw48v2sJ24cmWYVDS5eg5gIo+Szr0iZf1CPgu72SH/o/MUfZBAZ8lWOxodGUE4lPICN+zValAMyJxUT64kA+GU9kS92E/CjhLzr7+bSj1nJgJ7QrX7T7Cjya4SXw/gCfZvUWq2wP5lPbH6EnM8P4tM9DO4BgtOveF7vhU1WBkx1H+XSLufix+XH0R8011Q8n+GQmuG3Osgg+iXZfUjaHd0P7PwRBqZO5b+vga+7RN4WRfOp9p5viGY3+GFtfz4tB3p1m8k7G8ulM1xfmozg+BcrOWb7xDJ/uSA5ttzzLp7O33nxbEc+nNbbCttthcai07lGY1xnsMsRE309fpBLO4pOa2Jemy1D7ttVENhc/F9jQOYPHJw03x7SZiXyyfnD11FoYs++eSjWsG7kitjcJ8frNP/wDGr02+LY+mU/qHh9m5sC9q6vO9UHJS4O31VLRT8c3XnKFSfq+X/KhgEaUefYFPs0un20kn4F5tR7JdoDFMzTNk+Dq/ijLcnhDUSBZ7iL2gbb7dy4cmnFpVdolPrG0j9d3wev3Lqp7XUb+AkxTEiBb7fH3QtiQsG9ODyxLyNPUusKn2un81/ty+OTp8eCuWR6fjuk3tBbBoohldR43UEepom1M+LBIbUt3Ps4ZY1GkXIC98aW3Mg/e8A0/3QSltB4WSxSiHzJWC2+HzCWznV/BiSLTml13+LR+cO67K9DvR/LsnmLsDYb0gEcJ5qfvZQ4D/nk5J74SBj9t3NMBE/r/7bp3D3v30My3i8sQx7DZjCCYaGq05h18+C1pYfgDPk1NVV+xqIJPC/lzA2qq+GSgzGdNeYT8exubfoH39nLH2qv5tL+TL1haw6cOGxZ7HH6J7QtVq0WcE6INcVCOr9lZCq/s9hb8A68zIlb4P0HdvucrhT/nU3/oYEYqjDG8YjUAS8QahK3q+GSoVy0b8wJ7aKfXjdfwf75x2fg=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="32936">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwUmndUiO8bxhskldHURgqVSqkkxX3dbyR8JVSKSsNIZpKMaBCVSopUWkhDWnb2aKCMhCYlIrIjsn79/nj+ed9z7vc573Pf1/W5znl+9AhUne+ByVWf4T5yCs9euAc+VXNx3lGZJxcPEo7KH2brHXvgEjKWByzpoD1ey2DVksx/nQ6goHAlxu5YKyyIk8TMG8lUstWGhlYk07oeGda6tZZXvzjO0ncG8giVZKFAXkIwPWNDcjqD8LtXhbL7SbPcOHObzYUTcCw5AdObLrO/TgO//e4v8Pcp3Kv2mox+P8JdnwbueRvPTpXuGHPnPkZNSaEt63pwxVsfGZbXhZD5Ujzu7xHKVn/IbrIH2GWSJ9Z4h3P6omnk73cOew7F0NVPC3jMoQDsP2/MDaQunFttisEZ5UQnUqjUGdh/UpX2VapS6ONpZLlWj+uWP2eF1mnUnvkMFKvPSh+mwdRsONYGb8L8fql0WHU6dI9tguGgVOodpEZLR5Vwy5yXmKuYSnduTRMm2qzn1eqpUIIaTVh7h08um46bvcewW64F724vwxdTgTuSovi/2g6cMfLFxKfr4TWuCf2aPpN//wBINRgINrX9+MKQK2w5YBb3l+/GAlU9zr5YQe8PqVH/OS6sYeBPL/d0UuTkPYj7UkFv5s6ymX7SjNuXaMPkRxQ/Se2kJ+e7+d0tNQp5qQaFKzIsoifHXdGneVVIEL8epg9f2PKvw0nYoijFjVI2HLe6kurW22J1QCVpjX5LVwJtaZtFkZA/XJ0CsZ33Gj3A7pNWUHsgBS+Dw3ifVIB5BZuhu9Cel29fyTE3ballcCm27dXHJld1OnzXlqXtw1g04y3VbVYn5z+VdLRlN7RFlCAnNoOnFnxDcf8qygx3ZYlBWxBo3F9ITjhMNxMPk4WhEpbc+0pDzA7iZbgJf90hzzr3G+FsX0XDYysEijvDiQ/UcfHdYQrosORDn9TpZmoIjKVHCpLGi3nWwbtCc7cPpCXTyFhWAzaqGhRZOhlPu8U4UnwrOsYm8rVxabztyEEoFA4UHC5FY6BIF21dmEaTU2L5hEwXHRyQy6uT7G3K1Pw5y+YUds67TTlxabRksAyk6ibCzcoDcT+ecY6xq7BoRRdJaRVh9yY7So7pootRdrib3EUjr2pgkuwyHP85Tlipr4Xoq2NZRGW2YDXIBctbNGhFjjnX/1O1CUg4hsSJPpB7NwWKEa+xK0KZ5U9l47jke9ovosvn9DThrdiKxZ8HCMNN0slZ+w5lVX9Bh9YSDDkqg3UWmnRixHc8yBVFYLkua9QnY8iSQLhGX+T4FZqo8dWklVWPePpLO76kcwk73g7DijhN6tmfTmsmTcem7Du0MdMUiUdMudO5BMsLpiJ4WxwvUpiEmatk4eYiwpnD5TjQ4gMFxEoJeV69sP4dha4rabzqTz7GtpZivlgG3R0Yhfv9MyhgrZVgcqYXHX7K8Kv148VDNbltZjR0aQN6X6diZHEPfbl3m9c7RSP5sR0f3zcIOrbDsXL+cCpeY8qr0wjOvzZBwryJBzSJCMvGDxcqF28T3I6YIWn2YSgpvRTc9YxgumYuH4/vxercDLqRcE6ourZcSL00HG+yP9KotEhwUg4matzFTIWbLCt9lr6klsB1QB26Cz8gwF9X6HwZzVZPBCHZNRmbtsxG4b96Vm3axk8HjaC5X3PhHFFNBnPdoddbgdLhLHzfcwwD3m/jWpVMDDZZh4Qpn6jn3GxqtgphRatM+vI4kQ8lKwvytWrCzv/0mGeNIAfXn6Rcu4KfrMykzyW7oNACzIjvL/x3Pl3wT6tFQ9AIktnsy1tla0ju6ifKD8+kI1GZ1NyugtySJNhkZtJX00h4GN/hExui8WtKK4KG1E37MvIzfbxyk7+1tJN9ejrK5W5jvIyDzZKdAv9WXosNmnYY1CAODREpNgv7TK97DmLvbDvk+Smxv1kETgwaSTZDRpLZ0JHIaF8vBPvFI7/yCZK792LKuNkcW38cL2dJcblrOyu+vMhjvu7gNdUtEPnxEzGrsqhtzwlcn3WPIiZrClIjXIQrC+/RgqwuzHSJ5q/8hTZ8P4fVe7IoLmgOvVj2hZRSR9IG0wQhyMsYVS828l7HA3Dc+Yuu533F2S9HhStns2huwheaXD2HrG5upd8m11B3YTePCboAy1p5Xq2mIbx9ORLZz535xbssclDYRi6J5UJ8XCKpbTDki9YBPC9BmvN1vlKa60TB7vhMKEzVgjVpYbVoJh9dsQG7Vm3gh0WFiBl2EYt3ywnKHxdzz6MSLlx0hB5Ne43MRfnIcJrIL58bCeU9GghcvhteSgXMb5WFvENjhNULTKDY9JVGLIhFjWQwli4U5crtJuzZep9uFh8hj/0KHH3WA3fLanmG1Ri8derPiY1HoD7fiZvV56J07VXuP32uMM3nD8UMSUBGoLYgpm7J453mIu1oKd8e9oD1LbS5X+8HdDyfhbzvJuxudx+XXeuxW/MoHZmvjj+dEtz0sZrHrnSwWaGpyONzH5CWxkXUfRnHv+aOoqeznsFq6VHyjQyD3EwVm9paVWH7tqMYuv0o6d/djH1ho1D/vh975IwiRccJNuXts4Qzim3Y82AU7r1oQYTWLvieHS2Yns6H6bLxXH9gJvfGxvJIjza4JsrwhTdhCJXUplil7yT7cRvbrJyK9GZLxC5XYjELJ4ycuoMutNzgitUHUT9uLwYGv6ElZmY8wMoAmesPUorRdwqd+x8m9fnYGYkm5Eq0Q0FSjtXKMqBYM5v3FlSis6sN/nOPUVBlHPSXa9NZ/2PUU/ydDEbX0oQx8yjnyC5cD7LgG2aZfDdEGw9Cj5FckQYo+hhdi9OGdu4xijniZ3P07z28UArBk1kPWea0NhwpFBe2zSM1HS3Bu9iVn44bw0cPqLLlwh5a0alN5z8eoy9z5+D17I2CsGUWh88s432J0fwtJR4/K1OwdpqTcGr6bD6/MY79miVYdqkmkpdpYtXpTH5+ZYCQMj0NRcf34VmmCPpJxvCXLx0IX/WIEqTBlvGhXLQ1m65WQ2ir3yL4jx7GldN3Ql1Fl/+bYcgJ04Dam5rYUn1OWBE3j6tcPrOEz1kuv/yIHjnvhMhtHWqZbo/teafw5mM6TqysQl63Jg5YRnGRy338K5/MOXv3wqhDh+6sKsHrzcEYHg/cHZ8DT3cp/t0ZgZRBx+nEtztwmaTMP3/k8/tve1h7mh1X/ZFiT9XREKM62uK8gGrNRiP1PTDSewx/WfSTMo0+CM4aXSypkY2MjXW08kt/nrDuJwU5i8JwnDhn5Cygf22mrJL7yiZ943G+bjKYB+0Ipcn362jrp13cuCZLCNiezdY3CvFiHaM+/zh9yQolN5/neCFXxCMteumsZb5g+GCNUB23iO2m91LyhMckLRONGx+e8wsLR3q7W5xlq0PJWXwMqUT00v5tYZxkfpDLbnTDrSuUxh034e43FzipuhuhZ2JZuaaXFt4M5C9Di7isqARScbuweEoO6aSvZEW9S5ixphoj1I7jYJMjzQxQYf/ic5jwejF3rh5DRQbMM8vzhMwmBUzWdcJuvSf0SP8J/Z3yma8O78dDZ/Vy8H8F0DokQOpfD67OfUIBt3NIdpkbHGwq8d7PieSqBIg+zKGm/s78TzQVk3V0hUVjp3J58wg8vPOLinY8oZ15TrRPrw3zToTRMLEPVDxMjDvEVTHPaBAHlmRjhqeo8NMtFscehfKdQyd50lUnmjP9N71/bc/OvI9N68Ko9sEPdvryhArtx/EEh3E8+d5FNt3wnGVbwpDGY+ncmsswNrjFnb/FcEtClh92eGF94hGe632cux+ch1zsPPzcNBZObUexbH8upYbK8wPfpzTjcSwmSF3kxMSRaGgrx225Hs6uzuMC3WZ0atxDe04uWXolsOidXKpqOotsu3CyfmaOiffGQiG/Sfj03QYz6iIw80ME5L6PpdW/f3FiAOHR71wampJBe3/fxF7NAcKa3pHQ0VzFdu5K+BY4QRgWpY/T5qeFzGGPmDICMKGjHyueng/1lQvpiWcodKpcWeWeihD+/AICTf/St8fhkArQwtbdeXRA3RfnjdZh9TNx6M//S/MNBgqvrn/Fu7uHuKHrCXv9kEJGv1NQWPGXlEt1yWWoKG8S34mMS3nk8k2Dc6L6+KJIC+se9Gno2D49OriJH3mfxoJLPridp8PGPJ2Xdw4XnG+tQ9fwxL68oksXJafw38M5kKgPxWOd8zjffxQkpq2C2fB8mmczmc9KrsdrmafwHaNHK4OcOPRMGQomDuKZnbuhOkcPz/AUEapJ7HjcBWcKv+L9tw8wu1YB+9h/9GC7HvXOPIwx/feyyy49Kvy3BEm6jkjd9xKLovJpbfBQvP05Hdue/qMTX7NRp5oCOjKeJ/aWw3/Wd27cF8GOGaMwSnw6yy3JxbLtRjD/dJRXvtCjLxaDBDOdCxDPvkHJv+Mhmj6E28ubceBgFK94Pk54t/8ijAefoKvvv+FYpRmfSK2EaWYj1OQ+C4Eth9m39ho/OnYSk47489ehAv52B3O+60X2iRwqzEnNxJaaJq6oP006t8Zwhbs+HhwUQWugPjxVmuiA6iIyaY3nC4kZfH6PDJpHLaLJQXdgbrSeH7tGw2h5fwxfsQZG5eexMF+fVkmvgmz3GEGr/S0WypyG2bb7mPV3KJuPTGfPlhNk57UElBaPkFZ9sp7W5+93mkhSooDeL6vi98+DWfnXGz5S34QPDSf5ekAhLLqV0TVYFO6jt/H+foNgNmYctcosptO3JvOAyQUkr7+THQatgMErDbQ8+saqNuPoa5svj/cZRyKqIrxpmAQMTEoQL3mMp6pFEN6FcvuxHPR/uEeYHDAOwYI+L/W7RTJ5jkLBxHysWq2DobtP8qVl89jZRg6bZ0jg4+FmsswroLrf4Ui9XUBBSyO5OCUU6x42U0rtXNwans43st9DWSoX76VzkfBjHM3Q2Yem+uXcuF8TV39lsuSQFoqRa8cxvSesMPIXIo33QTqnAc9U1kDN6i5638Tg9nt5nn0zHWK/dfh7uSYqREZD/1IEXXBtofSFJ8lPUpK7j1Qg+e1irjVex1MzNuLQThXe8vsV24nE8bsbF/imrBgk9hhQjGUiNEK1uU5XDAfypkFxnwGWL3Tk/SK70VK0nvu/O8XuLctY8fw0yE8SQ86pkzTydwv1N3vObhuINbUHwEMuHZO2xfDhZivBpvkgnuUfx/sV6nx+zXCM+vcE2nDHwEkLeeSa73Sn5QpG/1QWog2NWFlnOszixOC+0Z10DoRh6UExLLQ+CsmbS9m0bx7Eu1p4z8aR3HnwJar0DGmz+0DePGAM1pRnkPF/hjR0jiHNLHOHw9xCmrBui3Bu1zj2jFBkUZEeamoIw9/YDSwo+UG+bACuhRmyz6BXMNgswpZfw1AOV8zaUsxp86bzwywrLlVWFuynThDg4wr76kLUOVchsrGQilc/h9uzqZDx96AUNWVhbfIYzDTUYcVfp2Hy3ZDy7/nBZAjxDekiMlolK0we3l+YfV2Jv8gb8dpzHqQ/VxziF55Tex9j1GsZoc5PHGLR5oJ1dC0vD21BcNIOSM+T5KgAcWT/eE41s4so4sBkHPI14mrtVnqaPBm4XUlP8vfxp7k98LEawP80ZLhmgSlULPZDO8kIcgl7SPqUODKFCXxj6l5Uqh3GxJ8tuHtBHBvKxHFRZgY668Sx77E4/t41gvI9I1LKXkIHRxcg4ZwuT7m9CJWook9cRQ31S2jH+BXY+luFw/6K44zfCa6tmYSvAy4i++0evLY6gLvh/yFWbw7fT92MaM272LhrJE+/sBe3yzqxbUgkyueOp+IF4ync9i4sFnhSlLcU2y8upgyXV3z2pDiX+kXxpbc7WXv3eBxe1g8ey/vh4kFPvoZk9MQUU868gSi0e8Wat46zTo0mdygfhffufpgf1Q/r/lnBqDMaR9714NwQA/7pswWiMxx4a8lJoSRWhj0qxpPn+wpcnPMBTbt00V3QD9V3UmDmfgpRwXa8afpXuCh6UfTT67xZzYtyGsoxTK6EIocZU42dF1p1FnOxeglddvBCeH0/mOdfwYJ7L9ETylBbZ8tiJ8bztS7fvn+Rh8X2JZB0MKafDiUk2i+KSm//5fhJuZy2uYS01PvDY1sJXTr1lNeFlNB0byUebtEf+cW7kWIox9r74+GSIMs1DVroKQV/aOnPLTa2XDTQm/TlE3FeJBbWgWXQ8P4L+XxFm2TrAVwcsYrLbdrpUthLSB1Lxeng/viTkA9lx0RYx2px5FRj4U3ELkT9EHh/uDfx/Cp8dlLi720SHN1az1ekv/WBah2Sf9+hZSf7456rCbLeeKO5sj8yqvrDyKwC4iJdfPDxBaxZmIb34h7QWLAR42bvQUN9f5jJy3LQu/4oVN/KaeZi3J0oz+mZsZhmVg7F7MH8d4kPJvXTYPdNjbg5uQEF9rs56XUHxm7S5aZjydyVsAf3mkzIbKU++o2PwM+SRixOSULJvC+Qxkq+MvgWN3u/h9Kr6/CbKY31CyRw+vcsfH/2kk5onqKN73MwJcZcOKdax38M5wsfx07gj4q5aFFZSnJ6TzDTJA6ec6YLdpEe3C33E76WDjgSKoGm4GiKc51Azh4OKHVcijErRgtLv6rwhuIa6LRN5LdS4yCRLQHZKxKwtU3i6oJTvHhHHFqESKwKG8LdzyTgI/UCeQ8csNiJ+HqdAx5/deeupfIsmvQDaeVruNpHgh9Gf0HjsFBWmv8diV/tOHqkKSqMTlPCxBoyOKnB/lrH+Yy+DNKNDqLKzhPfV0vyw6mmJLG4A3el+3R+YTapf/nAwhwZ7A+ooUD7zfxi7RX4+52mPQnfcNw9Fa52N/lK3Gkqt+zE7Zgi3B6zka8nmpJb3T80DhJn9+JwKD37ByunfVCaBYR+XUYR3R00Ivwrbl43JYXJBkh3no6fD8QFDfOjqDz9AZolAyB8OA3VWcnomrAc4hmD+YF/O6IfBuHfNRnc79NPyfq9ONs7AqWb18OjQYM3T0pDWqsMnm5ZBZ0ME/Y/5IVpO4IE+6v2/Hn7J9QVv6asO+f5eGM/Lji7nFKVJDFBVRKHK2P4mMkHvNHRY/Wr8zHlzjesOpYvmCi+IdOn1tyvdQ5Un97mVZ/mo3yqJKw3O/HxL7v5Wr8GmKl849Iphly+7zREhgzmXTUiuFH/H89ZKM4r44bxyY2DIDHHEEq/zGj/XzOKfLGFfXfcxWDXOkj2P0vOPcWQm9IkZF6yhaeEJh9yvE8TT+b3adZZWrVtPN+pWYGgyypCb8l6fpS6AMOmmEPU3pyu6I7hwKPHoJn0jOdM3ME5xmNQsJswaEIOXa8xxCX5Tgq7L4m0YHMKDD1LvRHmsIw0p8fh1vzSyAdzBnhygWMTFvcYQqYnlhcVm2NugQ33xqxB95969BYuFEovP8XKOTvZv7AWpQMtuOGeOa5lnYHBuU7qfnOELxoPRId9EUyu+yJ49mWc/XWWhvwsgX9QF8u7VvD5m2os5ESy/4hz9PpfJ4nInoTqy0SUvdTC+D0VlOU/ELkiCfzNfT9OzrwiTNgykJc4nKNN12T4mNxVWD28i0vrJuLC4EpuWlwKxFmhft8ldv/ThecJEzEueSJxyjmKx178cAzn7ZlvETlblTuPKNskTB2F19UDcR9WrDPjJo40rkRuzTk6H5yLN/cnUtMhEubO24GdT85hWmUER/ybwvmtpQieYsK2+WPZ48kgDvulws8957CSRRxZHylA18w0WF18SEX/pSFeLpX7fYjleq/J7GhsQT6bLyBeNQHda1tgMSUfv0UP8bDc8Tj5zJuffQUnKTrzS2MZVvMJQoyXBUnE/MCwuONIuuZHchPFBP8rs3jGt5M8vvs1tKLPU0nkEA7MtcDEysMc0p3JE7bfQ2SJBT0ttaBPs1Zz3LnzZD2kHVbHslBxM45SvGo4fUsSh4n6sllPPf7lSMFfZTl+6gowtPqLva8taOinJI4Wr4OG+EAh9tQYfmyegqGH1+Px5lV4/f4lbg05jflZalz47jDEQ40xuv9ULl4dwW1TLpDN/s2YbLCJlVfexfD5b/H8+nKUrezz4K5VlCTny58+ddGcqEnUGz0JDnGTYOc8n+0TJlHOcVWumLcbfmo72SXlAu10+IIVeiug3XkQ9b9DMM+E2PfjSqE9MRxJoqIsW3mBCn9WwneFND7LTsXjpCJMWJcg7FiRheOH3lOL3y1cTYgW4kY2gLTKsOfXe/yOuYjHx8LgE3FMiB1jKBS2bmf9h9I4Z/6BxC3WIBdn4PNuFt/3KuHkCUoc0KWHCr1CTmz5hBtxDbD+NJyLHpng0YADCC5z4b1ZZViz5QNJRaZCPfUtDEM+0OLh8nxsQQXK8stI9p8JZA6dwYj10pxbuIa6i9ZQp4oMIra6c8oreZ7CTZg9fC8sLn9AY6wvFBOPQvZbGf00CuaVH6Mw52QFX+v2hETgTlSuS8epnx9o+XZ5lte6SGILJ0D8z2sOGv2YPnwKFuaVv8RhHxlM3bwXLxasJZG2gdweOgHFC9ci2NmR62U/4OCeQI4Pk+GLx4y4KG8C7CgPP1LHCg0jjNieRfiDsZTgpHwMlrrDBMvsMHYRG8pm/TbC+IojVzQwy1/+ir8d9rxhwHDsGZ3OTjWSQsC9lSjOiuQ3CsDvUoEn9G/HSvl1NOiHDMp6JlPGv72493kO73r7D5cUothU0gq7VrAwyfAgXgy+RKrr19GEoDlo2jEO15xN8W/fTF68+RPpvbiLb1s/0fG+M07p7sVivUF4NuMdoga6sZraAZiHmKK/qxW1nPxET8eL8M0bi+BY6yn4K8xGW+kc+Ab74en55ziz04qks/aDoCn89+YTTdRMw777kTzf/Qir7rtEf75+olPFVjShLAfv4t6i5tRBPvAsxUZSRZT35qpiTtwg+Mp3YdiCz2RctQvars24nfMFvpuSIQzaImRm1nB20SCULVvPJZEm3BX7mcQdunh6u5ugKzsWARPM4Gkvzplxprytcj0K6/R4zeTL9PCqLfeWbMZt68e87Fop+jWspxWN66G0zQyb/6xH+n/yiJEejNwV2lzQs5F9686xt/QXunNdhmcM+YIUWX9qjAtHR8xlGvHyKeJvV6DkViLnjTmB7ARtfvOmgfPPmkE33RoVmdZoybImDb8v1Lsvgd6VavOx/scRvO8Ab0qowb5b1qT+WY7/yQh4Wm1NKr/NMKr9FyokDsDx4BbkvsmE29ttwuPeHihF67Bg9hIj7iYhptUf72+2oF1pCmV8HchLmxLIJHEwf/a+iTFHZ3P3np+QcTsOOfEnWNO6FCLNNnxQYwOyhn8lXfVxwliFJ3D8bwp9s9yJxcHmsGmtp7gQcyjeugqZTVZc0raYExsGo7JxMMS3TYHq6UKyT7pCR0Pv4E70VzrYPRhlwSO58tZTaD0LglfmFDr4ayU/O7SBNFI2ID3nK+3ySKTwP+p8u+IKLVYawukG5jznXzoKJVLxLqSM+z+cQjHhOyEamgj1Y2pCGQ9g4fsV6rYT5zXV7rA/cJtW3urAxWFT6feOzVivMxGXf7bw51/P8GrkVNpwuQZh2lPpUx87rR47lfQnvRQ2LSrgfOv/+PqxS/DUXQ6ThHm8fFM33S2w5LP3FXDCwgN18UOwOy2AtK0VhZWH4uB6WJrDb83mnVE5UDqyG8pHB7DONCWedbUVIl8TKeTrIaQ89eftWWUs46SHepGTaL7an5OFRire78du9ncos2AqFM5dpagnQ2AYNpRvyH6jcyahkA+YB8+meL5kfADt6sFICyuD+KvdWDjTgSscQmE67yQUcp8gfUEoFEX2ochpF4xcvtFb12DMWpOMyhEEsx3L2aHOFWdtZYWY3e8xUe8aVWof68s8G+nGmW+kwMcgP3QjP0/T5x2ziilR7C4KfNfh73c9bMZQSFZtpGFpw/h8cQKriexm35hmnFIv4p7JTWSw1QL6ihrs5D0UC7cU0xmR7ySZWEwnvJso5pZPn6/oY5jsE8zasxXntQawr3EglTxPxvEYdW42C6SfNyxQ9nEJVt4nlp4kzjggyUN6D6D1rgUeLv1OP38pon3kUCFERAkG7nOgaOTLm/MF2FwZirCU7zTh0BfWk9zF/k1DUaQDlFsqwf/hVB6vd51+GApcnnQPk04cxYvG7/RLJg+ZS1RZX0+fYxZ84aF0Bi9+7kVYH2d9NVjIrhKyeLwRuLb5Olmry0Llri/cL3vi6RAPturjzlSpJpSHX6eaY6BR6zbRkoWRwumjL9H9zq3Pq8uh+cMTej894bt0OA+MD+bPi2RxKmcT+tCKVs6NZu1jD/Dgwhne9r0GqQ8uI9LsJkINvHDxGUjCyR751RcguaOU/zac4gGji5Ag/QqWWZfw8fFaWCVb8OCBN8jJ0wtZnzdRm1IIROQtkWNdxeHS5lycvIzvqFqiLFGay7TF+OyYHzTxlj/ELSzRuE6BG43OQszpBomu8OYd9xV5tnMQ+fZk4frmRCRrbkCEbRK6NesxJTqInq1/wn+8dnL7PBPofJLF54s/6NvO4RwoKoftAaXUUniD1I3SeexXbf5QeoMs7/ygIRdv0OHH+qxnsV+41XAC5iczeP7zBjjFJ1Hj0iO4lPoVM+cqcZHtWwy1vMj1hUmYdqWYkyRvkrWGBptJ3yTDBSs5V32BsEhRSgjLC+CcUAOuqB2G+EdJCBAPQN3ut8gdPxmRLpbCg4ZJnNmWwyY/pvJF2VVYtlsOT78lUWrcf+xVvZkuTTMQVm3t46q43xB/48wJqacxY+9NepcnB4+DAultWMT3Cm5S+MBeSr8ph2EzDkMqb68gOqkG45dPwOen51F6Rw7PSq151rTbuP5PmcdqtWMT91LHEA+UrDrJfq0ClbUJ9FBEHtL1k/FCTB4Rlw7g7bPZrDjVEP+KooQg6VvUIvIC1sd66emS4WyW00tDp4zlEU2KXD3jAvbv3MXjk5Uxf48p2yiIsNiyatTpy0OheQtOXXbi6W29NLX6Nh5tj+XQUSfYVsyUC4xDWGK7DXYp/YJ9mA0JuvNw9Z0/i349jNABPfj31w7yUTZYGMKst6Abg+QL8HTzTkZoAgLCElC4cA3Hl9yiZgNxG/tAMT7xeiO8Oi6gKmknjG9OYOOorVQXex7fovcIWSet8K90KRb9uUV3JybT/jtWuOybwAPlMzHUawmsfzL3r5DHhUnZHMYy/CVmAH9SP4srx8dzY46d4PnEmb0nd0D5+hLUjPtNXkPnc7qhCf96kQKplGTaPPoCAoMeoPFBAUYo6HH0GnNuz0rG6qu72CmqnDT9fpOjrgKa4qahUPMJhmq0UXS1Gov9GsnrX/RyUUk5nRu4lz/YKsA4b4Aws3o9JKfbsZ1oOjwed2Da9H14rLQWj2YM5YmzB/NCM2+h+PkBOIcogEZK8pswBTbdmQgrOXFhyZlNENtjzJopE1iYEoyoqctxPfQdCu0vwutiJDQaxTjAZTpduamAI4umk9PKdIyeqYqSw39osc1I3jAtC+W7NFnvgClfalvE27KmssScLCyKSUd97WN8OG7CES6nMCKoDkMuyuCTiQW/ikyhyAfLsX32C5Je5QXHqWcxsLaCVsjIc/+QU+Ar4xF9ag+2ODzDqGFRUFCOguEscyxXi0Ln2SDs/G7PPbO6oPp3OlldkxZYYRQOKx7FGuMVcJK0hb6CLYUOGYQW/TN4V16O/qdm8y99W2oP+Ut6N3+hpnkQ/92qiHSdzfCeP4XDS7eT5MYinqnRDAXzGBhe/kt3Bk9FXWAltqYoonWzLTJfbUf8vLH8Q1cNI83a6UDXdvr1SYGrdlVS8+CLaDmvCF+K5CpbNbzW0YWbnRpanKbijK66MCG4BHoTh/K7UnUWq1fEwYxDMGrs0/h7trTncAnyz12CxqoCbnU7wlXJGbDesQOLv9lS97BSjv1hS2sO/MCPX5XUGq0GVa/b7OY4EVH+ujyzW52nq88gvU2+sBh2EAt0t2B7vQV7Pc7A68CJ8FFXwt7xDnwx6BO36VfRp4pubAleypYzq2ibhRIO9eXh8EnT+cbcKiI7aeFsYyLG/95Bvutm4NqGKsr/moj3T/N4pFs6J2vkso6HErxCZiBaLaRP4/7gpNR6HrlVCY36hZCTvgPP1hiefX2wcKgvU9SO9OCgEcE8NCga32MJiTPU4T5YkpfNUsdY7xAYjYpHwxBf3rJLhScfN0HHJSW0B4/h+cp29FNkA5L6fCD/fCUMlv/Cp7JKZGdm4lNbK1rXR3DkrBdQFOww1eY2Zef2FxapXsFI+UZ0XDyDzXvO08u/SgiXHYZIOwl+c1KRn5aK4N60dUJP9TA2VRuGa+ZyXG7cgvBl3/HllqcgkWUHlVoRNFoNQ4B6CgyjihGnN4u/5ZRy7YUobBRvx+u/IpjcdZucxEQhteMU3XeeJXzuvg3fntt0Jlaa5ynOxI0jEzhyWRbf2XgWraZptGjEHbIceYe8tWYiwmomPidfxsAMMc527+VVbsvQNV+DS/4Vo9FrJjb4zITzmwl4vfQOzVg+k/LuDevLkzrcLfcU7yx6MSxRhnWcQqnXcRVc7niyxghFblkjikW0kruTZ9I6DsYV9xIev/wPPDcmc/LlOxS45AHSgtxB0aLoDC3BrRd3aL/5FWxSeA2zm4eF+K6Z5O1pisF2yhhfFwd7pyd0eGEGyrQtsSbmOp+OeoSLinfJ4SjD3EsZ5rWhqBXZjhePQnF2cDot8lPG8u44rPgeznPzTGGSb4qPjaKoWq+MN+9C0XE/GgkvGVIfRNH+hrHVexblGacjc+M8zo1RRmS3KP5KhCE64i6lZSvj5tG3sClqgNm21Qh0G8RfCmbRM+ObyC1ZwS3aYkjVCYOu4VLevVVPGFKyGhMsw3C/YRYp1G7HgzcDWInCqDpAmq07lbHhxV0qOm7O2a9mISEkEOUn03Fm2gNUN45Dd4SAZ24ViPrbxRrfj2DbejHkFQgQGyjKh0yqqTrkC65NnE1GpW/I9G4p/F/HYPtHTayOFcMTQQXPpEr4ovtsZJn/wi7Tw0j9KeCheCx0w2Yj0TsZoT4qOPN8KHsXiPXNoA1KXpvh5fFqsjEsQ2jebASGnkbbQnWe7NeOMdsnMUfdh9rpaojLx0OvSYur/a9zbrYCC8qy8BPX4fd/18C/TQxHPodR6pcwtO8/jKof1bTK9ys+BpkIT99MhsWPMPK9poIPC87C+4Ez5xtGcalPDk91iIe8fDj+fFNBwhhxSHrvEpylr+JAWzj/WPUMJy3/QXnNfxjqkovqaZ0cdGYtR5S9wqDySmgtU+FLnIThwf/RtuAa2u8ijsqld9jipj3P9xBHwN1DOCU7DXVKaTCRb8c0idOon/cE5S8HsssmcQxyVIXSjd14tOMW55jlYL1lOWq3iePJ4hQcjhGHmp08/7dPHB6mAgfyOrh8/g/drzJ53I8ahCv1ZwcDQRhUJMmKh1bzpsB1eKN+j7o05mB+iTi+TLpHP6+H04LsaRA5Us9BFeJ8sDmL46bdo8XT51DOOVW2WzqHGveMgKrpZQSLFmBXawN9jsokxD/gW1mDWWXSZToRm0kqtiN50qMq7DD+w2sWDRVW5qnxzB0K7Gh+hNXzBvDv6xORbqDMUnNq2H2IGkKG7SR312j0ZCzAt8MWbPE9gOPt6ji4KA7GnXMwoVaGjwpq2F/ph1cHz+LswPtI7RzFbtXW0FTX5z3718PfOhdzFeyxfu90PB1vT6dPN+JbUDY2eVTx8dm2vKuuP0+6n4eTVvcpyOgihv6Nw2vJjxBNuY15qXa8MKEXWl73yaPTjcvNr5BFaI9waPd9+no8FS+O29NOjw6uVfnDu73keHN2OvqX7KQxp+6TzrkYvtm/DeG3JW0UFz7nfTbuuPDkPtUa2iLsTzZQ0w/TfqrhhN9DtvwTi/dnh7D2X3s6tCABl//ZU/6JYSzarwW0cSgbqs0l4cdOsm0bCaUqY/6vdyelSknxL5EM/F0vj54//XBr+GGYqItxr5Y64sJt0e/kVuy3e0Ar2pJQMnsujR6egVNO1YLfFHXIOc/FJRt1tMaEcoJ7Hnqb1vCMUUdotYs6DIIe0GXv+2xs0h8DVp/FzKlHaBRp4dqB9/Tk8FxS+V6HaTcbsWacg7DWdwOqc+bibn0qL989hB97NMMjcQNXnYvnD9EFCEhWR/7ILdwaGoa1r+ZSUKE6cs2roBei1efdb3CnrpTdDmfg2WxpftU9F3+uDuDP809gbGEYnHO2wefWJShTIXyPavHxP4asa+5A973eoadmKqwHqOJFUX/EiljifV8+FX9nxe9Tv+FWX/9bx9/FK1MPPl7VHzUp0Xyl1ULYN1qD5zsOEhRqq9B7Xh9OL3fRivfW3C8gEcbr32L2lAfc0TMDx7bkoG1FML4f7IHrCB1h2pw0iKWew1vaw9EfUvFy4yf0c8iE7KfPEP33DEddC/jF2ge43lkC59aRXG0F7nhvjNM7r6FMYh7SjCSgJbURoruS2SVSAy8TlkGuKREJC8PReYzw7W0jhFfq/Ge6BP5rzMFDo1qM9v6IghwN1rmUhinza+mj1zfMdKolfy8JOIRU49SEcpz4k4N5SyVQvbGWDDdFkGdQAR4rX4TkpRx+GhcOd7UDsAurpZyHFXhbdoun37qAA7v+omKvLKv80cD4vxowyasl08J5pFsxj54Hu7Piu7593kvh83LSnOA9GX8f9r3PncYBXifgLNFPkH08mGukJdj7mAy/7Kml5uQeLOqtpRaVY2hsjECY4nwsCb1Of6aFcGVSbh+/xSLESRNaLyLIdoYSv/wWQevWaiLxznJ0Gehxl78mZLcGwiY4ED2/JFAfqAm1t73wcZyPCYseEf04jxfrdqB4+SN67Skq7NotIbxL0MTp9Y9oj95uLDvZV9thkmCs+g44NJ9GZ5ZBNOgHdFa9gI18N1rbRwuurrvp9No0qLkPgIF+NosW/sDBgwM5YKms8OaZChfmvuH08M8UoXgep23T2N/LiZe5JMBmoA4ex27C+gw5hlsDS3cYoKU4DZ8UsvirbQiPp+FoRQbWHxnNVcJwKJ69ip95DJ/qNBwdnot5thnQDjmI09cGAIf38dTp2TgSUkcWvx4jblYEe1T0PX+0Ezca5Lh3lyvasuqwcG8jNMb7w3qFDmdrBmF3UR3t7cpDRWUd3b+9AJLXnuK+6jRhckwHfP7NYDntdAz/WEe8R5UftiWg+XMpt20MwukfC5AUFIT5So6oHPaY1LxSkfPLjU+MUxFSNB9T83w/bkrdi0lf2mGZvZitnvnjzAwVHu/8niNPxOFteza2ezvSAZ/HtFi2Cm8C0zgvMR1//B5TdK4yr1skia77HlymOALDYhyRFutId6ZO4xTdzbCxjOAZ4tls4h/PJrNGIGC/D26/F2AYtwcTrj2mggG36OeX2fje8hhR36uRcGKhYOiYhxFvHHFzw3GsrVsJtekXYTxsL5eXb+CVDbtgJeKHgqd7hIp4GTYao8/Kuidw6cIojh2cz0uN/Fgk8gpMx1nyIZkI3N7qhO8B0kIgBrO/tSz/fTECo6ov4q12BEwHhfGL1MXQsboN1e7jZJHRjMM6kaRd+YR2PP4Pt1J6YNB5Hc0VohyCCGi9vQWDJids6XSiNSYj2XbeQH72Q5MPdvd9wyILR4ym8pphT2nsqoEYtC4Cs3TmsOEGCaZVWdANj8S7iAic3RVJf3UMud+tx9ghONOkfn0zseMAzPf78b9nzyCzag50MiNw2cqSQ3aOh1iFERc5/sB2zxcc9VWa3YyG8Yv4h5DQH8UD4p3pTE4HDk+6iD/VA1Fe8pQ+TDXjl6edyWdcNz5feIgUvoiPF50hOv8Vmuof4uCTZTBrfojt2Vq8KcFG2PrCmYb7FuDU75F4c9WTG0WkcPaGPkeIj0VOv7H4b0wNz1CKgolOPU2anMQOHzfzbb2FtHHcQlw2/Y6EUVqYOP87+UzU6pv3NTyi/DzUHetp+kxLDg4VYePANhjv/odSr3M86204ix1ciJxWSb6YaI+GH6M5IX0hlJOqkRZzGXriBrxFwodVrtaTcK2eRCZL8pFL9gjcLgXP24o8M3g3pGbvYoujyWhLkMIi20k820KP0VVPpyLM2H6WOXfmRdHZ/CgcH9RAVaPCUfPhMjRO7kbpQy2oGLrQvZdH4Fmcxw7Ls1i0V4QL32vBeesHVM2ei+jCS3CL7aFJrVE459lAQ2VG4ZDGKCi6ZPBmJ6DjZRUa1V/zgN0NlL5pLk7LLOKuoy7wsR6FDyohHF53EuPElrKkzShM9cmj4XcbyLLGhS7kVqJeYzt691RwTvY/qDr39ZP5HuRMiUb0XW+esXkUilymCaeidGE3LZr+++tCt0VdKVDRFR2fD2DdQmlEjx8jTBW/hz8ijJS3ifyfXzdHledB2fsEnq9wpdVteeiusWeRcE1++DIPCmN+8OUAByQ9VMXc2hS8YhH2P+BKe78G4dyhRrIocsU2OovTk0fwwmtufO6SNEZo5lOm9SnU1rni/q1C3rDvHRZX1LGjjjbocTS5PHcl1WpDVhU7hO/NR1mctOHxLhrvZ69DqLInewvaWPtBGpeLGeqaOvx8sTYUf92D48tsPAm25iVaC3H48lmYvriKtFFFeL1VGytz57L2IT180tqLU2MiMdT9W19Ouom6FG3cFY/i4nv5mMUD+bb9XrL1TGKdK03UrdeNbdcXIcaqEQof9MDlTfT5Yz6lbOrAm9uLYCJ+AnYXzHifrQivuDOY1cP2omLwCZo3oJnWRUSi6IAMZhvN4IVWCtx8ogIVss0UEX8NKnwCIcaLKUDQx6XCvbhl2kzaNyqFvCNH8VRmPsZObia/Bc20IlqVd47KgGpBJlRDlgnfNi7G1ON3IR0U39dPp9hnihxvSm8mm4zF9DdGlu3OhGCieTE29XHF4V/v2P3hUHYK08GpymY6V9VMVy6cIKUWY4bZWv5l648p107A4VEzTexaTAcVpLgmpC/rfFlMfg368Djvxu5FDyBnMAj77ulg9ucnkAq4DgGD2ONVLoZWKrPLkz69fqqDnpbB/E6mj4++bUXyex2cuyzJb+5eEnoCKvty+D98NywgfW1/fnvHBnt1tuF6vxa2m74N99YHsfoeM1hGxpDfmNGQHzsalkoTBd2po/v230kZWjO4U1VWOHvsKUacjaGAiHG8sNaNGmvdsCOyAD+WHMe6/9+H8R6Nrb81eEhZFCruD4LIKB9YyF/inrpBKGxYgKI2cR7fOQhfh7ujf/pdqna7gW8eN7Co+DgM3ioKImr1uO6WgmKlWBo14gHfn/sHkp2j8dwoFm68lwuNY2mN2kmauN8d7x+HoijRHQm1dlwkfEbFtM+IPv+M2qTHQH3JYJyTeoUAz1iaVJKL+AEJkJvfgvuPg+E8Jxnz/7nTZhqDG5tjKSRVipUnvoKBShiWST6nGwvHYJzrGMzQC8O6IZpAoyNm7Y/FioTBGJw4GLYWn3DhwGCMH5yKffkGSJ35HMkDDrLXnOfUqdaAbYnRuO3nQY66qbh5uALSd06iPLuWzwY8p7MJHnT51UlcqY+lzmVDeUtpDrtlHMTBQwmY7JqHhb9vQ2dnGI6/z0fmTQ+qWH8O3wNTETysg5aPKCTufwLZYraQuFfKGR3v0f3PA4804/DX8AgPl9jLH0bbomDQErpiocEdJ1Kx2SKOFNZd54SbH6Ez8hTOWo7FbPslVGA1Fmutx2KS6j6O4bEofTKIxXW/QsHBXoj2jSPpmib23NZKWYmt9G+oMks76Qj6IWfx0WYgR0iGI6OzhjzDUtBqo8AzJSWEc4eGwGeZM+LKiYefHIIxm27je3ASCjaGcMmbVhyZmwHRlatx5V0rbY9xxqcPSxC/woFJ2hObb/d5zri7SBrcRvtkPalm6jVIKniSvPp8Nr3uxdqtQ+CvPIRftg2B4cACmN3ci8H2bbTEwRMOdJ3frvqI2QHi/L5rCuoWeWLo82E8bZMn/vnN4Poz/oLIuhlYVXUeg3yK6PT4hRiX7Ek7C+9iZ4Ss8HDsPtoZ/Q+uN9uoY26mMCetiC746WJEhydNfuOJea2boFuuLByycOM5G3WhvluXHcaV8r9V++jNZBt2uz6B367vq9FZDt8lYrxuwgsKsZLiO0uUucv8Bb3O08XUSV4wcfSiq9LFFOPiRR9cX1BT+j44/FbipFP7yDLdHlNvivK3d0P4ecMePvBNF48aLsFxxEkUH/PCqpqhWHpvH5Vd98LaQ3XorvDCofZ9sLYq4x9BcrzrvhfEy0ZA7d0Liuvywt33XjTinjprldnB/u9QfA12geJMPZimFCNFVhbrZNtpxTdl9vx+CJaN/ph+ugI1ZyogaeJNQyza6Un6ebwNd+ab9pbY/aUCfsVDeMSWabw2Uw85spXodZXFgEh/bpj8CyfO6KEq3ZtOvlVlleREfm94EO157RR3wps8Tnoj5VY7vU1y4OtP9XD+bju1VbeTS50aLy+NxLR+5qx1PoV7AmKRrafH0zc2wv6nN5b/N5utzshCobccnUWTOUd/Mc9R9qEXcvpwVvWhiuXePLrUFfvMXpLbxWT43JdFiOVLCno4mdNJH9vOxmJKezzMv0fCa5EPqQd+hJ+bD8GkDboePuR+Kwvn3sji6494ZKrOgliwOT/4JwvbTB9o/9zJb46+pPQ1ysLPnJcU2lBCYR2qPKc8nufmBPHX2BLedc+HnD+BY0gOEl6L0CwfBwf1fN6clsIPNz5C9beXJD34Fe3tLcRrW03Oz+zP2/Xi+ctiOYS4yWGIuxzfMF4KhbX7adV0E/hyHFxPLEJpSio/e6+PV/LnELjgFbk4vaKqOUkQUsUQ21HJCgekOG/rUiRrFmCP0X08DFlK011zsFX6Fpq1x6GsZD8Ojz8NnJHjzB3DhIehw/j3763YgXFYW/GKZmwWWOrqRnhXL8XOzDisu78UI1hbmPsphP2emiD4VQocvy2FuvQyZH3TgotxLPYlHGbtnnxsE5HHm9DFMI2+hc29PzjQbic/vfca8Yd+w8ZiGY4NfEQPCgpwbmwCMp07KFkvAeF7f6JhnDj29MZB3uAU3fBYBkWvDvo9bRGP2LqMJraMwxg5U17YPhuO0xNwKn0ZlYm7QZBajSNNP3HYq4gnp1jymNUJtGKNPJRuLcM1BQMk+olzjooBlN8swyS/MlY4mMe2H5dR6L+/OCyznOyqIrDWbRprFxzFnODVeDDzLdJDcrE6zg3ds+8grWoJvzVbjparqUhNewXl88XIe9cK23ADdHVHoGanASofrOcRqQbw2LKcxq8fyB9fH+C/HfLwfC7NY84Y4F7fcnCoI9ms5Yh8qCxsr9+H1Buv6ZCcAheetuQzpgO4oeo1jTLfjVujSpDYZYA5rmuwOFQK7noPeIBBIoI+vqZi8XisHrAC5W7uODlwBX0b8wNPF+9GlZc7jjmJs+kia/694ALuDDJEiNEKREi+58Csh6halIjHvolUahyPMCtDRFkXomiKIR6uVcDlpCf48XE7al1W0OcnDfgbnkhOuxLRJrcD2YVxgNgm9slMEA6GrKBP6wqx9mlfFkh7Q1EFKsKLsjc0qRs8Uf0yxkXvxOPMPo5q8+BVrcy/XddiVXo/3LmbSHNfv6GdNQoYu9eFH0lWYtKlL7j9cTdUPilzlqgKpy88gwGP3fihww24aAdC6cRazHldiKT78chwXsyyc31p/pFaOMzrJOfPeqwgYoTVofbo+LgW/TZ20sio7Sy+2ZcaJylispERRj34CY9DvtRZZAaT5x5IEt3fp0X7IV6di6Pz/+OJjgdwoskXQ5YVoV19C7L/dNKejImcnRXOK8KN4LjLG607i3BS8i15JxVhYKoRWpIO0M8jTnh6SBGL59tzs/MuiHUdgq3NSoqS+V/D5RkIZBdHcZvsjKyUsslIijTc8zcyXhpGGVFGS7SVqOy9s0caWigle5SkpKGJ0tZWUoRS8fpwPt3n3vvc9T+/I0VeW4ne1eih0nwF9CoyIXNJGjr39VD7zhl1Ixk08/AcKt/VBwho07f8dKwc0MPfV9Lw9D6PDpVu9iTIgByq+1jB93VYfmUFsp/0MZcdQlTaGIX+lEV0qDOfRH6JTOYvFXrnBbLl8cNNuS/MJ9Wf3gyl4+o7XqyqNCI7DT+EbNMHsS8s6KM3Rf6pZkkrspjpymn0yOoL8/X+wtba5kPhZjezu93NbgkFUk2kHyubdxjN0X5MOjgL24/tg/XkuY8OCJl1rjCC4Y2FpFz1hWnf9WMhJdNQe3Uq3Xp9AUJPPOjN5SFa1DINTMUL5WN+aGydBi+pr2xwyxq0L1KHkLM2uSp8RdyvE7hqvJUpDVsRl8t9urTHkX41G+Fe2hMMmW9l9642Qtd1Dok3HobD/feo7TFC/qGtzJTjF3rXz8WpRauQN5fbTFkxG4FG1mQW95Vtv+mFkO5y8Iobo/xtLRmXbMXy0q2sQkeLBo0PYKZcEyLtHUjRTYKW6tWyNDcZvBf2hnLFXGxUKqaTTVYY8z2AMi1v8GWI0Bl9bzgPjSCSgx/+MRLkrucP+bn97IaBP9uRdA/+B2JoMNQYl1ZlYGJiLh7sfIvbTp5kUyyDiGBvlPFr0vd+bpq/3591DjXjXtZbNNXLwLZBBsnbMmCb58+WLXCA5lleepCjSO22BqjtzYZKkz/72ekNgRUG+PiI8EE7ifx8O2B2LgNF5zNQnStEwZ/62Y/wClRmcdEp/4+YNy0HLurfWIO6LDirHUhI7xs74P4fcdUZ4FFdBXoyRtDq5QP1tQsx1fEbM5NRptEmYSpz5KAZnR9x5vQKqn0ag9DkhXiqnQDBzACWfNIHN/IC0FERwIIqA8AVkYMz8zJRfn4hvsqfhd6Rw1iTI4vPwRdRWZCDnYU5cJB/AGGRdaQzEcCeCvoii2uAnaJ5EDefhzRVX+ydsQ2/6x1IzW0eaG8m1LsKkRgrTXd2zMNXs234bj75vXUfHthsoeV6Jhj3GmDiQ7IIM6xHzOYBVpXfgku1CaiOHmDNaW6I3FhB6lnhtObwNtw/PcCEKh9gZ54qnbRQpz9KchBSkcPv6FNI1nCCvIEO+eneR1/nNna6f4C5zpxJVj8G2NwT3PRz6D0sh7exbUHqpLBCDntFvzN/YUOYe52gNVLb2ZtqAfwVU6U3TfWso0iW3qoZIkL3ITTKbYhf2xC+td7kGiKHlfPTMPtHKBmccYKz53fmsCwRH+RcqLbrLqm08ZCCgCiVnNpPESKSVLdqFN+atrPT9+RQLGFEc2gRSq59Zy07E5F0/Tv78NuS3NwWIdtHhnLdF+Ff93ryeC5Ilw9nIS5eje7+y2WZNypxeyIXmSkNzCltEfVMfYGQmRvBM70IQ72G0PxtCHu7HZAONaJNunnM9Kk2je6KRGrkXLMbH7OwzCyPTV3rQBfTdqCcm4tCpp2ie2H+ZHIjlcJs5qPh6wZ6pShBGmpfkHLRmwrz8nB7bw8KeHYyroz52K8wyGZ17UNu8DSarqhL+tflMYWrEnNoJ0syG2RPlOuwODgbn9vn44qri5nLQB67JxuP9HpLzJgQI0+FEjr7YT4KTmXDuH4xzkTWUvMaaTOh1kGWq5DPfgmDFlpcR0+qB737MMii+nZCZjiafkqUodEwnwUcrkNAVzbk7/2GhE0+S+b4htP2C/BZaxfzmTmbNvsuwDaNJZg5EoTdR3/gpWkTe3loIyWnjlLRlhYsk+khg8BdGN7MR8MOn7G0/QdOBO9iSUX54HEbm6zZHSS2+CzCtORoU7IBXUtZgv9qL8KqJgoBgjfwJSaOHLt34XX1NFp/Rp2OnWtirY2zSO7fAoy+UcDDt/mwfqcAnvYlMFmdDE1HbtKOug/nTckwz8xBXG8Tbo7ls0dHO3HYdDfWK1TQXdkEaIpPxwbLn6xwvhF6lV3A72JHRxWmkrNeMAKbcyCrUYA1+3ZDrV6SOiN/MicfI+huI/I7lYyZm41gFD+XYk/vxixDDVr/9jZsv+Rg6vmf7KJ3ARs5QfRshx/53/3Jmj5xUam4AKXsn47twQVMd24QSTl2QVd0mNXfroFrhQGZSQ6z2VJ7oKG/B+uSuvD67lK87VhK0IvANcUv4Od8w94+KoBx8DATjPhImU8TsHPbSdz8c5CYsQIVD/Yiwq4TP/qFcMHOGA+LRWhokxhZp4hS6kUXijtFtLt3GOYNfijTKMQhTUWkHjLGaY5AGC82pJncIyxveiA7UpWB1yqBrMesENMdCllb/iwzI2dF8HmkIXK1ImbdlqLCY6ZIFQwn78YUbPJXhM1BRazhb6A3kWn0eJEk9MIVURFeyMY/GkM9qhBf/hjDNqsQoiWBdEMgEx+em2JiiSht+alAL28F0p7YBbSivJAtvVDIvol8R1TIeoo9dhMkZkLnhFPx9kcgG0UmUuQjcVFklG0TG2X24qPMziITjW1foddfyLR9OM3GPmzFjrJIivBLJ/9uYbhtHWWSvWO4tmsvMv6WkJ21HlSMtchzPBExeZO58cIoC700yi6ebWafS5sptHEvSr9eR7hiGVoU+WmW+xGmL/0D776J0oHxOjz5JUD3o5tQ+6USuk2p4JxTjxrVfEQFriQdmauI/apHTZYm4Fz/i+393ILUy2tJxnoS9z88x4vIX+wafYPQmTKs/vqWvezqxrLTv1BiPYw/dY3UHyNK3dxFbGeZCewkv2DjeROo5wJh/DNh8uUXa5cpYk2nAvBc3pSUzwVgWm0+Tr40Qfqretjo/GY5ur+x+e4kY+jMo5f/BbGFK4PYQO4kt5VeQIEHL9kdSkNB4zXs5juDMvMeUOETHLRpw6dtdTBID0JURhD0yoJgXx7EbKKL8DC6iNVvaQNvXhHrstxOX+8Xw68zCCrL+7BxQQH+DAUxo+Hf+F1RxPqDFuGQ2Bj7E32ejKT2M+FPM2hNJAcNCs0gi66ZCCtehF7D/Sy1fRvxLtyPKSZjzMRShaIWmtLb33OoTEOVXIaKmHHgfiazdz/b+o2X2oLGsPkhoUfmKFxb9OiJcBceyiuh+XU7rT0yxsqK9kM+bx2dWLYd+0UW4/OOhWTSMsbUnowxXwsl1IUyqogqpyevxli65mK8/DMGQ47Jd/AsjAp4BUhZ/DoyV5nB3/s3olT+sBm8hfj6+TzJ7lwMv5yj4DNpoJJV+nRg8x/WcjCYpTycnF/WHn8jgtmi1dLU06oErhtH2ePGP+x711EM1cmTjd1zTDwyQ8yMHCi9+cNGLojQ1NL1lP93MXj5/yKmrQevrRrg7dWNWevbcWBMnk6658BvAzdJm7Rit8VkHllyGPtOfEVTSgMerGxCVkwI69/xEOJrZoFlrCS3v8/x6Gkhera34jLXVXzMXUfxC/4z48hZguO5SxCWt2Ty/syj8IEyevb1L3NpiiB1t3cozj/G1hccY74D6yBxewlUz8/CRu0j2MciSedzK1Obk4rGJUdQpTSTtN5EkMnCf2z/yn847fCP8QTGoOuMFK3zrKUjyhZ4f/MFEoP+Md2Uf5Nr1Cb/zAMQHuahLTyTmTTYzGyzVS5+pB+BRf5TEr8wgi7t45jmvRQf+JMovO4I9DhbMHtuHbS7bIhDYpy5HtwF3nu/sK5YnS4VDyH/8nXmaXqQbb77HEMeB/GFR5y+7h1niiRKupXJhM/PsehIAmyPz4Zo/1I4zCxCx9BScIXmUOjsIkwUjbNXQqZYO2M3mjW3UsYk24fs6EVwy2yYBIlSopopZJaY4vpKcQrvO85cnU3hOHOClVzjpdBSbzIP341stQl2xt8Uto2qtDG+CNydx0h1xyE2c/cEE6sowoxlkhRfbIrN0RfxWeM/+uh4gj06M8Fs6s/ArXgqinqK0Ks9n7SClUli9y6a4fYVI32HGJt4hUHnYYyuzsRlfoZkt3G8b5an1lPKOHvwAJnUnUDuUy0a/trHcpzamEp8FR6rhrJdHBL4VfebXgR/hDWFMumoNnwTaSBpCw5s2s/gHcywT3wPBc49TpLvymDxRxnhY3vwxEgCTs26VGIVRml1behXVaDQ0KOI/y5Mvmt90P3hMvjt0jFNRorqDnJgcSuDVvFRPDS/i/G2ZvC3M9ya1IH6o/DdHQiJXoauSW2ZboXpwbPMpB4fRevWYjZNBPi9uxhzH5+lhlAuClr6AKkjRzF7cRZOPLlGBW2h+HhEBdry7mR0opitfsuB66/taEeVCq5E3gRzB3qGQ2E0wgGBnYD9KAfEX3CSyM6tMLpTzFbGXIVTHFDNHwbNKZw4KLiU7KaF4Xs6L2UumkrWNcBlS3v6vHAKSTUCWzTCmLtmGHO9Nzlu+DE8Xt+Bo0Zh0J/BRc7c1tg/1QieEKTeZWHQnd4OTucwNjOrA20Wqvil9xA8LpwYz+uA3QZOXPKNx2wfSRj6hbHofZxYQ/uwbl8/Riz24XUcJwajTzLLzJPY60Uw8SbM9yFYzstG2LEw9qBUFfPOhrHcs5wYkC6FfSjBNe8DPmk3TXJFGC6e3Iddr60R/1gVJ67uo4eD/Wi6FcbKbI7D0KkSJcuPT2ZeVQj1hrGsnWKkOkzg5M/Af8lL6K/qKXRszqMh1ywKFTODhpYaZBUyYP7iAPn7Z9GJJWowXhuEoKVqMNlzi215pEVT/tpTu2UhPn44SJtNzaA5yaz2RuH4ahTOLmQFYbXvKRhvOMXMdk+nFyZceLlVkLh3R1Fp0imMuH6BruEKWjZ4HEuPnsLo/Hdwm5YCkS3hGN/Chdt+XNgmvh9CBgPsiMIR6rR0I8dgLhyzuYyR7ATcj5mcJ1+D6J4ZIn84oabjFM5k7aU3V1LoUAUntQyaoW9IDQ0nlhDfgQsUW8qFb9XhuMavjtTacCZZMY0u9o+gUOg005U3x+ybXPiqUEa599tw9/o0er/7NjsffRvrYm3BeekHlt3Zj5w9/5HJgyoUPZzkRbkE+tPHhRerTzOl7RJk+CecLeOLwJ32E2hzMaCa3uMktP4GIjSDwRd+GgOy3HCSi2A+r08gWj0CAY3meHJJn7pz1BGgxQ1lmVy4vYzGlYXcqNgtjRWRhrTDhps2/WhF0tUHuPWhB7vXRGBBiCdxbYxgn6dbIG3LHZy5PVkb90awh8lc9CLiDtSGd9CM6Ag8ieaGRyw3/urz04Yjd/DMUZwMvm1GvcoZxJhPp6acCLZdJYJEblZjs+YZttRlB/Y9q4YAZzOeLNZAbEEu7mpuQe3eEDis0ECJ0FKz1tQQGOQtogYfDXA1DpOq3WQts5pPv7oj2Osn3HSxhxu8YyK0ZGEWvn+MYMadP5jp5wg2ONOMwgVM6MaeZvCNWsCLk4cuR0vR0wW+9Hr9XbzaEECW0jywmxjC1TvzyFqeB2HKPFiqHsmON9nSiNJPHOtoxpQSO0gYRTKFFYtwz4wH9RstscOrAfs2W0JKL5C+XbeDjoAmXjpGYnWoJRYbpqFptApdv+bTfdWzLM47Enzmabib+hM/tYPodLklHQ3kQc/bAzB73gr1Kkvs+XcAShMH0BUVyc613wDPvKewXHOWvc1zIsEtmliRFcmu7Z9KRm8tsYIrG437z8LiZCTrPcBHe6+/hvYfS+w9E8mexZ2FbzkPNou0oWSy3jxLP4uC65G4v/EQKUckU8CybGh28WCS3LD6CQ9ep3wC12UJosFI+N3rAJ0MpwUjkaxlhAdqKzkpeEQTU0Y1IcbLS+GJjzFPLo2SREuYoc4hJMd/g5gKLwqPy9CycFWqnBfFllc14umC3chDFDotS5B4oogCNB7gr2sJy3fghZAjL+4f5aSIAC3UbtPC8Vg3KixwRdtOLZj68uKRcieKz3+Ef1QJZu2OwondvLgQGgXezRxmuvd7MBzBi7txUcwnJYqFzxc0m3U4Ct55vBg5wovqjX8x/mI5fg3FUP79EhblewEXTHdRkogoxRdaIbTICnsM7SnE4DSS7kTBegFRR08djj+Igp1NKKxe8cLJdAW6rfpw9+wSUtu0lyKpAM0uK9DH1QWXg6dx3tSYHnLwQac0BzxS1jglbQ13TWvcWlvKXBWjoa1jjbJYDkqIC4WjZjReafPhcVwBUH+fva5fged7SiG9kA+3yxTIY0k0ypUuTv4jH/wvheJ1oSK1pHORdu9p3HeMxukZXzCvw4JUrxrTHY9oFuoXzZy3RqPdnw/GnaXgCObDpcjLuBgZzSrvcNGHXV/wPjGatWdHM6XcaAT8K2WzxkuhefEwdnLMwVzLR1gmWYYAMU5KVyuDu3oZs2qIZjJzbCBzZBsutvMh83E0dJ5Es/qAEup9ygeuP6ZksW4OohWvwGb9HDyZVM2sCwi4Yk79AYXYtEeR6gWiSdKoA948MWylbxgKg2zJkZ8fx5JHUSAnTYEf4khKJgab15sidGYM9oWHATU2eLnwIftmth1fA6/AXj2G/dvJjd/3bODzwAY8N+agIzeNtJ6UsZuiT8DbH0kzfkynl9dm0lImS/lGU0jhbxlIdgxhHDp0onAVxDfE4MOOGFTs5Ifkjmz69FyciskWaWNXIP1lO5RfhcEoMYb9cLFFbeUkO8cYU19eDOYei2El9jr4dfwJ4o7zQ0U0DfUrz+F9jC3831yHcm4uefroQEiYi45u1cHjall6unAXbdt7ji3QT8O69hg43Y1htxYMQ9R4D27En4P7A358ToukBZO+VPQmBoF3tel5OsO13Q5Y+PUssi/pIKvxHLhaz2HHOD8tvqGD6xzfAL/VVCoay846S5Pr9FjoXOU1i1+9kOLpP7ycE8vGt5+ilxPNWCSwiuL7H7GV5rFsvUcJ0v4Q+dvFYvtRLnJdqAs/k/PstI4eLd7MT2neArh3hIc0G8NhWPUftIJiWecnFZrvo0vn2v+D6V1pOjoxgcdqlThlaU6N8bGsKS0W3xtKsOheA9JjdfFjUtS1E/3u5nQ/4zzqimOZ+UmByTaim9mA1MMSnDxyHlPLY1Hn3oamY2O4WRXLVs5Px7A2B/XXxKKwNpZN39kGp2Etko5Uomctj1nfjVgmdTOW7XJMR4zoKCq6dWHQJUCSg3LU6ZMOZZd18Lgxl7L+nWfZeQuodUIXv0Y/o+xvLKRVN9Ei8XK2pzSFBJ4WQdWVm26KT4HDWChpq5VjzddJn5CKYyML9HDgbwI13xrCGeUpcNaagiHho5CsHEXWgVKITfrWCfvp8LYVoOM3l08m3DicoSlouf4AE/ZxGC6Wod+R5Th8MgI/YvRw0XMKblVEoH/wD7MOiMOMsnJQSByTfa5NnefkSSpqCs4t74DHhWcwUNQgvrw4tp2zDJGPy1nfuZs4tsUep7rK2ejJOHx6r4eRbe9xaKsJKcmUYUtFHFsw+gwp1pqUWB/HRD/sIo7HM8jJpAyVQpHQF47EefXnKFZ8SAJ1Ifj0NI51s+eYlq1OO57Z49dzezzpt0fLfB5SsdJHy7P70MuSoBOjcfjBHc/28C2Hv5s+Lkw5gEiLSHhWOaPbQBFCAoJolxDE/SV8VOfAQ4nSgrj1uovJZ+yB58nneGdZjflq8ezKvHiEmcYjxOw4uZoJQqjsAp7tWY6/ywUhK+hKaLrAVu01ou7o5Ugozaeml9MoAqvx7oE+rapUoA9+8UzntT48AuKZ8u1/7PmbXmoLiYek+yAmRi5AZEc3Qu1eYGpUAhV3L4d3ZvzkHi1HaEE8cpUuspJTgigrjYdbfjN8X/CRTp0gbm45h8ZGQUi2x6NGfwV2dQviaXc8q7ZcgYEeQYxPi0L+e0HESw2hzWMFUn4K4tJRPfrzjSh0MIhm/BJEj/BLqJVnwF4gAUWiCRiXTACPdRS4a+bCx+w4OI8MAJtcaAPHbVi8uohl/RcxZJrA+hRsaHbRGmiREFKPPWHaQxeZKFcF3L4Y0oKE47gSZkbVnkLIizqEos69aNuagH9ylcS3I4EZzzPAesMKVriogm3wF6HlBxPYVM/zqIgWgnJ9FCwShPDJ5RjdW2GAWKeVqLH/CR1vA3wrTmA+okVY1GhNHsO9MDJzwZBXJ+TOCdEen1/YXpcAheifyDt9D9wF+hSCV6h++hVHeXjoX6EBxG8JYaAzgXV3CdHnzYeow6IIde8T0PV0Jdrf6JL7h5XQ/ikEwc4KdkfYnm7UPsW/wZVwe1oBQZ5y3PlUwYQ/p+ARXyKi7WyJ81Et1B/XYta8VRA4eALzO1+hIq8IziqJjMd6FbiUL+Ga2AKS2RiN46aJTFS7ByP3ptMXCCNn1yrs3LMKwr2KtDR+FZwSViHPpQdNHok49HLmJKMJY+lWYYwWB2HHtnmUvP0SqoIS2c33J7An/BLuHUhEt/ciyksQxr2N6VSZlgif9ER29rAwcnMSEVrlCqXL0cjXXwaNAmFcOSaMsbpLLPBMIrOw/Q6H8VV4OrEKnaYjsFtUQ/z1iezRDgUq6EjE8P4CutMpjDuj0agiByS+q0OI0gt8CJlJZT8S4ScZgxUZY3D4mchumbnBLrwYJdyLyUU5BudEk9hqVgkbMkSUogichYjmeIfSmo8XaOMcEZzQESFd+y8Q7ZOn5qMvcNF9K83UbMVFV35KlbUig+BK9sNcBOWRnHC0FYHatnp0Gv5B5L9HeP/yGfvJ64iPdbokCCtsn+KIW+5JrHijCNpaLuCriT2pLLehS4NvsGeL1eQd16KmBY44sswRO6KS2GO152zxfBdSiBOh3Mpgut7EQzrDlezrwl58utqCrq4wyLcSvW+NgdFrLpL1moW38lWYozQfzuHPIdaSxNSuJbFnUe7In1fFwoz3UFHOWoq/5ohtp56zjIBSLOERoKzuJ9j22RHSf5JgzSlCLuNJGPv5HKvDqph5eBX7NtsJY6pOOHu4Cgc8rkNwejICFjlhnkYym64pio3tv2By+S++1cyH+O9ZWB3cDmNnJ+w7Yk6Xl4lC+14VM7N5i4blyZjmmAx5p2SUhjnh0usqNuaezI4PVLFfXqJ43HyDzMXKEOSbzMYOr4VIlDcpZXCBP3stXlx2QpbtbCwJE8WpEHGaW74W8yJE4Z0Ti6H4XSRa9Rar0pLZzexkdui7I138dw9R351gwKohwuWMDWXJrPXkARpv5iOnRlFEBJVBf7oz3jcls/K043D/xEFtt0SxsyUdFaYZtOVOMvu6ajlVar7DwkXu9G7iNwRsnFH9Phl91eqU+KWDFvSJQtCvB7v+JePt0oMYjnMiB34xVIukYL9iHJzy19Bi+RT2XHPSmwreIWi2GEZb7Ki/2hlJZ/tg8/QWtEermdDEXBI2SGEJDz3Ap3IC4xpKxNv1Eju/diFQ3ghsyBncP52hPdgDLf0aPNA3wl2PFHzwSYH2hhR2b8ZqqMIIl3VssWirGLrMjNDinwK97bkYcqxhp8LEMCs2DlaeTZCNSYFhCj+9XuaJ5ZuNEJaZwv55PENNthiuu77H+Q2rwVucwtqyldET24TIoNWwj1uNlxViGM65itWx76FTF4dlx94gsl0M6rdTWFaHHE1vcqQ3j2fRz5dxyLy7Gg73ViP3TRxye53J/fM8ejqQAs+/M8j4ryeW/VsNj/FLMONNhaigOHZJHKQxITn6ISSOIxJd2DP9DFKnqyCwtJ/UFVLZFA1xXFu8BqKa4nDUOQJ1U10qNTOe5IjvGF8gDvlltfhjqkyBC1MxA/G4vc6KUqxSYbQqFc5baiHrZ4zN/3GRtFMqEwxbg78uqejMfo2nO8+gOnUVcfiIY+75dejNAp1NrcWVkjVYHJTKotPPwGQysykEC9KBtAz0J6UyyddelDu+FcEFqUhurUTamVRm1cvoRIk4xD+bkaayD12qS2WZ/2rx8FclAq/EQ6ldHCkm65F0L5Vp8VTBt1Mc+UJVMJSoY4GO7+H6Thybbofi77N4QHg2Xf4YjwuDqezSewGau7wN8yNdoJjsgoeiU6HyIxRJuS4Y9a1j25veoGhDFfaN/sMu6QQc1E6DQI8PqSxMg8NcETKYm0hLl6Sxl9yfoGA+Fef6XKBtNRW+xXVs7MYyelaoS8Ian2A2yXgtMq7wtQ3Ako1TyVrfC5V8HTi4Mw2zfRKw2ZaT/ik9RqasDR20cMWlMiWqFl5KE9t5sfxjOYmlJCBgRw82pQpR2+mpKKrJxCXDDLI8n8ZO9p2E9c9xnEpxxbu6NKbZMBVKNs2Y2zQVNZN5MuNFPr6ddsXh864wsTXBWsd6ZrFwArbu9ahvc4VE71QMKipT3FFrOin0llUPpzGMTEVPsDFZcKUzuw9TqJTPDdf50tkBMTcEikvguXg665Jzw8Xn1hTAI0q8UungVndDrEAiBr9YkVRtPdswIUAFsyUwX0cC53XSmbfCCuJcmM42ubrBYYkE9Ph5SNhWAme25iH9PwkUf6tGoNQ41rqmQ8vyNuolG1jxfD6oHHEDd5Eb/FUa2A+B7QiWqoEyrmJtqxtaItPx/XsJcvcKk8fC7bDNkIDPj2eomnDDd/9FiCqXoCv6PvhaLYH4mnRm2ZTOFMMbmENzOrv97jZ+mZ7Gyaql9PytBJ65alLtcPokE6rR7IPuqAp3xwnJ8/TmQyJ4PzSwV4dO41GgE50+6g7Bs+7Q/1QDZ44vmHKZg/q4FsNm6mLs1miGQZ8XeYz4YOrcw+zWpL4skkTCc3eoqDZiXF2MMtQaWd6AO7RsD0PuWzh+LlgMvdBhtKROp81T1uL9BkkMvUqj5WsbWd1bVeLeuhjSeyUxcVCSQoZUqUSSk/oiD7MXnklIjJbE6bTD2LfnDfKKN5HFbA1ad0YSX0ok0R65FjYxa5GatxbjjZLYMe8uqnfqkIaFGgVaqpFDrCP9uZCEq7KKdPPnYfZ2sBb7xZuwIeIuFP+tRSSPB8R5MnDNbQZdksuA79ImSGhIYT95IGt9L5JbNMjG0gPTXZZg/uI6VOtLwdYkA7uWZLAtSpdg6e8BYRsp+meTAZEID8SsyWBXJXSoNXUJuizEKZqvH/GhdThwtIkl5Xtgs/c8mnhwBPo+u3Co1QMGkRmwudGEkJQMJp+agbN3/uFsWgab070EqvM1oZObgdtvmpjI9To87jCh4qmgGVkXETHWhBvnM9hB64+YX5+BgXopcMsqUU+YDTVKzyCdW1I0K1AT+4TqkRuzkRbOvYytTzOg/U6KGpVdaNYHKUiaLaX5U3aj2c0Tcv1S0Lp+Dr2lN7FgEw/N2eeJviBPSId74tqdZCzbexle582pv9gTWh+T6frMTMzJuMzq6zxxeigZLtqZ7FHMTJrYV49rdz1xJXEG3V6YyWpuqJACZaI6x4T+XF6Kpv/sqbtThTY4SqPr/mWWW8pFIqszWdKzpZAUy6M32zLZHY11yNyRSZ6GWlDdlcledZvQS7MUrDskjWOCcRCzW4eF066wNUqqFJskjYpkaZz0+4d9clPIxTMFG/Kl0bQuBVIH1sFs0r9eH/aiXRY90Lkojb/V0gixv4LzIRp06ro0BteZkluoBl19mMlWrZkC02eZTEhtMwY/Z8J0Ljd1T7SD47ce7Rtch/d/M1G1eCNZlFxhdcUDkH9TgsrdMbRRagwKDaaYtT4K8TJZmN2kSn3yWexh3H34nZhCBi+usEH1aXigMQ2XXl1hKg0NOBltT9H9V5jBTzGSGr+CGg5xEl0x2Wfad/y8cR/iHxtQHbke8c0d6F07DZLJ6+GVsh7zUt8gU8IJ1/sFKcSwmdHBcugGZRG3VTPsNrvSzdUMOpmhFH7Bkl6sECfre9w0c7YgGQl6gX4HItmvjylVToOVjBeS+ffiZXMWcz/OUGfghdjfN5Dd0Iz4IVnqKF1KpS+nwXPtMXQf0DW7I/ID/MPTEDyShYQte/FtNAsOv5tZUZwXHsR7gXusD4Xi2TgvlY1fbxoRPCMb+uVeeC3XhTbFq8zhshc+tHhBUAcI3e9OIfrZuKIPmC3KZkcEJOnA2n5wv/TCQ6urrOtbLwbK11KqrQy47bLRsTIb4lXP4bwmG/yx0VD2AbJ8s9mpARFaYt2E6F3ZTGJ3NlxiQMpZgGDSHATYSVJ2HrAlTgYcp4DWvDkQF3iBlUU8VJydDe86IK60DDv8vYmrKJttbdeh/LuAVsdVbI7zxpkkb2ytlkFEjQzW1mWz1fUymFXThIiBq0yjLZv1Pcxmx57ykF6zN+50N0H3jQy2NdiTY2wNOAffoseQULiAcHlCBm8Fc9j+np20Ql4WIW4trEhBlhqMfXBe25tyFr9Dos8jyIQQ9myeQrPW+yAkqYXNd7wMye7jmGKRwxIPTSE/4VqEGPPQN2dZ+K3JYUKbtMk90QfCye/wJMUH9r45uD41HQ+25rD4VkLSblkEzEjH0yofxNW8w4acIXQUDCGl3Qdb5qTjmqg47R1twZ3MHBzeqU66R3Nw6vYQSjqGIFEqi5d2T/ChPIcNCPhiz8UcHKmQRdUlWcyV8MVubV/E38ph0rdzoDfPF5zMDFlPZEE9OeB9lsMcDqTjkOQVzHiTw/a6XGOxkScgsu4au7/+GtunfAXf+mWxUjGcflgkkebOx3ihNIc8w6+xIK5cJJmdx4j0Npp52BdWc+fQEtFYNBt70uOpuey+XC77TzGXzZHQJCcxDfpXc43NjNCjq/q5bGIyt/zqTcenz75QWyYHX+dcaOEpbP6YQcJWg7i95NApuQFXveVgvSUXq4QO4+uMYbw22gD12eZoNhjGvphcVDfMofArwiT+NABbYI6DjsPQ5GhG/wk5fOEYgGxZLmsvy4XVTVdquyCHuoQN2Ju0Abxhw1im3IxnzbnMJUSatgwm4t26w7DuyGUfidHXe3JwiDeHZKccyrpyYdO2AaI55ph/ewPkF5cjNr+VrSpohdUHOdgJu4Ijo56014Tgyrgc3Cdy2QB3HuO924r991qZLL88LF+2gkMyDzlSefglJ49bfvvpmO5GvPreykxm5cG3pBlyQ61MaI48lpp/RFTXAFtiMYK7wTq0QsKChh83Y/rWQForpUZX9m9EeXA90p3koeY8qbZyeEV+xKc1eThicp1V+uSxY14JZDvzJOzzN+Jq8Qhmr7qO/wGsq9ug</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="34" id="sample=1 period=1 cycle=2 experiment=2" defaultArrayLength="295">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="498.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.011561868436" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="33884.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.065816666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="412.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="12.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="12.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="412.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="21.808494567871" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2924">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwV03s81HkXB3DVdrOo6ELCGLRspSKXtuJD5dJTCrtRbmPGmJnGmJnfEL9p3Rq6bIqSbiuEVYiQtlXPLpKaLhulolLI4CnKLWUJ+33+er/O63XO63zOH6fYv9GWn+QBnX0+6Vlq3pinrFGKa37E1hSfxwum/4Rj00tK+ogrK2z0E11/wjyTdyfEm3YhzmJ7wg5HP5wcutG8KM4Ps65kCfSr/BCinfO9uZo/AvOTOtlOATBe+ZnnVR2A+ZbJeqxNgQjYnmC3MCkQ3fU5u+V1gdBw6ZmbiCCsnXFgqrMJC3n6ufEXicbFc8ZSnVnIrva49E0QC60xRp9+rGJB515qUF1mMKYxlKcXZQfjlsiOMTaFjXm2ln9+mMpGfuWXJdOYbFz2yZvbF0AUaD89zWHDJWPO7tosNlSf/lDltbKRmVVY7dnGRsd5+oqzGgdcboX8V+JkwlMDSwYHwoJPVbeJCddjSt05HPQL27QOtHFgbu8W2qMWAuOFRUX9CSE4K2jrD+Rw4cGb/TY4i4uQn60qk4ns59X9t4nPygzN6SouXJM0VJufcJH8rc6S161c/PKkZEZ6Bxdf/stpek18mS59sTghFM8mRrjpraEo2BgQ9LEtFA02TUEiBg/rmp7vURrz8OG7XWuHnXgwnfiZXRnEg98rRSyDxcPMjqjmuHgetL6GDtdn8tAzvFOP28oDd6pf8b02HsKGcLd1nIdGl/xcHTU+VoUUnLIy4sODu5x7jhirHrb0TRAf/Cf2VlEsPjZQwZ/b4vhos33+xTmeD8/KY12iLD5sap+NOVTzcVcjv/a3W3z0DCkNjGr5eJB/nipSE+C6idOrLCcB8kYvxM4KEGCb7cXgtGABzkY0Nz1RCIAu3ZqYbAE0vdffuHdBgH+s/H7/540ANeWSy1MmBThw94m7Q/we7LLptHP5Roinfw9y5QwhjvaNLHq4SQhX/YcFm4OE0DftOLWULcRNxRlBBnFctTu9N0GIVdvGyuLOC5G62t0j4a0QSnmI9UJGGJbVt5ueNAlDk3qAssoxDL1pU1Vy/zA4U9c3TBIpuebEktgwbHVGo3Z7GCr6Js5ZMEQYLn0hHiX6v7okzDQVYU3xtRVJm0Rgz3/ssXCzCAaNl3WVLBGu7rgxejxYBGP/g4pv80Sw0W3IfVwrgtuxTtPsNyKE5vYdKlSJwCiKTtP8Jhz71Re6+xmGY+vg5Y7WhHAYH/2cytsfjsPP3W6uzQzHRpMGQXpOOOwL1ocgNxwt3qEl41PEWL9CV2Y+TYzJv2528ozEOLzGU2HPEEOl/vjIEkcxouPviH4JEiM7JTNugCVGqNJp3/t4MUq9l9dJE8SIl42WjxO/vmpJ7qsWo9rgTqB3ixhdmo/6y9UkCLfc8/bbqRJsN5k9YMSQoDjCpzmX+Nbc81ELsWT+nXAGU4KPzIxbFask+KFfa91tDwka2r/YM7ZLoHfcKtLXSwKbKQc+7SOeXzAoGA+W4De8OWfJlmBELyrPj5i5YoD1JlyCF+/dCpTHJRie7yu5XyZB7PjSJMNqCWrH8tO76yV46PT6q3+fBBLf1Yu+GElRL0tRuDCk2GvVEvGKOMFXP8ZfJUVc2eGom1ZSTKlquTrLWorJwU6zDUR3n8r+i8elWFJTeNjthBS2X7sVNy9IkRfuNnDtihQ9uyYqnMqkWH5ghGNQLkV0zmxj1xopTvrjAbteirtuKX9NENt57N83NkhxkLf+3qE2KUrPWLBTP0qxNbfn9iNi4rvH5gZ9UtxnFHb7EhXzUi3PE7kOtNHkBKl/3VNpOynFu5NplcnEa95b9VuIRxcwXeu0KFgFaH1dOocCQrbUK4j7NfT2XSOOKFOqk7UplJwVukQyKfj1Lm5sWknh4NGgg3IrCqZrPzKvEmc82jLxzpHC7jOG29aBgt6qtF0eThQECutoTU8KXkMOxxREtdO7ujKCKBie2MQZYFF4O7qu6E8JhXmI2DNfSnxvHVcTR8HJY0vHF6LFFv9HGgkUVjhy1L2ItnY5dcVZFI5M7VPszqHgS/WavSwlZu9pNywjOYzrHqiIDhqLgprLSd5u76TSKgrlx+svdleTfHdeHHNpo5A2s71wQR+FRPPaDTuJ2XYpyzcMkftvaHv4T5NBw/GMaso8GfhZr4e3EAttHZcXa8vwUugebcaU4ZOi++ByKxlWXmZ+iGPJsOB5k0U3sWJwZgPzsQysFe6TywZkwPjsHtacCPx66kPhkapIlOh2lXQTWQdybDWrI2EWkLXYtD4SdvoRvTYNkegcc9zvR1RtSLz7UroXoWP7P5+6shctk/Ujrf83ZNKaWboXDS4FZn+eiEL7d3kzV7dFYSmz+ejfJtH4IfFE73+soyF4UM8tco4Gd5lTYaNXNNL+mJvieTUacReOfliiQ2NINHHhHpG6+9RXZURjvbb6xGoTGrNbBiNjiWti7g8PEYd0rrvqraFxeFrJjExihNnOjF5iqaZZhclGGoWs/5VqbaLJfwjmxm6mcWZZttaoFw06w+H5Dm8aeRe9vlfn0BAeYeuIiKzDDoMlRDuFbWMfsZd36dIJMY3YhJrEDCkNmyL7nV8pGuJOtygrGY1PnI1zyonPknSnZyhoHPrj/fHFqTRWNu87fYTYutj+h4dZZH6x72xxNtkj179y7ioNZ/V7tePE76+XnM26RUNht/u6uJZGDLfjjuFtGpGZ8du6ntBQWUsy3RtpXFq2IKmd2Hj/5M8/tpM9yS0KXx05GOaBzI9E2fmYgZj5cvSuXytWMuWQWPzS5GMixzkXr5y/iBUfLT7omMqh+O3ta1drOU4a/O2rJObEdVlZriH9h+K5FcTTAr0MQ2c5PM+uCxwlCm+ZLPPcKEd5kq60giiXdu0d8JLjlM+0kdvecky+Gc1uZctRFqp6up0jR/5rrel1Mjn+BfcDOlQ=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1500">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwQ1YDHYcB3BHnt50XD0VKuWuorbTlqP37vf9p0cJRy+4h0uZlyJEeiJvzU5RIpqeRyl1ulp6YaVS6OqWTEbDxh0uCaV0qKyQzT6f7vx9tE1/lS59WINkTiiOR3WSqLNNfCjeEAcj5QEPM1ww2VPAeD9z0SiMpd1Ob8RWQr14b+Mt9sDxndiCMyiuWSlm595+EIdoEqk3ewHb9d4GsvcdWDMqQYLDooCdk9V0z/UF3JcKmL7Ph3XseAtxSRt5cEwWWKXHIKZbTp1uScxreSyKVtyip09DEDjSwypN0/Hs8yScVGVSfHMmVYUZM2cXLkvPjUDhKS5bou5Fy3OwqZm72UT/+XCQWbEJZ8wpVX0ftT844WuUBcVY6BD0uwVOfvwLtSdK0RH/jA4ts4SuohFj2V0kbjhNb+x9UcT3xd3uHJK2vsGjV92k3feCBi5a046C61CdX4/7f2zAaFAPnZb1kNe1VBTlCRGY0ksPbquY69Y8KtGfJcMKPb0fMGFJwRngxs2F8WF7/Bu8HSrdXPR7iCD6VEiaRZHIu1xE042GUamYjwApn97W86kp5Ars5I60ItUR1VmONO7sdLZp3SjFP9Ww/b5KDI8oqUNSQopcZ0oud6YX40upK6QUsrWzMTZvCbPWhsLj9X3kX51Ncef+ow51GWVcErEgc1fKHRcBnsoVTeoLFDetnF09QCi3/Yb41AI33rckTKygcBkH380QokLzIwq0HNR0cuCfJMSf+VJG06sgLBwP/8EAiA/MIcnBKtoZbsS61HPgvM8NLk6X8DhWyTTluajnHib1Rne6IfmHpWyppq3XqinJKhUW7e4kuF1NfquG2P66y6SbWEsfFn3Cra+30S2tJXlpLTUkGMEg+wLaeRpEFCVj3fH59Ev0HYwOGOHGWAuKW86h/yMv4KZyFnMoeImTPXUU4O6BuaJ6pMUYY2OsMbYF1pPsfCEatPXkpz9KNtGDEDmYIHKmCfq+96SRKBPk/eRJJ9o9MS7fBLqYXuzie2FwiimixHyUWWagNaGBik29qfmUKYzO8tjwtSoc3eiNhVu86UmEgLXJYvF6zyQ05vhAxXFl/jn9GPnsg8zFhuyRmxkGRGaI2fyFrS0zw6swLnO8eZ3K+1R0TN5M2w3msdSULLbeLJhutFuBGx5Ms6r2AhOsUe23GH9H3KHPnE3wqqzBiGQ5GktCyW+dARufs41lwR6WBeFU/KsDpnWtpPz+Ikh4fGQp2qG3VVD0DAUpFqThepgClQcTMLTQhfm23mTpV1ZR+JCGHtbxkbQ1lN3x1JLWvAmGPlK6GCfFhkQtbZCfxkw7AZYc0JL3tCPYfiSQpX2S0tThJgzJE2F/5ggwIMCjfg5LtnOEgUMxzlisJn/L1fjN+gm1LVtNAhsnbJ6VylY9r4b5YifoHjfjneIuln0chVmKE7NV1TGbpTXsnqQGXVVK7JEAx79MYZGvrNmul0rs71FiQoIM562d0dmgo/8Be7r5HA==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="35" id="sample=1 period=1 cycle=2 experiment=3" defaultArrayLength="228">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="175.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.077996886544" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="20667.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.0675" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="3"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="437.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="437.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="23.321104049683" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2308">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzHs4lIkCx/HRpFKKWFnshskkOlKTS7We+qHosidSNreSMcYMg/eddxjNO5RbKiHac5KSsG0pbbmU7YKYhu41dHO6mHHbkt2W0Hah8/71+ef7fJV3MyOtPTdDf/G+Pgf9QKimj1vfbwqCLXdof8CqUIR+HCRf6IehvvVsHzdrOwL/K7/ivmc7PH6/ZZWt3o7k1vq8VIRjG/LuR6rCcepTcsoP83bgmutgPMt7B2olxcFVxyOw4IFpw6geH69LQ/dW2/BRk1kRas/ho9t4ltfxSD4Ctx5prMjg46CyZyJKy0eeZdCLIFYkIr8m9c+3iUSKsiv6LSPZ1+pe8SoSNZf9w0pZAvw8nrvuK2O1X6ddip4AjrdTlg8wOhge1J9iK4D9g+feA6sEcKlyCDXgM304l9WVJkCuy+qTVmUCnGHNuqZkPH+X/aq4WYByjuqvHk4UDOpyXG6VRuHLqG/HnBNR2EuvTex5FYVRMmGgvScKz9+1sGN6o+BmcNH+T7YQG9hH5j7kC/HjAYMUgzQhBC9eDRxmLJavyYrvEmJ/rp7FZ60Q2cbf35rBicbRO0sXf9glQi3LbpNnhQgbv+TnPGVsM/xVdbJFhL3pUwUO3SLoXN7UdTD+sOXCRZdtYgzpfOO+iRDjhnI0YCRFjMet6QLXTDFuVpVXjx8XY+H56E6zLjGyvTWl+xinWej8fteKseRxbNvIhBiXa6PPNs6NQem19SaW1jGQTb56JN8rBqKrtS6eGTFQXJIbJZbGgMfymeNUHoNMv3cvH6yORduKY0+602IR0MbudUuPxZzaDJFXWSy+BPdsn1oRC9OnzyLW6GKRvM3tX3LGorWcla1eEjzTUVe3hEuw9YWubnOEBGOo6NnIlyCs0KZg5KUENj5/rjjDj0OpWxG5sSEO5kMW6puqOAStwcQubRyMCwJYyrnxqB/nhssE8Zj+boyUpcajs/6ZY3J5PNL61dF3GBdc7Fg+NjkBh53q7fTnJeBB+6Mn/K8JaLxnV3RlNoE/WlLPBZgQmPufXUkaawJpNr+FVNoQ4GlfKzi2BDzT697ZcwgMh1UkRS0mEBFo2XWPsdjt23Qej4A9HbzPGgSmr6xyOc/4HS+GfXMjAfZ1n2ATkkAf58eCiQIC63lWvTPLCfxy2v1Az3nmQzpZfKwmYF242eBlE4FKYVm28DqBC5XR9apmAj8F6ClMHxCId3bfJGLM1JuI93hIQOZXnvNeQ8DRrtAgq52A8f38Je5aAnJn7qXgYQIzVIZF+78SyPEV5o/OIqFrW00fmU1iVWriuVAbEsKmXIsbjIdDSnYU2pJwGki11zGWRrYY2S4mEUCqLxOMZmrXl3/zSNRqioYcl5LYY0Xa0oxuPvuyYkAiOKS5M8eLxEnW//79mLHxjvbX7QSJ3dOtH4kOkrhQ2vTHgQLmJ5a032BMXDo2vOc8ifr1a7e1dpFYabNZ2GYiRfsHYY6EI4Xv0elb63lSFLZrPG54SrHAJn9Q5C+Fz9PPf3EDpFjmvvPmd2lShHuUsCzLpbD2NBo0HpYi0yFvxc73UlR+/1NHySQKdbdF3L+NKWTd3fR0CofCp7KBExp/Cv3LnMQHCQoh5xbRxbsonOniRikLKNAjjVqjQgr/CMxMUxjNJ30U8k5QiN1lfvZUGYWa7MLPNdUU/Ao+FLhep6Ap9pgiekjhW/Xc5g0aCuqWLRNVjAYLr3XYt1OQHCKL7HUUMl7vVlV2U9jSR/eY9VBIaOYdSh6mcKXb0axkkgx2m71FEmMZGvJDJEJrGdgL5CWPCBk4b9kRXFIG+4o3tX2M5pkC4yCpDBvyXK5V58vwc4nxsyGVDE3xDUSzVoa9DSzbf3QySO65BqFbhkdyW4XFsAyWO6uOBjJuG12y9xdGz6Bn/Z7+iSAs9Jf57EjElqkO4rcJiThu5NW/hkgEaXgldcOSJIgLtTN5nklIFSwxNOPJMew/f/ZnFzmyTMJaur3kyM138F7pL8fVRaO3NdVy1Kme86Jtk/HpmHpMtSMZVHivqfBQMuJOXVrkzFbgtzsnRJwaBT4bfFF3tCggW5g3rUilAHdQrXN/pECrt4fpeLcCp9/vT0nsUcA8xZdrNpnG/IC3miemNO5KreJDvqFxeo0V1cmhgWlvVi+fR+P4wd26BsZpu72pmXY01rlPManh0Wg5ptLELKWxzEdY+cGLxnrunJDkQzQybmTXjzMGbk2W61fQML4THfCwhkbT+52b2LU01PRCrXMvjTmNbw7ojdBYcHXQ8QhbicZa57J1k5VwN8peu8pECT+jGZc9TZX4P/B3MgI=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1180">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwQswG3YcB/DZkCYqUm09xhHdFRWvaqa6UL/vv1VFcLFVR61UsfS6XWiH5np6uC07vT6ORusi3Yh26TlLaR09TOeR7m4Yu4S6dtcS3czNo2GaUe72+chEMXRRbyTZhQlaxm7WH/mKTGf8Dm133QQr3Yk4Oyvdsy3H7h2sQmveI3JZ8WX5D/1Yyq92JO3sp5CyALb+eJA8Hr17qGranprWa+GV1glfC4cqzzbT5HIEO6VopqrMLaT3H6HgEC5da+DSuBMPc+mTSGgbJU3aGM3OqmFs/AQF/c64f52Pw6m1zNLIh/TKBO2WCDA/cQTB3wlodJuanRqtpsiF53j4eA/E06sQrVto/r47HRN4UJ3bQSwqlRj8L4D9cZqQU/8aHska6rghR8QtOQTFodB8MEeLQ17UJKiBJtKbRt9oEb30Dy5fTGHa6WfottSizLRE56IbSA0hxf11E8lvGshQnQhrto70+buoWK6jmS4p8q6nQBvjj45UfxpaWqMT0gCK5QfCNT0Qwtk0nHbfJMMBMxY8mym0sAWTY8HEM7eQfNwOpX4/soTnFZhrGMGBzz9mjaUhSOyYwf7jldB/M4BF91Dc/C2UnrxVs7CMHUzoeRcZOl9Wrmils3nvsxxlOIqWsiDtC6cwWxY+rP8a+t9bKcxkDx9lG374qY3C+Q/IqHuB24oMlj7mgGKTA0yFEbTWFUHlzirsdXdEkocjk3o6wpDkiO6yBAbvfShx+BaGCg7sVRy2rV1MF9Y4OP9gC6xfcdmT2v04cqYFEnEUXTrJw4gqCl4FKxi+LUfeXQmyWrpx1CaBKqYHUeU2ZE7MY7ruS6wa+bjU3kvJnQfpPScXJtzoJVUil0XKYkl8+Sn6XirYz7NPEWl1wb/LLuj6aBhdcZM4Fy6AsLId4/wiBHn14dOeIvg2rWDf1SBwFhn5iF3xWuvK7pwfpN63gySwMxJPNMSOJ8eRn64EvI3t4HLiMSCLh14TT1LtL3RU5oHx7CHybkylnYZUElnrycGzEgVmNyYx+8D2zEw1nceIO3WC7vS+oIxcJ6bgvKR2pR51dQNwvpKNL7ZuZW7ZG7CmT9FqzRRVqHOwUHgPw7dycPL7QHx29QYTSTaRVL2DRefn0p86C5XM5FKaKAjLfxexmVw927NLhMzwV+jpu4bmsnfY/6ieftM=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="36" id="sample=1 period=1 cycle=2 experiment=4" defaultArrayLength="199">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="484.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="274.018731706783" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="23438.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.069183333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="4"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="462.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="462.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="24.884387969971" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2020">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNynlQkwcChnEuD7JUELzQNgFUpt4YIbjUlRdLlNa1omEXiwK5IQkh+XIYApEESFAqoAgWqtaAKLSlKlmvOpYjKrSgNOABgiA3obUWxMVxEXS/v37zzDz6f7NCP7VGYRnn4OIElxjkftxcHxK6H65y14gh0sJdAUJ/UxwmG3pPcLLjkOHw1TfShjhESv0/WbWcjRvOHQWL49nwvRuw53PS1tStQ7fPcuBe00J4mDnIqwp67eHERf7O04HOzlwYs4/dC43jonrxlW0VPC4aGfrJGTMXSzubixzLuOgeOXMxuo+LVZQtJUUOPGS/tpz9wIeH5tW7bYZQHmhplyz39DwclD5ckmPmIcg73Kmmjwfmwkj/EQc+YuyBrxoz+HjaxTCuz+RjE0t5wWjlY/XohWbPfj6+HusSqvUCrHxcfT7TLEDF2/UvhkjH2pL6M+oEKOlfYXlJOl23UNzSK8CPD48E1w0K4CURLds7JMBG89vhHmchWhnG55epQjjTPtz+jitE+uyIg24ZQnQlHroeXEZ2/mCnrV6IXY8OaVS9Qtyp3+99jpYAvbG9qYOTgB3ljFdr9QmAyMTPjk/Ez0n2KQY7EYW6m39tMSQi/79N+5aUJ+KTJv/t3qEiuOQ8TheEiVCx4HvTEo4I52zRJiZPBPccXVlzlgiTn/556h9GEQrYiVRqrwiv3y1+QTGLwT1WYGWeE+PeM8rGXl8J3l7b4doRLsGHQV4Ndq4ELoV/7BzhSxDo4jTEyJSgTWKmvCuVoGBqODdhQIJy95iNvLNJSKyaiTCT2r/oFHtSpdh2ZZXpeLgUyolJXztfiqRrIfvcM6SYP5r7NPm2FNH91U/yqMm4+d1A50eZybBny6YkpI2iZ3ubspIxb17ohfnmZBTXJYSepMlw98HGnlvxMqTJGUnPDTJcvS4ocSyTYd/pFVxLvQyKb0saoz3kqL1gy7vmI4ffG0s800+OrnaXmVMBcmwvmjVlJX0vLKq1gvR899LbkXLE3uKH+Z+Q44MI2iK3ejmiGSdO8WxyaG1L6XPG5NgV8luehlQfF4E7pO0LqibXexD4bWXc+fueBAZqWU67fAgMlu10+d6PgJl32903gMD7m5vLWKQzdZeVhaSsjMCK+6RfNtAqb9AJxGzwo6/dROCfH3nM+ICArmYwi0VanEU9lkOa91nRRPw2Aov6jAfEkQQoaxIyfdkEmtsH2Y4cAsFnWOHpBgLd48Oe3xYQ+PqSzCuqjPzCPXRHSI/V082VzwgMnzCN95NO12SNBr8nMH786uFy0r9RHq7/zF2BifbL9U9JXy7KjWLOV8C1NK16gqrAc7tDn9pPgQeTA5uO0hXYKn7RZAlV4GHjRdtJKJB6/TRrRZgCmX8ut2m2KXCwh77QzlZAE2vLZHEUoJZO3YjSK3DdUMRPJ01uoj2eJjUwK8XeGQoUO0Znp1oVoHk2CEpImbVJVXP9lBCL1nwcR3q0uoazl61E4cL3qygGJVJCgjQjBUpc0h/e7FymxJbsAI2gVYkMxk63dW1KPKFreqWkphy+o/alEq5ElOr4hBKVAxULpkjdOt40+zmr8Nw/8qnJokLVLdmcO3Uq8Iq3OtW2qrClq7649IEKy/fkX/yhTwWmtmXeMGkg5da/6AMqPGm5FHaZ1LbBx8YZV6FnUeWUt6MavFmU0endatj+3jkSFqlGbrTh14k9ahjtvg4xe9U4eji4vZyU6tUd9TupyHhg3ct4NSK1q4c3sNXIX6a7O0aoUTG7JHa7Xo26aIdr3f9RY9wWcNjaqka73y+aQ23kl1fU1W/VwKvJdC+WnYIAV/d3j0jZq/3DUywp+GlsuV5mTQHvQK1hzQItpvKjRqQ0LaSjX0plX2ixe4jV0SjTwjQ3rynouBZRs93cW8xanBL83rujWos5pdxicZsW2cwfe+Y7p6Jm3vliYVsq0oq+232zLQ3DrmfeDNJ1GIv1OjJ9RQef/72t3ndXh81v5j5KH9Rh/zLLyZBXOqx8sO6HR6T/B0bf2aw=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1032">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwXlM02cABmBHgXK3WymCqChi5BgoRfKzIY73/UpHODYZIlEah2CTBR3SPwwuiwcaBsWmBTFhosUoWscmbEwuXSQgI2tLMrIIWbXoZB4oYTi2SMKmUZ+np2YRm54Y8Mr+FenqgGPbI/H1/XC2x1VBWxZPx/srWPdzEK8tDMH07xCK73WLQcUI/nGcQPykJP62yVDbLKNl/S0hPfRlxZITh+0uOO117AqUo2xWzsKAHaKhcA+nQ04i5GwXcxZ+wyrZJMY2pVI9EsoBr0OsTArDmcAsHrz7qcjI1fCdAAXkpQrm527mzoPHdQOydylb5cXyahcH/5zCt9H3sXpUhRXHWpBxvAWfFF7gRu13zE5qRaamFfrmVnjPRLFjaQbd/8/gRug5RM/Poa+wjXvaNQzQKcXW+hjGHu1h0cMYdGZcQJyUwyeePHrPv0D60Th66m9wXL+ew/+NcyHvCqz5G5De9Aoj42a6jB1480M8GpSJeL58mMW6/eKl6SqHJpcJo7sTikdjoi8hGX9F+tB8KBkCu3iv1YfbbVHiC1M30m5143vPM5orUrFN6cfT4RpqYzWI+0WXddXjx4yQOpqNdi6G5/BOmD8rXRqui/Tn89AeJP7xDaHswWBUGs3laXyTMMa8MX/OlfTCMRKsm5el87VvOmxb+3H9g370FgjxZXKbMG4eoEuScOdAA1ErIahFonk+kDtighibsoUTiRc5IF2H2x7E5Ikt2KkIZpXSwohKLc5+XiySen+C/94KGppvYneVlW3bbbQ5w9gV0MjIZZmImMlEyqxeFMxlosao5FoLKKzDSJkCKldmoaB0lNG1KrpPqpjwchRr7bvF6vJO7vuwmp/p9fh1Y7hw+mUjUO5EfJ6a9nw1rR+pWalyQipwIvqImsGXs3lqVs0JU4I4YXCjrNTNqTW3ob1bRDFVhEaffl31sd955bEHS4p25lvqmfjeOl6KShVeeYRorCnhx6EGWh8YOGq2UFW+Fz/OG9lX0kTf/V0Iud1E0+JTTC/lirdVzzyf</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="37" id="sample=1 period=1 cycle=2 experiment=5" defaultArrayLength="199">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="205.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="274.016408683336" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="21588.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.070866666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="5"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="487.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="487.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="26.447591781616" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2032">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyHk4lAkAB2BHtkNtSmWTMEjx5FhhxcaPHKlFBxY1YwzG2fhmvs9MaWecxVYqkjZnmVqbti2U6OJRimw5puxKmplSW5hEktjNfn+9z/Omz9b7Lna/P2xOPpH83BgCd9uTbzbOCsPYmrUqrttOPP13ieGGRiaMxC123+9n4Q1Tx0/jAAubS6TMkhYWchzFU6e1wjHfe0gnC+FYvb6us4bBBnMwQO5mysbgjcCD3R5snFzZo1m/kQ1v63kaBSw21pXrZ2c2sjHtry2pKIvAq2f6BUeaInAn9MdelToH2xXhugc1OJhL+FZpm3DwTHeb+QcmB2MdrW5FkRxoWU/V38vkoJbn8Wd9OQe83tw9QQoOpAv/NnQwjkRQV1SCWnokknIe1AgVkVDtdvf1UkaCsGK4fVSLAlM2Va9/JgqhmtcfFpZHo4xTeeLhy2iQGoWGwQPRUIx9HtafxYVThnffAzYXxbcfzv46nQuv3MmrRWe4eJU14R4u5+K1arTkMu2N0PodnQou9soXeMxRcrHUo87hgFoMzLQdus6VxaC7KCuiWB6DEFOZuXpaLMxZi2Ue0ljUaq4hq5tjobfuaiThHgfbej/5+qw4HNsg5V4oi4Pz4vbj2hVx2NFWXWlyNg4pNu+dvjyPg1WxVs5ReRye5qnfPmcYD3Gs6NamzHjMeRs0P7g8HrK3yn+v0DpdvPTRpyIeKqN345DHI0E6YTCujEeklcuWQM8EOFu4iR/TqnX16/WmJ6A8YJZB/60EDHN2OOkpEqDbLnhroUzAsqxcxk9uidDXDdlG3U3EUKXnKabnbqwo1hjtoNVuVy97/mU3BjwCfg015GFyWDbg4sqDaXBEpkk0D6fzzJzWZvBQHtbaK6Pt2GWRZqqVBMIyJLvBKAnjlFbptvQkXLW8lkIZEbCf3GV/ypjA8LRLtrcJgRaNQ6xwWwIbUjL03oPALS1nXVN3Avd7EjVb/Qlkzv8wXLGdgFpWUIsdh8BnlnRCP4lAoX36paCjBNZHB0zfySMQ1i+2YeQT2Hf++n3hGQLWDt7/DdFabD222KuCQODlg6qvmwi454T0RdEm9wSFVdGu/Ke21KyTwFy7129eywm8ryzY5aUg4DcTuNpOh48V/UV7/Iz5OPSiT/wXrWZbqWOILR8Vcy82ZdO+MmttcQYf7uTI6gMefLhl1mm10dbvLbmXxeYjjDXo2nCUj25V0en8PD5qtx8eSP+Dj9mH+yaoS3z8OH2ktou246C+PnuED6cFa8z3QYDK+dksGVsAF5eu+q/SBPg82fyTdroAkTvV9n3KF8BxneUi+2oBtoxHEA0KARgixt6AEQHq7CXrdn4Q4O2bJ4s+MUgYnC5YFWJLosG3zL/QjkRf7Esqg03iO5WGTgOPxIo/cnAolYT6jtie1EYS2d84Snw66a+6/E7SRWJjqbDtlILEb3MWuiW+IJG58maV5QgJk6G264xR2i3hocELKYja5eFK2m87Dy1v06Hwqf2cJGMRhShGotWfDAptcaEzDREUciXXzhYLKKwa7b/Rnk+hNDY4tLSZwvORKwZf3aHAVT/fKu2kMJhYkjxGa6RWVXVCQaEmKNh5kPa3v/6etVlJYZ7DEWvvFxRc0551e41RyH46VvxaLRnKcFVeR0QyPJ8amD/hJ+NjjI/Pk45k8ArXe+nJk7GUKCz91U6IVb0/bBjNF6J30vrkg0tCTPkwW9RrhDD9ZDGYS3tXuc/merMQqVZdBqRCiMGkZfHVJiIwa2s+J2wVYa1l7UAHrSs5erY8XwQd6dbWtcdF8OUnjw9UixA/NcBe0CmC1YNVc2fkItyJ+b2bx96DRT7RM75pKbit258aWJ6Cbb3tqYKuFFyTr+k5LxXjl5t+zU5XxDDOcbVdclcMyQdHRTbthGfiUJNMDHFibovnYzGe9WqkLh8R40Vbk/VjUoIv3z56VJclwXIz8/1njkvgMePS1yGVIGeLDUOrVoIo/+mQzbScR9SFJVckGG1Mpc7SOr/b5FAgk+DIzozdt19K8D9iZ902</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1040">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwQ9UDHYAB/C4e7d7zq3lVLrDOlG9+Vexs9Gt7/d3R+95nOgvlUMstG5RjueZZ+o1j6HliIizXNaahVJUODlP/m0j3kir3bvE03NRy9Pa9vb5FOc/wLIRMh7tehoz64WLvqZSbujyNWj+GM23JsEj43Lwi7MWCZ15kKuCOKdtE4a5B2Jqq6xYr21E0SszU3J8kBu6V0xbPoz1dc0YYwphhb+LIZPzkZE4l6GuqyLOEcpNdhn3pl9n3+/bubNxn+BYlZAu62bD6hox3mrnTbkvOs8rRPItpeFPqR/HBp/hzjt+jKprg8ZYx+YZo9AfaoO2bzQyPAG8tyiQU3Z5sO/SV+L6F+EieIGa85PUsKWpufLZh6ItZxpP3TmKxTONfHaoSOSXGbll8WO+k2ezRzme2hteXJHrhcF9Aqb9dkT32ZE4YEel9HuYdoQg+uVE6lduhu1cHI85I8WP1iH86xvOI91RwtZextktldit6+SL+B283Po1724r4el/6nkxZZDue1MRmzqcKbpyOqb8zEc3lUKtkvB4+g2OKJNQWXiKCU8lLLxfjfTW6ZDiosjaeJZdSVL2HyigNzCSHUGRPMwAw7zq24bouacpaTrPQWUhvptpZb66Bh2aGqxtkTG+shZQThdrYj/GrIE0MbvcycvFOpo+/Zyt0ky+9VNwpHECNUv3IO22gl8uasSVkjloqWqE/oxOtD5uQrunCdrtiUKz632+KapglC0GwisR63quwhz2ARfqnejY6sTkitd87X8Nucs3cIXiAtcEX0OthXDbBde/EWweSuXSbCM2x6v4Q7ULjwpUDGs6gOF5yUL854LTYKXnpJWl39j5KiWW+8tjgeRb+EQXSJ+kMZQ9XACPz3Pa5Gr+9S2E+aeFfOhQ80Lqr2wI/w1bPopjf7VelIbV05ExjtvMS5CbWSIKniTg76pBBsj2UEszJ70XQduTYkZlRjBIl8XKgxH8LK8Hio4sNHRn0xFuwYNVFvae9HKo3YuX8/3FSLeFZo+Fh1N7saS0F/8DtytLsA==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="38" id="sample=1 period=1 cycle=2 experiment=6" defaultArrayLength="183">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="248.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.076446351073" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="19384.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.07255" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="6"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="512.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="512.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="28.010726928711" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1872">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyHk01AkAB3Bhs1uOrHrVbhlnbdsrSofajK+hJDtIaotMDGMwh99vjGamHONIx65jPFdKhJSjg1CkjJKU52qiazM5ynq81Ki0sdrfX5/3PmVGBT0Ojn648+rXM1ZNfrDU2ttseYyF2pNTq8xaWRh213erNA/AWIfOSqZlAJTqnD/aGAGoLVHbH3QOQEeHuU58YSD0O+s/EP2BECXcHzTQZqM6qdhvpQUbtQOXPbv92XDJHQlczWbDYG9kdGIQG3oDtPSWQjZSnM7lG51nI+jpzI3dr9n4fab+80GtIFw1KHhvYhaEWkXdepuAIIyx0nbPnROMm5LyvimzYLzTYn4wteRg1FFANy7goPmE14JcyrX92Vonmji44XCnqXGIg753a8X7hjno3pQ0dtU0BDPnVzrNiw/B8YbVu23VIdBkTXGyKHWGXzT60bh4xZmTUOnChc2jByGac1y0W1987lzAxeVyE90uNRcZdS8u6MtDsWn9tDyfMq2gPOtTUSje6dEEXGUo6k1SJwzvhYKV0jTolRAGlal/bRfloR/qxKykMETdL6nLOBeGXV1+498VhKF6kulkrA5DfmL4uIllONhrPGrsi8KRTKdLOlx4kNqtK1SweSiX7jp/dogHvZ/7jh7Q5ePJmZaBbCs+0qJ7L2c589E6neW8zoUPydSPRXYsPh4ZKVjBugLc9LWYtKYLMJ36PZnpIgDDfaHk5F0B9Kt6l23VFcI0zzX/kqkQvV62p0i6EHmDRlw6S4i25luMtGAhjtpo+C5FQlidXKz83CKE61UfL3G/EO0e/l86Z4UYvn4rpVsegdKGGUN6fAR6jWfSKyjdY4vf7iyMgH3zxpZvlB4B2wzcSqhfROrtVEagcUdNqkiLQPJT8+LoBQQ2v7TZV2pG4Mk/v63SNifAuiZezLcgUM2+HXPZloBdtvFkjSMBxcvcwGYPAku5VzKTvAlUWE57NVKWhZo2uLEJ2Ex6Fw8pCOTw6g55ZRBQuU4cf1BF4NTd6spvlAnaWqVrqwmc23F7xVgTgef++WctlQS0DkRFB1O66v3tYz9AIOMON7qB8qPRqMpigoDmbuVjEeWX0sT/QuaQeKB3vGHEiMRHpyOlTDMS3a/H5nnZkkhytvXcbUcibL5geT1lhUPK9jyQeF7pN+XBIHEksZJxmtJHkcHjOZPYX7yjQygiwdZfG+4rJ1E+2tl6PZ3EM36RZ6KChJKvHq+gLDoo/TpO6e/J7FEVksg8YRNbUkXiUKtA51IzibgVISNxXSR+ste1+5eyb0l7SaOaxNIyYrRvlkTg7dTW099ImBhuUB2mifAiZh8tOEKEM9npim2vRbivdJikTYigxzi4RTwpwiPR7WoDi0hkmO6djA+IhIX33WWbAiOxJFZL0qiJxNEVm+hRRmLQMt97u7PFiJkOrLqiEINscQwJzxCjrW6JenxAjMwm0c2Ng2LUpa87X0nJeVjQ76sRI7ttXEqziEKucE2Vj3cUdFg82ramKHRYNV+Yey8KtSrfqlPVhzG0989SAyMJPnH/eju7TgKdj0yZKkMCju5WlbBHgv7Ns21PDaWoU17UaPZIYcjrGXbzkcI6ZzT5WIAU7y7lyJhVUqzZN5iZR1m2PFot7ZEiurcsLWZAiu75+vJwbRmemTxUlG2QQV7BVLc6y3DA/cLTb94yjHX5ST6mybBUE9ixqFCGnUvrrwnlR9D7ZkQ0dyIanY6ejc8tYyDI4ykZ4lhEihWpHXviUBbLvMEWx0H2JEnXLikOy7bs355CuW3+IlN+Zhzeh2QeW1gThy0lg/UvjeXwb7fWXrBeDtUv9LM8ytavWx/3bJVD7P34jRlDjqq85PGaA3Jct5hiGPvK8T+XNac1</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="948">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwX1MzHEAB+Ar1REXKSFvXSy1U8faXQnz+Xx/k+FSuaMXppUkmyiV2LDIlTDr9Y7NLnGTmJLokEZhGSoji+Q1vawmxukPi3mejnPOYk/UFRSr9ZJ9/zTGV9mwbtjOjLkx1H34vXL1n/sI75Hxi32p0NlakGx15Of6o/DYMV80F+exvWQcXrb4SYqGBnZEWuiodqE1Z5d47hfBqX6nWGHpRFKlgcq+7zT+myUOV56GPGEyx59sFLk13fj2tBgV5SWwTSyFadkH9PqXIVodxm29Jij7TLi3fjoU1WYE1ZlRNToTEfZ+lPdoxYOMASyO8EZ62SCcDLW8NHad+SMvmJtfwZQxH7TGVyLPpqSpbC2jZ/3C3JOZOKexwvZmARIjihim84Ob8Q+6dAu5PS+Fmr8LWejmj/bb/sSMAD67pedAQwAm6GUc1Oey1SCje6mMdekqnD2gQvLjq7hcFEPV00V8fdDM4G4H9nw8gpCZjkxuvYaR6UG0NbylMjAIUbk1XLHlHe2H1Sjw8WbTbCeemOPER4fCaU9fjB8bj4lsk0rkKZdgSOHMPTvr4LM3S8SedqYqo1MqDXUXO8f7iqq2G0jVudBL78J+73pOHUjgC4Wcm+Jv0r07kdInB2HJL+ChAjmtTGJOjAZZ1RqG/NDgc3AFPSQtPAMmMNXyle/zQ5j4ypUPD0zisKmRwc2TmFmyHLWVa0TdkybIatNp9CJNF1ugNz5Ex3GJwmEVdkmj7HJ6jIQL+7hIHU7blNU0ua6h52svLtnWhqKkI7xzPhJxUdEs376BOWYL693CuN9qQNrFeXzba2TbG7l0yUNJT9cuBJ7pwkqDL3uP+TLtZyyGRuNoXdaNoZH3OPN1AMWFNQwfTGPtXblofpKBIY8VYnd/kjBLP9mu0PJvShZSN//GnK3Z1GpDOdaZzcC+UN4q3If/Rlgv3g==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="39" id="sample=1 period=1 cycle=2 experiment=7" defaultArrayLength="215">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="346.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="274.021054740076" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="23635.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.074233333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="7"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="537.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="537.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="29.573804855347" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2192">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx3s01IkCB3CijldIWysiM9TNI2+7opOvRxSHJVZLizFjhiHj9/vNYGa8xrN2e6x0yHo/IrdcGblILSFkuXltpLshLtm6W8qj7K3c+etzPhfHfX8t7PWDZ/KO1y5dAaArd8sVKAZD+pvetmNOp5Eq6fAyw2ks7uJ+ldIZAvcjJr/RskMxztu3k9YbCtdgR9ucvlBw792tcTBk4P3R5rUkmW0eFipOYQwUOLTm6qcxoBBV7bBWxsCXR3meaSvhOOVws3ZVnolXroEL6zQm+kYnFnzpTOy80vZPMxcmrK3jtvaHMJHnFlzEDWWCVRpwVonJxC5uRGwLi4mt9vTY5kwmrs49Hu4oZ8JkgZsZOMtE8EzJuzA5FsbM6wavyrOwxbgr0N+ABdttHtInchGQPOxwC5ePwJO5hoX/GkRA6VJrBj89AptOU5rtMt01JqMPGLKRsL3pWkY5G8Uuq8bLz9iY2K273jnDxnnXgL+PzLPxSM5XRVGRgxKv9d1/STgISCz7bFLJwdl2Uz/LGQ6WVqefZMusbC6sVXnOgba/SO0xLRLDWaE3pWWRqF0yUn47HYnjdq7ddbORqHukbM+Xi0LIl4/qTb+PwqvUUtfW6iiYUR/8dZy5aJf/rizYhQvFyfgWbxYXfZZ6NzlZXPj9+oKX28FFzDVTmuoMF/nL3sZDs1xo6mjvDaJHQ24pv3GjKhobWudnTHqi8bX5gYNSgxj4cKSa95kxaFY//OOA6xmMTd25EewWC8Own4M6ZPqPfExzTI+FpHNvbM98LN6ohXCNFXnw1vfixejzoFHGSGt24eHoyTW1hQgevodyjFMGD5W3yYkpmTlTpikh2TxkK11wMqniwerr9qhGmUGsc6zT1Tw0sN+P6fTycCAbl8y2xkGh8Fh84744lKl236oPi8O4kXXbhCQOSSfe/XAhPQ5Kgr/dNtYkUIODpdcNCKTsYQ0k0wn06zia1FgSyDJrZJlYEQivv6W96UTgz4sOz3pBoOCvdqUHPgS8f5rzOneSgN+R6zahTALk7YMNazwCp3Vf/q6YRyAo2YWmUkXguPro88kGAkubtPMPpQRS/X78pN9EoLqw5pK/zF7PgX/suU/g8z66j1DmKvF0ZaaLwOM/Yy3Mh2W3o7eKRgiwX7KjtGYITEjEIo03BNrf+TI61Ul823K1xUCThF50a3+EzOK9zkY9WiTE3QobpwxILKidi/SzJNGr7eCeK9Oh2zz/mjUJ3tz0bk8bEjpOHyyGZHofT38QDhJtnY6Xy1xIjPoM2TidJDEomCyPkpDYyeTYtOeSsCy1GZ+TmVo8n5F/mUTMmJ3kaQWJ/esJuvxKEipV6/ZdjSQq5HFVq5uE6p5t00YjJDxtbDlPZHKsckMUN0mUDM35Zsn8ScKY3dSioME8pNlEp2D8XFp7woKC59KniHRrCs9odzPUwyn8Xqfbv55KwWCYffFeGoVcpY998hIKhRlXppTSKST9L8vbQeah+LbUTJlx2brHAy5TOPPvRNuKPApBUWz5nZUUWlx07cqlFBYfTFTe6qJQF/HNLzXDFGwz76bEj1LoLdp/wXeWwsnDet95vKHAVTO482mZwh/KQ7WBKxTsPg6GixX4oF/AsW4aHzUDUXN0Oh+DOzwM1qz4yFy/31rF4OOesyk3l+BjupbvGyjh45sS7phHHh8q5oeeJlbwsWOhI6Sgko+lIjJwXmZr/Zac7Q183Gj2Il3u83HYX3DihxE+Es8OXNEe5WOe2+jeNsOH3kZoUKCGAAelciv7LAR4f62vbL+PAEWXtPQHygXQe1GUvNopwL/cqtOWuwQotf/lw+KwANvFgdpWvvF4xVASGQ/Ho8rhBfnqVgI2BhUmjzUloLHfyLXdIBHFge+3eNISccR570CFNBGha8+Mih8lYvZEp8PAZiL4qnc0OtWFWBXr+XwKEyJAOf1NE0OIs4ovFSIzhRAuOl60kApRYVtQnyQzpzv/rV+XEO7b3p75oluIGvZ4Y+GoEOWGr4tvjgnBs8wbkyNEuO49H5YjEUG17KvJA7ki0KVptMlyEY4udibbVojw8j+3PdzmROjc9bPH5WUR9P9I2FpiKEauvbb14iExVkbC5ZxtxPjMMG+echZjsYe7vcNFjEaOwmpmuRiq6tOabdZJIB5urse/TkFfcJ5kYYcEQQo9VaduSPB/VKAClQ==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1120">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwN0I1TE3QcB2DA0cnrNsRuBJgNxBVmGwFGcPH9/DaUUxFM2ilgN5Y4KQhSNODQOIwU5y5hIieK4guHwgZDpZxwE4munRkLMgzhwl1sKIgIEigyrOdPeMI3HaaR/kaasaXS0GlXFuppjX1XOEbq4yTND8qhYdEE8QxryPo4j9oNM5RZO0v9FjVerHTG+oV51tntTMEyIabgQjXPfRCbFASBVxeJjCWQdchI07APBfHR0vNWDmw2DrSJP+LTQR5bteMkfEJ+oyauhc7wE1Em3YujYglOHPVG+8CfNFhWxQSjtQhQSKTC0n4qbrpPHxlSqMLCR9jjAboechxOu4bIkTNEu7dW0hN+DLRJVVgn8UNIhB+yM+w0OX+SfF0e0rCXP7vl4w99nz/6kmuQdDUQdtET6vn6fWj9npH7aDCeKWZJUVlHM5dCqGRPC5qmCrG5pR7VXBHqmxlTa4soOFNEY74OmjWK0OrnoAuCy7Rft0B3ee9gN7cYvxYRy/RvpCyzjhxlYWzlA2e8EpSgvEBPk2Y9aSM1yHdZzP4OXY0jy1NQ6rMIJ/InmEdvM7bwOKiJcCBOWI09IgPVKd9grnIOpgvEmLi3Fu9V/n+3REIqlYR+6ZnGmu9dcWxrPBYLw6hzxEOWsCMA+zMC4G6+QgcFrzGP7iu0b8N30Gw0gZN1lZ7npkMq24AD3RU41VPB5jsO0bdxSox+3EpFijtIz/0Mr8+2EvIa8cfwD2Ta6wbvljKIrW5Qjrthe407plVRyOGpocg24mn3CB6eS0JbnpEGX/6Onbej6F+NB1Zn3CBNWjEuzN2gi4uiSZUQTfWRM/C67om+Dk+oX7aRU3k7bbQ1sJ8exMC+bDmzLDHRoMJE8p1folc3h7+mbkMm5eKb2Js018IF/597KHx0k2LERE+X3iJDE2BXpyDRLEVkvBaiz7tolU6Gt+Iqcf5tA6rlTuhLT4Byi4WivmhFrTIQvZ2BCH91EDrrOJrPvQn9/WR68dUnuPOBHOZL48x6QA775kls+1mO0Mk2+NoOwYl/GN6FQexYVxzL1QcxU3IqZOWpeLQrjSJyVuBuQxqWlebDOpaGs23XUGXsQt2wGOtU07TQ8CH+A12NdWg=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="40" id="sample=1 period=1 cycle=2 experiment=8" defaultArrayLength="159">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="143.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="144.060826280208" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="15551.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.075916666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="8"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="562.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="562.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="31.136831283569" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1632">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyXs00wsAB3CW1L16LbfcTom4vZQ36aT03dJJR3eU8siJGWbC/H77bcwkG1LKuyO312i99FDpqdVsJd3Sg/XAKdqMOr1uoY70Wvf31+ePT/husn79GA5aSh/HlLLCkFbWcuL8jfXYEbDvRsjyaNjtabbtbYoG40pZ06RtMahw6qhydeZCkzsvY3EsF8fKbfz2KuPw1bG6etiSB8v2f8z+MTzUdZ5beSqeB50NEW+bwIPvZ5OuKp8HtUSxJsrIQ20Sf9kPh3gQp4uNsXHxmFVgtSO5Nx79l/Mq7S0TML11wlCvIgFTHDoabZwT8XCgnqyrSQRrjCCsi3bGjtDu1r5EGFzKl2T1JyLNgnnTNYePae+6Ar/L+UiidPtlCj6y+pNampV82GnUTXwDH7bmMaxGZRK0dy/HXDUmIaaI8dmNK8D9Va6bunMF2Ku9sStKLsCvgWCOskYALx6TY6IdPjrp5ZBKgKRkkhlZkIwnbH66nrbr2tjRn18k48dHW/sobEbnsqCwOarNePPArNkamAKd3XVlP+02m+6Ah7wULNvXbPksJwWnPlnN6NGk4OcWfc9NZSrkcW9LLgWmwW0i1+eMPA1e6zwlT1+kYdf9oyGRM4WI3lt9++8AITyYo7x984Ro9I4+4Ds6HYbIw+pBeTpujWblfFCkQysZnNFRm46X1r9dMOjSEfE2/32FIwGD5fHZXbQWt4v8ljsRmDrkcWy/B4GatU5qJQjIrHef2sgl8Fy1ZfcdEQGB5NrWhZUEpqfOqRpsIGA2vtgecp4AMoLvzdUR2GbvNpvXTmDPyPC7DQME6nzCL8Y6kjhj9dNihPZ4pykzCiRWefTtzGaTCPtR6P+RVq/n1ZlDSZRqLD3y1pFoLMs03Y0lcW7o9ZJ4LomrbuP9dekk5kpeuqgqSKhPy769p81ajRLlIRJtVjuZV86QuOda8LqLNpiz0aHmLAmbPgbnCe0J4b+mA1oS1TJTaMEvErqlh33vTBRh5E6ZrniyCIoV7uIB2iMG08LEWSK8cWnUK71E2BRBdLfRdo9vbny/XIQFX9Z/fcQSYbXcJSyWLcJbx8IF33JFOM3kbvhdIcJKv/JW+woR2v7y3tRzTgQLYYpMphfh2rd7bdJPInx5Nj/H2YmCT0N4yAQvCu7z/Y/405aXBQT8x6Iw7iS/PoFLIfBY8IM/eBS+DNvcf66lYL89Y3VRO4VYF6e7Q7TjHDS7OHoK6hhroVsvhdDKXJ3cRCG31La+5wOFgDkHOTMHKViuqA+MoP3emzr4ZoiChFF/vIQhRqXnyLyiyWJcDWlxVJFi5L3O2RenEIOldy9m1IqxirFRclArRlXQFYNFsxjxt3WjYBKjM8gz1X6A/r4N7V1MCfwfSVWerhIYLS46WyskuF5abIw5n4G1/GnsrspMdBhatd2qTBQTpokPGzLh+aePmjNLisWjssNSKqVIC39KLqmVInJKod+eBilM3jofHW2Gh8rl1i8p3OK8IhaVZ6Fu6uPkQzVZ8DG6F5ppIyOZC1lMGfpXOnP0HjKwr1ctamLJ8MoUepFdQ2s2f8qnPbmmnrwkzMbZoPyCgYpsrLB5sp/ibsFZRcJSzSE5SosvvGKrFMgae6TE7qQC/wPD2kwe</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="840">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwNzG0sFHAcB3AO3Y7pjnmYxdHkmLhwOE/l9/1zm7actrCFlcgWQ9FExFCq7W6Xp7QehSNNG7pzmsfrJmXJbDKt2sytjqaSSg8S9eLz9sOpL6VC/+Fog7yBikZasFW8RaElxUwYn4zCnjPwW+1Gn8HEUhI8ESByZvoBDhX5WlD02CjbSKghmWQbshee02RJJFuysYZKS7jUkoifQYHYJy9nxhYVbX7IQcX3BRhv19LTPwLURYWiP+IIck/Nk2eVE00ZnZCZbCSdyUgFMmdKC/PF7LoJ8X9NpGtYIqsAV4r1voezYnca2uMOhyYF2meb6dc5JWwdPUntJYdBNgDpTRFFrpaiTe1Neek+9FXViPaKa8yPq0BEoxl2z1ZiqukF9F1KCOarsMulGtGHOWgpEmNspwXs7B2YhygAAp8eCm+oYnnjPeSY30v7l61jxLlB5MyXoNV+GWpXDV3OklBKXDpcHmooqE+CekstPdtRwUa1WsRZhaD8egbe/OBis1XIOuV9MGvuo5l3OsqSSilf1k89gwaUPeChZFEK5Wcegj2scTH4EeVJw9Bup0BrYTirlZzA9gkbDFsMksXaebamNmcrnbZIMA6RY1kuFIdU9G1ymPhlK+B9ugLN0ii1ffRnB4K16N2rJ0GqAL9TLiDkuADV2bVIf0W4n18A/ogOc9n2ODoRQ2EzXQg4OUaWER3MK/YJueQ4gJ85TtwvV5Gq1EO4cQvNgW6Iy3T7f+bjoCaJEleS6DRfzO68r8Fj5RwJbPhMG/6auDwndsPBC/V30zC9+N9MB3W/FMF88him0zLwNsoP/W0lVMcxw7qwkv4B6CkD8Q==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="41" id="sample=1 period=1 cycle=2 experiment=9" defaultArrayLength="199">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="343.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.011561868436" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="22959.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.0776" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="9"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="587.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="587.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="32.699813842773" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2032">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzntUkwUYBnAQRESM5S2NmJNQuSVbGA5vPGODUMnwQiAgbGMbDNzl27cNmejmWESGIQqWGpfIvKEsQDMr7iiIaYhE3IIxslAQxIOJStn31+88533Oed6/jDU2x+1j4Mhd7ro5KBaWgJwIA2IREf8mX14bi8IKVqjXx/FgNG4oWHs9Hua2l9+eDuYj+Mb1JscEPnr0TaEnigSwSXiw8a6tEJeFyTGrZgjhtHryRPduIfxvFg3PjBdCF/qql0VZfjKDyKGcc6ZT7yIUYhuDHfNlohBdtb8NzqoTYmyyeMnOu0LcjLp2PMEihNuQmhdikwjXXldNKeVmcS/9PUYiBtLFvKUJiaCbzj8ethFhbtbNFRxbEXpkbubigyI87c6MHq0XIWGhY7Td22Lc7t7bmFcsBnNO/MnKITF+kBFutD/FWOD2vbiaL8E6ScxCu4MSNHEunH5/QAK6Ay0vl3JNS3k2a1CC530pBkFwEjK3vl0yVZSEuFM7qq30ZBS8tOatX5qMkg5xp68hGZELmAfiv0nGf0Ex9f81JCNkBStviiNF9G/DK3mJUlxa2dfVaJRCaHJb9Y5JCu7YaPSFfiofXtPgMCCFwTnsg1TK/K4BeSE9BakO45wNxSmoXFcz9e/XKSA8b19cGpSKwCNjDvspw2/dUX/FSwX71yjRNOVVl4JIR3Eq6mkX19+3pKK0Ru0sCdqD4jUTC+dhDwQ5+r1D3D2Q36sZ0tnLIJM0XzzGk8GgnZ85N0SGp6OaH37my/DWg6HOcLocn7vUNX8SLMe6EUZQo0iOIGtH+CvKzNJf+ofEcvTlurN9jVRvqVGdSak59118/2k55j/gjC3iK5DPKL/y2KDAZ9PtkR0lCmQ8mhbdqVMg5A2T95Z6BWhh3vQAGyW+2H3L9xpDCfOCG3KGuxLLw1cXFjOVCJ1kPZrmKOFaP2dZ81YlliSV55u2K9HnWbq4p0KJhjNdva6VSlR9dJ/HqFOidW903DHK3sCGvsA2JaLKqjbaWZQIexja42NVYt+Pnvv9bQlUOwrPvk8j4KGwro9gEJh80F/ST3kiJmpmwTIC3A9jm971I2A8pSUimATW3t5nOkPZsilyUbo/gdDr4yuzggk8k3PjbFQEluxUTPkbCVSdm7228wiBJ6Z+tkMeAZPdlfavKSO2TZ18WkJAnXG19ZyZwL+cHRETlGG03bPxikBp9hNdkbsKXkc6n6X6qXB7XunrZREqXFyrLXQWqDAxttV3RK9C+6HKhg6DCsM2gzFZFSpcuSTSsMZV2MlKazTNINH9ITtWaUdi1q6WJF8XEpbaxUf+opFozb43vW4+iYJtP/X7uJM4f9f+aOwqEmeNrhKBHwl7a1wVk0XilvO4/Wo+iX8UaYczKCPavg3epCfRFVXNthhJrPcqvdSSR+KedRcER0ks4AR4PzOT8Lj/0cvaWmq/1ad5dh2Jqwc8xpzuksjO+aPUi3Ki1S9fQXmC7SY9ZCHhmHYtx2mQBLemWa+1ktjMLPe4Rjn0gjf18DH13+h7c/hPSJikZp/LlI5xdl3etmr4PDd67HRRY/ViLWNkmRp2he1PbfzUaOl2Sw/fqsaOuZFLNuSqwbQN42bXqvGoYmHUzA6q71X448xBNRYpH/9tZ1UjxOnCWwGUNTG/TOdT8r65n4sn1F3q9dpDpga7/HQC9nYNVAFNN+9Q0np3rXgooLKH+7J9Sg3YSSc/fVSpwe4s3/bJGg3M+uc/EbUaGOz1PMWvGnC3O8Vq2zQQdm05PAItRpLC/xBytBB5HvvkrEALWy/Op1lmLYzx/pJ6yufLPXT232kRxveo1ldqcev8hgC6Sxp8JeneowNpSC3zPJ5oSQP3cFAuWbEXE9tfFh2ipyPfFPCPuTgdd8wZVcOU7Dd8LDKaDjNYU06cVTqUfS+VbSnW4VRbSElPrQ5fGJp5ie4Z0K55ceByfwa6zcY3N45nYEvmUGCe/36wXvc/Wj62H2A6s+ctPojmWZsO+L04iFlpgb8XOBlxo+Rq2ecpRvwPz+7Fqw==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1036">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwWlME2YABmBrCEcpPTTjUJAoUdDppIqbR6Xv+7ViFYEgElQOl0kUpAoLYTJ/ILSSxougbApBgtXidGgsgkDQBTcNUyBxFW/bgCIOBSPTDRnU43lGB57g++AyUer3FPqAfm348H6dwb+IfQ//03KXgfNGtFTfPMeUunFm2kwIrJvMf+pMMI1fR1GjCZZxuXjxyYyvUjsw5r6oe9u3j38krcZd2xwmf+nJgSqZSHhppY+vFN3PpPSrD2FMYS2d2iWiOkTPxviHUG8uE85bKlzpVFH+lwqhljQOhf9Ey9E+xEvM7Oj358ewlTxy5lfWFmv5uOs8JWNBcKUpxXxZNRLPpooG+XQe7JqOM9V66h1tfD6jFjsHY+g0+PL1wlDmHg5l+b1D7CldywKfd0hRncLiq6288srG+cM2BC6fDSzRcLM9nK2yCjYEuPHNlAgkGX+jIbmCY+1nkags5sR3lWJ7Xj1Pxh2j9H4xm5JL6LJliTcRC5B/dyOP91xAUk60aGnexBXBHkSIBy+8iNQV5keixBUjzIFq3g9TY2hDKZe5/uWgh1l3KecSYnIXocrbk/mZJ6iTe3Lb3l6YpzUiUhnFtq1RmJU5VwTZmzC2LE0Yf/diXNxlKCe8WNjfjJkNPqx80ALzFinTaw7AaF0srk0UsfdDFt2T5omg/2VUju/g63A/PlqpQcYaDTtbcii7rYGx9jDdTg0c6+Vs220S3TfkxM5oFngreFqqYKdBSw+7grePtcP/ZTv4PJcpIwpGRYEnvwY+rsujTAsOVWxk6gFwabZSrKpR0tFWIn6YquKNwnMMbjzCyz/quEviJaztevScXyqSGlq5evkcob8+lVLrKPeKXvq+3cKj8T9TYf6C+po/Ue+4if7YCZb53kJ28hokLLQz1lLJpm9jMfKuCxGTpvGgZDtdKXF4k17MDQODLBiIFlW/rGdzwg7RLbXQWB/GT5newh2Qhoy82VRH7xGP32fg2qsyRpz+G0HDC2gdzYI9u4KJ5U7ORQnv7JGIiw4TPwMI5kwD</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="42" id="sample=1 period=1 cycle=2 experiment=10" defaultArrayLength="138">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="220.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="15536.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.079283333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="10"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="612.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="612.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="34.262756347656" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1432">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx3sw1AkAB3DP8roLw8U0BlsjulzrFafLfl1L5oYu7+S5y+5ay97vt7t2LZcW5ZHLK3FlznqcmbgklJM8dhSaGK9LbhJW50jn3M3RFJL7/fWZT4FWk53FqSD8KbaLrek7h3zFtEaFznn4tg56hzAikTKf5O54OQbd1b5hpwdiEGN5Isr+YBwU25tnO7+OA8+hyHSimgVLvxXeNzUsLHCiHay02Djd3ht1PZ6Nibwc9QslGz93RucFqNlY55mnuGnEQ+UTqHvSJh4Jdwake5Xx0OLMuKrm4pEfshS2XzMBY/82k7eUHAR40LqvzHNAn7rZ2fsHB1HRSZbxixyUhz/079Lm4rzfVqbXBS6MG1P3byu4+CTTTJ44z4VsZ9bnKWVXrMYDCzUXc9dq34LGQ9/z6q3dUzx0T4Qmh9Unwu3R1LaXKhFGQSaZ1pf4IDLC3Q/181G9POD1bI6PBt8y4TM1H2MDx3W6F/j4O4g1FKFMQoJNbugkUwD6WtDoWoIAogxOl3a2AAuhonuP6wQoLG3eHu4R4IfakdRN62Rk5BrsmWck4/5L1t1PmckQWQ0Jm3RSMJtVrJ/NTMHy8ICmbVYKRjfWOw7VpeBYopmvobYQG9ZFrk46QohDEnONsoUoHq+0ZFOePcorp18WYmFFnmGj+x1KRjIO5FHaBHe2FWsSMDX/6GVpS0DyU30bh0bgxrXbJglBBH7JmWXdoXyQVrvpwSaQbdxVqaCsmuOxDcsIjBaqUUW5YcqcbGkl4EK03t6l5HWwfSxUBK7TOm4GU8qZzvZrEwSUUzvS2XkCeFK6x0FNQPPLF2l0TRLKL0SbHMpmb39msA2Ju86PDf1cSNwfrLNbZ5A4suYZ2wwSjEo9P5dAEsel1hEH4kh4EXnjyZTlf/1qXaUg8ftKjdFQCYngwKAhq1ISje8iVVcpeaaW0rYW6gv5H/VNRCC3amtuOYvwfUaPk75CBFXo7Zc0pQiDWSy9hHUR+mtbgldtxViyGBusvijGiT2R2USZGOa7TawbfdTTpi95T4ixXu55pVMthpmAa++4T4IHVZ0nBYES6Dpr2f/YJ8HCRl2Zm0qC6KtvWkIeSdBAF35bRFnR+PaV57gEnMKOLo/fJHCrSG8dVEtQvvqwq+CVBE3jwiy9dQnCjeWriwGpcHXcMWhgpSJiSm38uj4V9HNqjpaTFBeZ9iXplEdCjukf9JZCZ5QkGO1S7JsJNKwfl0JStJSmQZPB0Wzjn0mGDN1cPQ3dHBmeuvey68tkkPI+jqxQBnifkT1plYF/dNzgDWW2wbEP/RMyLL5vb2/bleHwVwEXjLXTcNh/OqqwNQ35n927WLxPjijCZS9K5Kg2MmQsK+Uw6vlgG6hMx/OZq7RhSv65LFeX/nS8Mw4tGCzJhEPJ68/fzytw5j/H9EaTHPwPAoLwnQ==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="744">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwWlI03EcB2CPZk4yJ6tUJCG1/e3ESnoRyL6fn0uaeWQqTvdiznReYcsgUYLZpIvBwrIiM3FguIittqmLNJahJmlDHUmNaJmWJjidiJGa9TxPpT9JVztJkRWEDU8y6703x0LjF8X6+RUKNkbhvE8M1+o/sbRikD2ZSWO+2x+wsE2ZcjRKhL9nrmFW956037fS9cZ0bOkPpbEmPRmiJUz4qA4hGWtU8ElGupUpHH5eCO1IE9lHm6DwynGfL4QnLhmfr0yT9VUORntaqChpF/N/XA5Z+xyZpbuRtj6Ei7kX0DaxSGFKNZ5NLpFCs0wTvFhyhcdS8fEOqtvkMflaJtp9e2mHH0epgZ30RpGAX0UJMJYbiT+8Dz7TJrnqDqIyzkTF+00UcMAMvSEAVzVmsn8LYH1LYqZsD8Rg/AuqEiXSeFg2EzUMQe9MxOsIC0mjLGTL5eFOHg9JP2JSvG2dODumgDU9CA9VNnLYjlFJt4008i7KcivR+0UJrjaSaTK6Kab6Fn4v8HFjuAze4BMkeFAJSU8VDLVWCMqqYW52EM074OQE8C0bYZmtgXz7NAsqHqAOtYQK84R4aRogd68EU31CzL69i5nsk/DbSAUne0d/dKcgS+WxpYjTqFGM4Jwqgw6pWzChjUbz1yxIQrLRut5K4Zwdl7lGHHGPU2lDI7jSGBRQDvJ1WuYcy6c99XFwl9xEl6qV6T+KYPD3kHO1GYmX6knbv5P9B6YQ7ts=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="43" id="sample=1 period=1 cycle=2 experiment=11" defaultArrayLength="157">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="286.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="274.016408683336" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="16997.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.080966666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="11"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="637.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="637.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="35.825664520264" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1620">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzX0w1AkAxvFVuK7USnSU29xKcS7ltaZTnpS3pMM4vayXtZaItb/f7to31K7lnCu9eKsjbUurk4QiTXRLKDQo9HLXdXWF0ShyXk7p5X5/fWa+M888XtOLwiSGuzC636JRo78fW6/bwtaDBb4oKtUhMwIFh1YN7fkpAv5LBt0F7RFYflEbwLJmg1HUfIQWyYY8xW+45mwUuobczab0ODCcFrzzY3LA+uC56VQ0B2l/tD/oUHPQ3PmtKvQ5B3ZfDU8RtGgc4qcF0KyiIb0QMeRNKamKZzfSuFgXoBSb6XGRYNjD7KZc46+Ou6zkwufRwORdDRe9snmPi9UxeGn/wc/kXAwC/Vojml7GIOq6a/t7RSzKvrjEClXG4oHX5dFMyjEb+6rIZ7H4qL/9hRPzALpeHbePUcTBa+q/q+KyOGxUmXvYhcdjKFHVX0lp6WJk+lEVj8Kqpw2sjHjYHyyPeHgmHpc69bsHNQdhdtn3gWZHAlbeJLcYeSUgyiHMs42bgKW36+oLWhNw+zHh4xHDg6XbJusGJQ87T89WzsxPAsMbxUHMJIQcdl6/MCYJT8f7bX3Sk/DJqbaQ1k515w8pdAM+MkuuOc5u5WPxvYLHQwo+aNGWtDVKPkIX/pkRSXnBJlU9c44P36zGsdfNfFQsqjDdPo/A0hXc8o5VBNJ//ia80oqASeCbuc1MAiHqBZ7HKd+6qUd6KTkKTonrNgLvVb+xeMEE8s/fEZyjdJVn3RRyCHSateZHKgh8aTAq/3ySQH3oL3875xKwDTxh4lVK/cRVXb1XS0BW3r3TppnAGbJs3HycwIqdyXN3KHOmeNYsPRJhdpFifysSCmfugNd6ErLimwEbN5DgLatwl1HqdMEt+5xJnJ7QaINBQutUXJTqScJ35dq8Pkq7hKNkcCCJ2b6cQXc2iW0+PS+yFCRWSHja6JPU/uyBa2pKp9/rS2YoTTPzrXM1JPRMtDc0OhJBxcnchbdIdAe92VJE2UIeu+gwQcKeDFIZfCbByHrJmTQRwOTZZ5sWJwGyp8NdFucJoDCXn+/oFeDpMlH2/ucCLK6pbzSaEMBCznOJnBTA9uuJcdCFcE2bHXFiCpHiLZrKdRDixrSHR6qjEE68gLuJh4XYy6BffKUToiH/x6bE+0LsltmN/zAhhDHDouQaZcD1Mi2bLkKlbK2c4yhCTVvGlT27RbjSrx5+lCtCyP0KRrNOhFNhdcYrW0UYMvn39T5KWlxR340+EUZs69eueiHCX8cadOcpi3v1j1WPifBr5UhshjAZXcNTBsxnyWix6D5qlCfG996dqyvKxAjhFWoLrojB1nfzd6FLkLLOrW++lQTby3gZ2bkSmNeN9DPyJGAMhDallUrQcMq3cEOZBLtHhybrl0hx4uN3h5lKKRbQu8SaXCkIa22nslaK/trnFXtapJitZiU2Ua7Pqfwnp0eKtl32Hcr7UlRFd85kT0ixujQjNstRhvkD+ZamJ2TY+yScXqqWwaMn5eoI5Q7228qH1TIYvlONmdXI0HDB90ixTgbze/HD5d0y+IXNzL0yliO+rrxhbpkcrXRBeoSjHJut2wZt1HIMf/o0qaJ0W256i/02FU+qo6eM2Wn4H4iZPE8=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="828">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwX0s1AEcB+DOWWRnd2mMKC8rMq+daLbbfD+/I0kmdKzLkpuFjZzdrFdXLO4yf6B2ztp52znmjBbaNVqJdba7zXFK1rquMueyLr0sVkzPw9//MyVi9X1K0tYChr68ZC58eEhxFxPgXP+dcux6G8o2XpBDOsu4W+qop2IR5motXVIFCUtdBdjObiD/Ph3CizvgtdaDcLEnLfHmKPJaE7FvdKHolTdNl4gZ31yGadfwKLqTR3NsLbo7fUi24keVW5+pOWOVuMoOyP8FkHnCCme5gyJzNCSzrkBSUId4aTqsxtN4faqPJlRHcdctAqyCCDJxB+Bq2aZB7Q5xZU7Yd8+jOCCKWmsJ5YF6UkujEGbUU0dtNInesDAVEsNk3WtHtZ2Fmk8sVM7FkHBjGrLoYVo7N4Pd4Dg4NWyMd7KxbB2BJbYQe6ofQ116nDzVRvQl25ArGRM2POWTX0kQLJNPyGDiIyezEc/zGsER7QVHkkAVY6P0Y2cTkgYF2r3jmF6FB7x1Jvh3JZL6shmZw+P0/VESjcv06KjZh0zXfSjMyVQr4IB/k4M0QzPOhObBkCigEw8EOGQRQGqbpKoWHVaVS2j51g+lTopIBVGY3xQpnk1R7GgrQgd8YC5KpaGqVHorTSWTowZ5bmnoc0/DQdcBXNEbaV6TQfWLZ7EQnIVbXAdUwkDmyO1AxGfPY2uhHl6z6/ilnqdB1WEElIlwNb0bf30LhYKPIWiyd1OcIR9/ZvIhyV4iu+Qd0eYy0ttYjNdJLqOQi0l9R4x1nhYimxIecjmzE16Ild5CFFt1GFkMB/urg2z9TvoPuCsPRg==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="44" id="sample=1 period=1 cycle=2 experiment=12" defaultArrayLength="176">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="383.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="24192.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.08265" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="12"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="662.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="662.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="37.388542175293" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1792">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwN0ns0VAkAx3HDZM9WS4rDbnVo9ohNXqPUsmt+JLSVY/LI44zG9RqP4d65mIfsGI8ja9sau+1uKURJesjsVohUotpTkVSoDYMlLY1Us1qbvX99zvf8/v2FBOep+goCMb78iZK9ZRci1I7XtvCiUOro55WqjMLE+HqRR2E0lGXnrfp9hDAZaPhUFy3EjLYxL2GPEIH5MxXny2PQ5mHRsMAiENp+22+vIQF7t+11SzgE5GbTmpBoAi1j8hFXgsBzw+roslgCol83h66JI/Dhsq5uTQGBQ1N+0s4KAq6+uy3dKwncdL8Vzx8iUGLSGxFiEIuzjY4lZxhDA1WicJtYlF/RBrczNnlZd5ix4jBTJrtfjzgEzh4+qmMU+Mx1tHLi4eC1hnWhIh6eURpO80g8dOncM0vYCajzNfpjLjcB21V9k8mDCfjmHenca5AIo9GBlijrRFTvu//Dh/JEpN0y1JjnitD+dwy9slqEYLqlJc87CSeLH+xIFyTBufzegXeqJHydfSeIX5CEVW7/BYzmJaPEw0/Dq0qG90uDq9/6puBsZHiFlvH7lqYluVUpsH1Z+UpcnYLZQcHT5tYUiPfnxEzeSMGT7i9IL5tUvNOTSxN4qdikqtFmssVY0KlrEn3FCEid8NLEiZHaGTE6EZcGXr4k2z0vDdb7e5smb6ahkSA7X7DT4fE2IPAjVTq8nTRP1NfT8V3l4t27bUh8G+Do8oRR0GKwV7WLxJS/864igsRVdnuHTk0ivyXpmHMpiZHiqlrWBRKnnwulSkZpusDH5RqJiN22PfouEmMrLGtcukksvj0+8dcgiYuDDeLPhkis3zcyNjpNYrhjfS2fRYFcJwpOMaNw8cdDMUE2FBJqlxay1lAo2bjartCFglF1lVbDpcCu6a+3dKMwGUK/TGbc0bNTOM2j4BZ/qU8GCtp5nxiVD4Um1tVZKyGF/fRXs28ZYzJ+19jlUjD/bfhkBuOZhTfk2EEKauPSe4fVFD63emY/wfgwZIAlqKQQVOz6SnqcQk27nchDQ8GB4ucvWqCw67KHVZeTBH2RDk3VXAlW1LtEnoIEP8kL7LRCCXpmUs8KCAns9VK/R0oJTg1b/BJUJcHD4Ia5fkMaOs+5VW9saAhmT9at5NAoarTnFnFpDPO38gqDaOxc23H9bjQN/8UDynghDTuRoLOT8Vwd7wShpGF0fnvVCUbnajPqXB7TdFaPfymNg5lHEhuP01jIiS5OfEAzPzLlpWppbFxtmuA5Q8NiB2c+/zWzR16rqiUz4PbzZqeytgxEcvsDWO2ZsJ/9V2DrmoXHW2iTWkZb/wMH3LyzYDP3fnAqKAtlR/VrK/lZ8Li79WyrMAuxSnHXxzFZaJGzTxoPSdGX+qetgU4KofkGfeuCFPOXVZYNJjLUemz8h2Mqw9oB8cZxaxk4t5+VPHSV4WlgfOiXXBmIY+Fhy2NlWNfK7TGLk0GxoG/ObpDhik4UUnRdhvdhE6NJr2VoO77a2MdEjqpl0wU1pnJIbvWGj1rL0SrkFc8TcvQGD2W6x8rRLHbXcw7KEbJnWt9VIUcSH3SAkwLdO8P0nhUKzPkUXTrHOBVmDqtKBUoNAzjiegUMiMfbnDQKJG4LU2cyktI7PQ5tChwRa9u4gwrsy1cQIkZ9wzQ/Z1k28npquY8Y1S5pRqZm2djw5oXVXfNsPHC0cLrM2wv1B0WF5XQOSKI5JYSxratCL2eszV9kfIqx24K4Zf4qB4eCqz8JK1DimGfiUelgLjaxT1vdZxQW3BhztFKhzFriNSRR4X9R64NB</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="924">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwNw3ksFnAcB+DGS0Kkg5fkjRDT68rxOt/v5/fmyLHKfeTtbW/UwtpoKTWZKSG9rVll5FySoyKWm3JTrfQyL2llc0Q1Ravoj3q2R1Z4iXJdBRTYe5755VkiOWaj6K20mSYnwjFXf44+r9zBfE0ny2gqI2srKSL+9NAjyR7U37JiitYMit2nTNLQPmqSKRO/WS6yy1nAvZ3mGDMzYCNBKiRsE7Ihm2yyLE6Hu5kmZdnV40NjIjNQk+GYLJOV8jis1WErRYjSYfTMH1FF7kh2qYa/piqa/Obo9s8CyiyqwLT9AVxcj0fYmjfkNiVULllGB9tNfQ2+mPmyTAM7/JDCMSHJ8CcsZ7XA1es+qWhXYTJkG5O5dWJNaxVKKhrs42ANRfL4yO5/gXPfRcgLUWP8o1Pkk/aYThTwWL6RLfhhviKDXltEl8owpmdHtaMcXIurp5cCMQLyr5B+zprIO6GBdLcPQairCjosx0hQCBs5qIpp7f04bfAUz0slMB++SvzIRmqJaqQEL39kVHixykYH0u/KogyOI1KiHFF8tgaX5c5YPFWLYmsBrbwR4OSEgNx1NPCa60pJv93g9yQe0c4FqKvejOMpHZhp98Cg41fc7O+g+R+JuBDjSb4JnjBW12Z1ykKMLQoR6NFNZdItUMsl4i0wqJWUMyXDIapMmGRD3BFqu2vFVh74M9NuLsZWuFCscrHgrs6O2BkhINYInHU9VqXqAq2uYPJU5yFPg4dNs3LSeMxD1Ct70ei8lFkGh1PQRBlm3xvjkI4Jpp0U9M05kp78UpD+30yWbnGeGd7wEcW2O7DQZDEeZqdivFMMbreY/qyK0V24F3HXe5Dn4sSsnCzw+/+BCAlNG8fSuiKeLGoyUTq1RCHv42H6YQmK3ncYP7OGDUmpaM3dxTxq0+gfrTIitA==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="45" id="sample=1 period=1 cycle=2 experiment=13" defaultArrayLength="147">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="256.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="15532.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.084333333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="13"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="687.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="687.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="38.951393127441" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1516">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx3sw1AkAB/BYEnlVanKV10h31yiPNmLwtWnKo4Tq8try82or/H6/XfbFeCtSHlnNFetVuHIbpkOl2FR7o5ytmOGSV+fiTFnMlelG7vfXZz73mnOavnKCsVv9mb3WOwQLv07wXbzC4cJ7czMB4YgrNEo16goHDkT2snO5KLUtDPyYx8XnD/ZT2qdOI0flmPtUHoU+foHnGm0CCh2LPW+tCTyyZb/+yYZAlszEy45LQD1y2P5yNIEjl+e89sYQkB3MWLxeRaDgU9y6wHEC7YrFCcdV0ZjUXdnsZhWNhDqLad8x5npBhKlWDFb7mtTWVcUiMqZ6ZoqxwzDKu/19LARXG3q+ZcThocewqTgzDgmnjOdH2uLAU0u6xWNx6HnUmp9tGY/OC3ccpuXxyNS4KYPrzkDKLTr7YyQP048UX2xzePCpmHa7wfjCTzDUdpOHLSf5mwZGefh+qGDRa4KHvJg+QZPPOXT8aVd4zus86u2KKsJ1EjB7sdAhyScB10xHTgww2j3oGDymk4jQ3IePDWMTIXRVTro+S0TtlP5o57dE1EenSK10k8DpSX5+468kbOTcMr5rRSLEQNZy35rEp3MR2vqBJErEKx8Sg0ncyX4XpWB0fMc5bk6Q8Ju9JQljbJzcfKu3iMQ1w0rWwVISsQGxxIY6EktPC8yfKUhwatdZ6DeTkN8LHLDsJjGiqwpvYNyYLvI3UpN4kre168xrEmnDjc2G4yR6VkIXjlpRMD1RmdbvRMGbFSMycqZgU9YeH8BYHlYh1gKFrb8Vb43nULB+Xym7wmhp2iv4h3FhP9eJ3E9BNbhPLgqmoOxU/xyRQSHfwGz0RTEFTW2DXXg1hZAk3ai6Ggp0R83EwScULnGuVMyspzGY0vZK7kSj22PFhc2hIS3bm9V3lEb6Wtmxt6dpLJY/N5pJp/E0v+j4ZDMNd7t5eWgLjZH8NAsF437rXrl2K40YV01YrZJG5az5kS1zNBqkDa7UIo3MDasvtjBmvdGo2Ss0HC1LmzTr+ehvSjPRs+HD99JwsC/jPOtwj4qRWt5FbHbio/ECa91QFB8mflPyVaWMtyMUEsa1w2cVrhN8zJyp39k1z8dHg/JM/wU+9GYV/XOMfgYezkEmAuQ1etoMZArgmePory4RIIhUVf1SLcAH3OiXtQpgaHDqu5ouAbQiHus49AjAHmJJ15gmw2vNvy98jiZjJnvbt6TgZPxQuPq//CjmXE2qsCQZLwMnB4Tjydjdxt5p4Z2CLI3KfFdQClQnlakld1NgfLtw+yijuXPfy84/hDgQWiZkjQvRtc1z2/UQEZZ+38sVtohQvD1gX4BShPfWO402jYpwyFbbW2YihnZHpLO9gxg7ClwcrlaJ4SGofrXMuPS8m+VbLYZZWOL9ZXsJ/nZ3b0zYI8GDwbYv56skqI2Vuu1plaChsy+dfiWBlptF3hzjkaILX4kJCRT1LJ2xVimcZlZs9FipMLu0XFpUnQHlhq7QmrEM7NgY3940nIn/AQ0bEeE=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="780">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwWlIE3AYB2DcUCda4bEtyRaG5lW6XDO3NX1//ylYoYU6s0LFyqRDKOzQCHWsNJPRB3OoHUsRzbFNOzQ8KrF9UCdmB22ZYMcw3caqLyZk1PMclqeSN15JAhbN8twZ2HfQSMZJL8va6U1/zZEh3VOL24/G2OUZH0hnNdTW4STDDw8GNlrpWn4mYgTtqo9eO74euI9CZwNVin4joNoA/tGTmN46w6ZcDpg9Doq9I4XVdwU5Xz7RGW8fpud0OKuuR8haOPGUO5Bb3E7m5iVEhG2ChKdkm7vfQyuNIrUrivZvy0Evt4c+CNeI7UnDwGAcqW6FoSnGRE6HD+5phOzv/CsEanV4vj2RPDUWHPnMgaSFixADFwZ7EpXyxbQhop88NMmMlWLqs4oR+qafxouLoL8hUC1PJFPC1GOqtyVjJegJ8hZK4Lvcg1NqP2CLhBIrJLCo/GG37KLatGMIsPqj2yQlQXgZ/rke4GJKKvzqUtF19yYlVQxBUzpM747LUV0mJ1G5HL+eDtOCXgGlSYF6swLnFxX4KV2H3EkxCxpyg6cfpbBeHaZsSnCfvSD1UBoGk2LZ+tZCrDYSgnVjZOeD3DIV1XWFQP/yAi5FZpDIPY/A/FBkzWWSc6ADouwWWDR8tKVkIaJrL0YaWvH2oY1G1dkkPJRNQVVaXC0XsqqOfDQ4r2OipoCK/hTg+6ydgoscdFo2R5wyHhtpnYZrvhGL2mgYO8eh3t2ESJQgTlVCzZ0x+BYfD1nCCVpqXyXTuSvEt9XRf2tN9Fo=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="46" id="sample=1 period=1 cycle=2 experiment=14" defaultArrayLength="127">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="191.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="13970.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.086016666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="14"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="712.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="712.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="40.514221191406" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1332">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyXtQ0wUAB3BeIYIy0vIgHm4IgbBdCKmJFd8p5xAPLpqlkQ22wcYGst/2+wFuEG488jCO92NIbTAoRa8ULGJXwBJETjGIN2o8JOAgw+NxpUdKv78+f3yifLurToR9iiWb1ouB+QJELo6VCb8QIMEY8rP2tgA5rCVfr7h4zNpuHbppEMKNsTXy7qQQy+1v2vxjLUKthX/1dW8RuLLzd5rFIrww64d7jCI8iiimPpgWYddcdc1RKzFiKjr+CmeKkTjw7pAkToyhS7tbB4Vi5JNWPxiMYqyrP4m9Y5WAl8+NI5XGRFTEWxWs0v4tn1uImkpEUWX5WsdsIhgu+6tO/JmIjjiuxMFOgonfMl7bp5Og+Vcu7+SUBEeHt/myjVK81WKusdMmITmajDjWkASvBG0/9zMZ0sUeBv88GWp3ruVdoHW4WGVxNsmxV/wkx+6WHBbXyOeGsGRc2AwMNYcnw76A17NBO5oVUubDTEHVvawqypACno+KLws/iw3HzFx73VkM6PZfs7NLhYzDO6RPSEVLzQIbryjwDXf+/mOtAtye9uvJOgWu7PE3pdcr4HyD3dhgUSBGcyr/oDeB8sqv2YvRBPzCmiIzPyRgeNSoiRURkAaECh+WEvjX8xDHsYxAk9wkb6snMOlvcn3QTGAspXPY2UJg0P9wn4A2gf2eY+Akga5UE//GUwLZXteOM6yVaDzMORbNVGJnsWiXKkiJpL6m/NvBSgwUl1/KOqJEyAu/EQOt/tyz8epSJWRR8tFeWkZBtKHkuhIco6DqyYoS0+tcBcFUwel0u0ztrYLLj4HmhmAVkgSKiMEYFbLithUuxqvAWm+66qRVoV1afYXSqcCz9WE5ranwUWq3steFROBIa6+HN4kSqdJNd57EPj7jgVpLIjfz1EZnJwmWg05aNECiOUfue+B3EtUnY1so2pJUV/2WFRIF9aVeBask/CTffjxO+7576FCWDYXiM0EShx0Uaif7vixlUiBTKmwZfAru8W2NtSoK9qMBvuZ6Cpo5t/uFnRRmHJNsl2jzgsymjVsUjDvGRLsfU/Bxbrg3SytkTlgsy/S/4cwIW6WgD9ru2S1KQ93T/nX3zjRMzXnYh3elQZ3Lj/JlpYPTzXRzu5kOUeHdkp/KMpAd0Lj2fX0G+FZtX9k1ZyBdoJcFTmegfH7BM4r27S4TO7f5HLjnN22LjGq87D1IWmj3Ns1gS50al1NynCwuGrTPuAbPczT4rr3rQPQRDY6zV3LfidagzvrhBNuowR9O/72q39RAyHrGGV/+HNLTubztVDbUZ5SX5WNa/DLdz1NPaTG+J5UYov0fEifFTg==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="684">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwNw21Ik2EYBtAUbGo4o1mBH9GqhbBoiTAZq3VfTw6nOMs/JbNZGoEo06IyCizccpIjC7PRwDE2dRtrbhY6ixnZSxphsqa5hFhg4ZaWkQ2y/NHHgfP3qR3WcxzbK2mi1Zat4DerkJ2wkbr8OT1rcLKkUY7UT5KRI+tFxo+qIyWd9YgfS0H5PiNlHS2lX2kddOJ+E/Tjt8CuR6Fzt6PvTpBds3eRLzUTafOTaP/8FXn5PZj8ZEbX2kdyGy0UHDNivJVwef0LrfjzyDD0jSIqExRlm9iYx077s/pIzdVhqmeAlm5chYPvJof3D3ysERtzxLhdcRx71GY4L1TB263HoNhHgZ0a5FoNaGv1U8sbCfWLDtCDu3FUNw5gjl+AmgktzBMPqcLmZ07BKyRcy+BlF1J44RRCj4Zp3ciD9TcPAZsU06YiWrtXhPfxUfpwJh0F4cc4rZPh/EUZyT1yKA8dpEB/G6ZOKnCzVkELDheiscPkjb1DeMWFt3WbITQRZv3fSZiYx9Iu4HX9/xqOGlY5Eka3IDYjZoVXLmF7czGlcgIWSlGiZlELcvxErfYlJaWXIjG3DZLpMho5q8ZyWA9ldyXJImGyuAyQumbIF1GxSpkGTJrJzN7dSBaIIO3cwQb9IpTkRikjOMw8G/IRWhwiS1xHL5xyOGblKO7oxT+VtN91</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="47" id="sample=1 period=1 cycle=2 experiment=15" defaultArrayLength="132">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="460.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="16382.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.0877" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="15"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="737.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="737.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="42.077026367188" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1384">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyHs01QcAB3AuokZkXsejvDOi6Fg1M9/rkQ4dB/O4Xrfr5/24j5/LfeEUhUpxrbgeW54Zad7ScDw6bdOshB3KKy7L2rIdZkUe2/3rc85H2FNoqefmj7N0TyVXlzA0WimTp3Lo+Fe1qIz5Ax0hEoMMVzMG6h8++UM4wIAq8k92LjCgtbta2XwnEvkrH0vpVZGQXgnLoFAIPD/muGVjSmBFLrQ8gU4gU7NEQZUg4FctrrsVRUDB56ZkuZKAeS5v3XuBgLfRsCZNLgoFLyjL9sZRcC/YWrSQj4aznL4ejRqNkE23j+TNYvDf9yEum5UxCKS4rjYsxeDTudhhpeUYTC87Lo4rxMIgb+YXraxYBHUvnA56FYu8AP/78pVxUN/ZN9sljUORdZnSodp4dIo/Z9tHJKBBrL+RcCUBNzu+Sx6ZT0Aeqzauzz0JrnPz5aPRSfhz+2VxX00S/B/PRmr3J8GoldOd55aM26tx1C1FJnwaz1cMuDNxfLFT3iSLCfO9xFVvRRbyEvMTN6JZCC5+a/tFNgvmOpcl1jksCGb0Bt89ZqE/fo9hq8RG+NDmUb4cB+5idguFwoGX023K9hEOrudoSb425sC0X7FZi+CAy+rUZco81Z2IuSIO1B31ib0WDrQdxnc/aeVg6bKaid0gBzGZ08mxMr2kZLaRPIn64nq/IplVN8QXLxiTEL05p3b8JIlH+8o4UTK7VgybJK4kRgPYLLiRENCOWLB9SbBNDHYKxSTyhmlO72WOpDcGNheRCDc72j8u0yKONttWTcLEYCL4XCuJ10zlTqldCihXD4c2OaTgjLBvMvBSCuQuTPk/GEvBRk1s3QcNLjpP0KcsTbnwM5yK3GJwsc21ap0c4OLu65X+02NcdBSGEuVSLqJenf9ArHNRZisYdDJJxQ2PfyquEanoCO+e0ZhIhYavWb6/NBVLB34d91hPhe0zWsdFmb3+8WZ9e6nQUSsdsfNNw4u5b0ucGGmY2Ox5uJCVhlXis1av2jRQ3/wY0dOeBp153d9UBtIwpiLeVbbnYUaSVX2MyoM128XZ9zIPgwOaBU3tPHj6BhuTQzwQh63udT3jwSbYx0RFnY+f7vwdWm/Kx9KtiK39DnwoJRU572Tz4WAjDUxo4+Pu/ZeGcqN8hIemrGkt8PF8OTd57qAAg2GTbQ1fCpA1F67ryRAgZ33EoPcrAfY/qsi62iaA5fXdRPV2AR64ylOL1YXYSnec8hALUVpfrvyNzPSgM/qllUI4vWeML7fIfv1nu6dPhWBpKxpVrAnRW9V0wPOQCDGNTHsvOxF0c+suWVSKoBHw5F68TPeIiYJpmdeMdg7ajIng5iw6QVsToepdye/97Ay89TSmZvyVCZpPDWdI5v+S19hf</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="712">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwVtIE2AYBuDIrRE1sMNsZkWRbUZrKx3YafN7f9fBMFbDoG3EFDInQmma5KQxpdTldGpYLL3YLEdYSy9Sh7tZFi22hLIhHlpGDYtMISM2pVjPs+f0HL0b3Mri75fY62oB7pe1w1JXQ5enfdT9S4aSWIK0xl52Y99X0sSqICncjeGjaSzY9xTRPxyVRFyDfq+OlX93gRMao4RMhpWeMOWO72chZyuGmyeI+0qO3vYMlvSwDhUmA1LVW1DdkIoD+gherO8ibmARHeYsNB2ywVlVj1JhJSE7nfJF65jTEKe2JDFNC76hofAxTV1XgIR7kWXVsvlKCQ39vAebfxTK0gv4YJZSn+UZOfR6/N5xAq0CDnw9/9B46QGMBVxoj3wivsbB/MFMVOSMMMfwNkTyqhG3rkHAI8dQ/3MSzRaB38jDE+4gGf7y8CWcjdjCWliDJZjj+OjtmTLIr/BZU0ABae1VmBZ2MZc0GbY7hETyBvgfMYh9KmRe4zHfyibUqI/TiGgz7De7WMe5AB1cDFCu9Q05ulOQF0hB7VkhYAhhY0s+Pl9cxdrcY9TisWA1R42EXk0D3jQcc9djuWg7JnQaUrrHqTPjFmZcBZiYDJPl5E40Rm/jrsdJ9tASVPEp8i5rqfOwDj/MOipXpsOusKI97SO9jFhR5xpFcdhNk2RCLGeWjDPNOB8txqnoACSRefwH9WrlkQ==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="48" id="sample=1 period=1 cycle=2 experiment=16" defaultArrayLength="100">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="237.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="12130.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.0894" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="16"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="762.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="762.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="43.639808654785" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1068">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyntQywEAB/CWdeTtlMeJtaZkquvB4Uq+reZuJTo5V9Ye1lZ6rP1+vzVbpTTKo3QU5zzS8pNKLpQLCQtxRDGPpa6Xt6Q8j9Icv78+/3wUebfbA1aLcaUtoGpZvhT5LTPKyu9KwdXX1/6SynF0cF5wQ9kW7B7eVuFor4BQ2hO1hzHAq0jcxlUA5MYco1SBWg/WgvJ4BVQh7IhWkwJXxw7z1/cr8K7HUya0i4dRsGjJPNd4VHq28nvslBDnDpQt5qkQ6cJPVJpU2Czc7n+fkbfrs4ukT4WZugn1HW9UcApfKLSOS0Dbg/4iN3YCTD+X3VT3JYDydq5cykkELZ7t0NCbCFXQyFSuJAnLJXbdTWVJqIk7ET31VRJS8mOifOlk+MTYez0OS8Hk735fRK6pmDbHN+Z5aCqqPQ6UitlqDNO72/PD1DB26iLfMX7x1soLzWoMvF1fSgvSYDEr2/8q07D6GKVLaEmDzMs/l+egweQGe77eXYM8912hZ+5ocLSZHct7o0GiLHn7KIuAVT93qJNDoPHr2hivEAIRqS5BezYQGChorB9hHNvLPRCsYF5X9uiKEgJBgf86ey8QuLd5xfLGOgIt4eeKVzYT+KR2vreXsZitSpM8IRBVuyEuiUWiiT9kDHMlEaQ62LXNl4RoZ2k0Akhk+AVWKRkdWMJr2QIS+yY69T48SCJHxxo+Ukyi+bSbVXCKhKnid/z8ehKhx3s53NsktH9OlVf7U2hMGbb+llPo6iG/fd9BYUwSPn9VLoXxRifnF8UUBpU7eLYSCjfUtg++NIWPeZxL7hYKpuZJnOwfFIoujz06ZK+Fz5pBw8lxWiQ7OT7humkRMtKwUm7R4sKmWREd/VqI9j02FpjTkUHnTHnxNB0GW2CN9+t0bB1ky7LkOjQdDr7VdFoHM7fgU1eJHrbY2XH7y/Ww9rWau2k95tgGXnZc1MND0/ooSmDAmmcVNaI6A7pNMvoW469oy/QhUwaqnladsJuRCdH7FL9wn0ycrYsunGbKhOXbJedIRs+7Wevc6Eycv+kSmcX4bNQw/XpfLv4Dd4ln5A==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="548">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBkAFv/iO2mkHljAFDDlwzQZuu9j/y8a9Bxvy8Qrm1IUFGzoFAt6YCQVq+M0LM47RBUieSQzbhhEE9JgFC9VYIQX4mDEENwA1AwTGxQZyohUH4vDZCzwcPQOAIj0Dc6OxBtd/bQFPvlECYt6xBUUyaQIgTm0BHUVhBV+HaQaV1jUFXEaJBRFD2QNHqJEHh6yRA22V5QPaI+0CuFWdBsxYpQVisfkGbICpAfc6rQK4aAUEJXQFBoNWBQTvPLUAQLC5Bt6ICQb4fWkGqjplBZBQEQcUgmkFRYxpBh1aEQVTGMEBtxzFAzvQQQre8MkCVfd9Bf3KcQS1EdkHXrjRAZoaHQXEDNUDiWTVB36s1QPTnN0Bp0ThB5Gw5QFhuOUFuxjlBG1kLQSuSi0CSQQxBswYBQhf3u0A4/DtAIW4NQdXqv0CoNUBABdMrQoOLE0F1EiBCu1JHQbBolkHnXAlC7SkdQZ8xHUEWYB1B3lVUQM3jhUFpO1ZAOawjQQuXwEHsldxAT+yYQXaiwkHae95ATn1eQBXVO0Hpoqeg</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="49" id="sample=1 period=1 cycle=2 experiment=17" defaultArrayLength="116">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="344.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="12368.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.091083333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="17"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="787.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="787.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="45.202575683594" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1220">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx3tQ0wUAB3BhFCQJ2/HQwVmwFETRCx8x0tgXeXRZqEBItgF7MGAM2G/7bbAHKuNEHoJDTqPrcpMSJTi8Y8e5g3UggoTR8TJe5wE2kRIWAXJgHFC/vz73iV28w4vncDEyOKU6F5GMJX3S2L7iFNRU7OBoU/nI6GJ7NBgFGNR4VdAdhXg2vxrdSXljwfoyhiUEvcVXUisSItjee+L0cyG+vmSez9gmAst633jITwQb893FZIgQ5hNuvSIQ4VxvP822LQ3fG/YvpzukwX5flbDFEqPsoOr3cZMY4bTj3WuTYiwYiOcDL8S4craLljUjRnDwE0HmdDpKGecX7MYMrE+5tOT9mAlzeul8KyTobX9/VBUhwdMabp53sgSxI2onn8sS/MtJjfvNKMETpmL75pQEzm2agL4oKayBd2wqpxy06Jc+GI7KAaNwVEsX56I0rD3asygXoZaVyVfduejy3jP3yEmGa+paMfstGUYYG1WNehne6G59+ku7DOUmu23FgYDwNDvB148As8g1KYmySblzos2fgO5pEyMtnkCYbP3sz5QKwWd3U4UEaCVCV7aCwFhP6zdtlJ717/CDqglEvn098STl7vFjz/7pIOD+XwJ/70MCO/xb9xZSlh34SBjYRZ3mfurMIIHKPqe4Iw5y5IZG3MynDPk8pTvGTw4abzSmjDIoPfVC4odyyHWLD/YdkUMXcImfcVKO7lvOOT9RBn1XJZVGyrFyTHvgcS2lXrFW0inHFsfjzXWWAvqJaMlUtQK8VCvv3pACV287ek8sKyBZO8SWvVbgRENdlhuLxK+uswMFfBLMYZfsTRkJfQkPgmoS98Lfe+H2kETtowaVxxAJt9eVvlzKrz7pnB2aJnEq3lpkspHYObGrb3ORBOum75+CJRJik/dh8zKJ6TNzsVfpStht3ODGDiV6+i2jdcNK7D8+owk0qmAdLNiwmFXgig+7NJvzMN5jDxmrzkf2LEdkm85HaH3HLru7GqubCx4fi9QI4NR5Zd5W42jiS5lXsxpVhRU+Skrf9caUdkqvo1mCriU1an5gzEUxNPDYMDapTRpc1kyJJymZu0X+r+haoPWg8CJDi5A4pZRr0sKSHFyuGNAizIE+U07XgWkwbHkydEi2ZS9lOhbgwR+RIauMAlT+/WXrdv4FMBL2MNOVFyHta67Et4VI+iuFd6O+EPYvaor7nfW4S7M8Pm8oxv+7YaAB</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="632">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwVtIE2AABtBZOrdFTYhAZiZ0gcayNsNoLvX7fom1GCI6Ly2pQRrYbZWVw8JQMY2xIkuwHkrqZcrmtiznUmjkZYsopOX0YaYvInRhEAsEJTrn1Rcf7+c3wXHDLxIZIWz+eReGpYBInWnHcvADdFnbRXrv87JWmVycLZ+lO5xB92Epj7QYmGsfYrO+ksaBQmH+Ws2OBqvo+TOHQZ+V44bvOL23mJXRFVwteIoLQQ/XDF52mlWs2ZrDAyYn31TcoqvIx5DSzbJLxUS2mkZJKRUfBxmxSBgJ1DB124NH8TSeyvNCtZjGT439lOUPg1EX/d8OsnF+GDvaDjHR5sNrux/WBbnYuO7HC1s6FTNanpzRMRjRUTf9TiQXY5RPFHCsXSJsVVI2WO5BnTcCpfQt+kp6sO6X01O3hZPTTdyT9FHjGce2Ky7OVT0A+i7z78M4X96xU55UcuJHKca0YRwvAb2dQEtXmKvOMN7nkL+Mj7kvNIXmayc4MhvFqkJFU+tFZm7kctkRw+iKBVmjXTw2NIApfZzz5//RWlFL9UItMvVWaDtuUpXSiLqd9Sz6nS0+H12CuXA/z5ls7N6l4aZyDROyXvYHnnCyfg2xuAO7n62j2+nCf4NgwKc=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="50" id="sample=1 period=1 cycle=2 experiment=18" defaultArrayLength="121">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="273.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="13292.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.092766666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="18"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="812.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="812.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="46.765327453613" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1276">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXtQ0wUAB3AcoHEIAgYDhGMOC1CPU7oZ8pBvQ7LiMeIVsB2OjQ3Gc79tMLbBycMg07oNmAScjMedQkce5Mxk4QSqcaOMhyUF3EDJXYYojwRLjn6ffz6h+28zC6PYoN5c1job2diY/WP099osJEeY8w99nIWdGfcCu7os/PbjjIZ6lotMf21GX3s2cl9NxB2g8HB+LrGERufBX+4oYTF58AsPMMRn8eDw5IMlLZ+H8NnSoS9reUhoPmfq1/HQ4bbHN2WBhwzL+wadDR9eb1zujKLx0d/i7p2fzcdw2p3Psnl8bAYgwmqTg5jGnuecXTlgzU/Lqf4CcFrKRzU6AfosdXm7OwT42Y8qevBIgIN7qj1N7wgx4Vno4VQtxD+1ilmeRYh7Fx8Hi3aESNWUyCP8cnF/+IA+jJ6L+nFW41p7LtxoU7VPu/Jwq2v8leS8CEe3tKPpiyIMJR7vbSBfUPgNqE8X4MKWNegxeXer6b/jtEKEflh5VxRViA72gFEVXYibt4cMyznFiLvlG3q0phgcQ9t1enUJiKLeb/KSxHiTkXx/jtwkPlYRyxPjWUDUy8vky65XHTfIg80hQ0saMayezCLHATHmyiqWB8nfS/srOPKuGOl1F/ZOjIixLREaTz0Ug+ERMx+/i0BiVdWxMWcCV8pNafE0AnZh7QXfhRB4rpSmnnyLwLcF3/twye1NO3/SQWDAPlqQxiRQELWtaiJfZFkWTkQT0KwP9gQlEzC6j5vPkZf5cD734BJoS8pgrJAnsGNbPbIJvEZNTl9QE/hJzr3XqSEwnrDqqu0gMN3QHftihMC28QEl0FWCSxH6w/VuEhy5I9tL2S+BIVhte40rwdxBQ41ztgQVYlFG36QEal/K2/nrEiQpAie+oEiRKjL/4E2XIiJf5pVCzllxKKWHSDG006sTcqWYaZFejWyQgkn9tTR+UgrKYG/JR4tSMHz3CcNXpXipmm+SrUnhdaaI30iu6xLSM4wy0J7ox/rJ/66XiKZGZRisKzcvTcmQpb4Y/O5DGZL+FZyyXZehM6bVfpVehsM3PlV6+8shcThjba6RQ8y6IphvkKO15EjYgkWOSLevrJ8MlCNI3zz2y3A5Ku3YbqlMBQaLTmzS1QpsJU+6PNUpwHjxjDVto4TerjhB76LEIW1+itPrSswaMq12TCXOcjZ8+DolNr/et2gaUeJ0ZsOkwaJEYOUldreLCgqn3TRjpwo888r1uA0Vmk6uXbMNqcSjHoaqz1KFG/FFPW3WKvwPfPix6g==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="660">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwB5AEb/oi+oUFvUKpARyXuPw70SEJgLm5Ak692QL3yn0H3WYBCLEMiQW5CgkAvT6NBx8PkQb8qA0HfjQNBbpewQ8JTx0Ag+HlCRTOGQME2BkGUgkxA4Hk7QTJDdUHpMDFBFcINQfY4bEKS0A9A6+lYQTOSKEJpSNtALjo3QbmeEkHmMblBpE6XQDp8QEGanuhAcNtBQaUUs0E0PZVBPoDyQF4EIkGUzo1BehPSQFVgqEBAGqtASiuuQLUtLkDXT8RBJ+ECQZviAkG7fK9AYiEwQE2dCUJ42AlCUF8EQTkkMUDxxjFB/IkFQVD1kEJlFgZBtXGcQenLMkEfDrNA7uenQSd+SUEYHjNAw3AzQIFyM0Cms7NAAcoGQfm4M0BZGZ5BA6RFQnEAtUEqHGNBxm4JQchziUHAR7dByc+4QNLROEC0BLtADcEMQTD3O0C6Gx9C55O8QKLhPECLUw5BGGZuQajtIUITOEBBoWMQQb6KwEA+r3BBxF3EQCRgREJqK7hBTrrEQOcCRUHLUUVAadXKQAdeT0ElpYJBzI/4QQf8nUDP1khCAoFWQT6AIkGw99lA9jpaQJxliUHcEiVBjZiJQfro3EAudf9CCUMnQZB8X0GpNShBq53iQGjzKkFGlpFBwiLbQUdWW0HS2MfC</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="51" id="sample=1 period=1 cycle=2 experiment=19" defaultArrayLength="102">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="161.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.079547431863" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10597.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.09445" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="19"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="837.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="837.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="48.328063964844" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1096">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXlMUwcAB+DSimCABG3IQlBXQAzD0o2ORRfQ/op1WjehgnghTB6UY9jSd/QE5eo8lilQcRs6eaJDh4ywEhumMavj0GQm2m5iBMcKtBw6jdC6GTNF3/fP9/Hzsk++WrQX/AesXCXLw3LaaRZ/WYBmwZM55+EC1L/byNqHCrDNG6+92laIKy6Xgs8nEOh9qkouIpA1LRlv5d6cbh0fZQl8F73EnzFOwFcnjVHxitCbWPHFelERJIacTR8EFWNh7DdraLwaI137nI2sGv7HT1c5nWpMPb54vturRibxempMUIJlSb6VuZ4SKHcaE17FloJ3T9NAxJXCE9Mt+KatFK4NDw/vuVAGibHn7hprOU70ONt8igqIFr3M8BAVWN/H5ghFByCLULTmKzRouuUR/s5dniCpP7Nai/CDc7v/hRaPZgM7Zou1+GGa/Es8pEVhmOKEOLgSlwRr5yqzdeC9xwwoCB3S65JGGG6NzBW50qaDu2MwIpc7P+SZeEsQid30gmaXiMTXa5ZnJXxIwqQ66ivnnj9ryP8pg8Tk/y3ChloS6nGlrqOZRHZDp/J0D4m6dUem3l9GAb9cFLu5ZUERtxvjKMxMlPkHuVP29V67LKVg+8OdPiincH9At/BwP4Xg7x38lEIKIeFK74saCs1FTRumainkffr6SrmNwmf9EuMwd4FljyHqJIVh36rYsACFJ9bL8TECGqz+kDY6jsbY9gHLKR2NSdWcfYWbRvvxFmm+lwZj7qqXz9PgRbwxXPfTsAht03V8Bv61d847KAbfqnPCqp0MHsgHEuf7Gez/NTl1xSSD8BFvWM0bBhMaJfX5Uj2sM7G8vdl6OCac5zq5xYmBVAepB5YkfXTUrYfIcHNolDKgWxnYcsxuQJ5aGmrvNWDjDeZPX6wR0S8vdfBSjFj8Tn9Tn82IV32ZUV0/G/FjaPq2mx4jbgenDmfaTIi6vlpeazfh2v2z7I47JjBXt84QTWacbv/nxV3WjGeJNX8/j7TgTJooLSC34ML2W+Zu1oLh0c5zWZFVcCh6QmalVXiU7CrO3ViFyk0NxS3Catwraa1Oa6+Gqf2/GwrZQbwFqexw0A==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="560">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBmAFn/lPspEDtzq9B9DlYQ1Aw7kBGF35Bc+3vQQPhcUIxE8RAghv1QXOOg0A6pgBD5hkmQe5QhUHsVwhBTjnSQIvBDUILKo5ALAVNQgGM1kBWr9pB8p2SQPTu20BWooFB2fdiQMi8BkFCNhpCtkrvQG2Pl0Ej6iRA6U0QQelip0D/qydALZbxQXkbBEJoOlRB3iuuQfxPREG34IJAsn0vQQ1/r0AQVYVB/GiyQf0XBkECGYZAWuLfQcRxYUHjHH5CwvkHQZdDN0DJRjdBGHtlQX6xiUHb5zdBLCcKQcHQuEF/0rhAvhELQqJxuUBWyblAdMs5QlAGUUE7qrtAR/sMQcRtDULnEz5A9+NvQWQxEEFkWwRCGYzAQBjzWEFsNRJBFhm4QQnhq0GAcQdCjYxFQZPgRUHQEEdAQxLHQDy6FUFRBxdBrzEZQfsGGkFb4CZCnFjPQM6P6UHm+xxB7CSDQeOk0kDUslVBsKsgQTi3VkH9GbFBejpaQQdZzkGv6FxAl3HeQDJGYEBc1WBB6dIoQR/FjkEGAS1BTreRQUumq8w=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="52" id="sample=1 period=1 cycle=2 experiment=20" defaultArrayLength="83">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="158.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.006388337832" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="9432.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.096133333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="20"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="862.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="862.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="49.890785217285" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="896">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXss1AEAB3BkM+Yxxxaz3IU41I2TvFLfTuvhFcfMhks/Dsfhfnc4ed461ui8kxvnTkib19Cs5dFh/FGxpVmkzBFtWh5HsyjTff75jB94sxKvx+FKusQkWB2HSmYjx7OcAw+CvnBphoMhTejlHlYifh63MmeVDyDYVBZv6BPwbYnKpjkQcJ/z85EnEah69latkBKQkC+abmkISDVGk3f0klDhu3LkT0vC5GxhOF0/GQQ1VGvvyMVWWhevX8VF7OM47bfvXJjWG45HraZAzojhzyhT8dV1isLoSIMHtff0bgIP0fsRgwdSHsI2jW3EZTz4XiibD+nk4UlmZc/IzQzYXSM3gml8mC3aGVcF8eFeyngkNcyEczXtS41DJnwSH+7vJmeitNE68IZhFuR7A2Pm3Cy4js9Nn05noU920BLuIIDjYc2ogi0AL0MxzCEEsHVZvN2mO3zNqD9WKEAnZf+XSb0AtQNs4xW1AKtOqYS/PokfZy4aPdX9Pqi2MJJGwln1J3KUSWIv4Z3bqW6GqMQvxItE4xKLG8MioWAGmIl06+10NMvqSGhfu31epQhRXd19n2olRIQ9W2PjKERPc132EFOIUPFmQXyDEIFRZ11OVEL4xLTb1SSKYNEd319QL4KlrPqjql2EtQ+M9JgJEWYnds2953UzG8rlusXrxqaHGhG8zlmkBGhFIPz3rZXqHDR1NYct6+bf24k3WM+BZMlgm8fOxTbhPxDckQspdZukv8qF3Otk0EaSB9rUyAJvKA/qvqvni+fzcDxl1ftPKoaWX2FpfiDGy7G8zr9R+aBLo6c8B/IxRDl6IxzMxzBjTbWle2/vt2mEqgCt6uctThaF2LBtcx0pLcKqn2xuuaEIJSX1KfRPJfgP4gIqPg==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="460">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBTAGz/hoIYUGwFuNAlJOYQqoj7z8R2fVA++v/P0azIUI9z4FBbcNkQY4qg0AZzlRDg8udQcnQEUK/me5AfiaMQBKi1EHltYVCZpNRQs8wOUFqTxdB1ue/QZb7mUCLfEBBEF0aQKkiKUKzq6FBXxCiQNlQ9kBV0PZA2+j3QMgikkEXEChChKT9QG3fAUFzLC5BNeACQbuBLkAGIANBIoYkQoBvMEH4U+lBTMixQGcbnEGg03VB4ckyQMu7TkKLGTNBWuLfQbeyNEATRzdAVUi3QLF/ZUEm6DdAj1oLQTENOkB/xT1AVbk+Qe8HP0Eysg9B9+k/QuzwD0GtKBBB1oRAQB9fxEBIYMRATsETQRoRx0BDichADZ4WQddeGUGcYs1AKe9NQW4OUUDg+VJBZ6PUQXqnIEE95AVCFzxWQSuJ0EEEMShBrJssQR125kCPgDNB62uKnA==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="53" id="sample=1 period=1 cycle=2 experiment=21" defaultArrayLength="107">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="330.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.013286398331" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11705.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.097816666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="21"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="887.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="887.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="51.453495025635" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1152">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyH1QkwUAB2AGExK6QItTCeRLoivAoEUhHfzEeS2MccPJEIG20cuAffi+ewdzcOhGQwG5ksnGdYPgAGkch2t0ZSbn2lA0zfiYZ3lFkHDgJC4R/Fh20P567p5XRdXbJMxCRL8Qujcr8whuJvlv3tNQgpbLi+dPnSzByeWrFYEfC3HQV2g+YhciUftXo/VLEQQD4SnPGWLsNWi3TPPFcIUemDeWirF/u+XmhS4xSoiwccGsGBfdgbm5PqXo32a/tCOqFBF16+3xjE/A4H4QxIglEHF9JOhuF4HFa2cP5XcTmHjW1jw4R6A7yrEsnSlDoMH/xIeREgwOqNlJYglaHwsE4V0S+HlOPxn5UwLzL42bKnvLERf8rbWNWQH9huel6OIKRLob9Rn6CjD9yv6O76nEd+7isHK2FIeqtg84vfJ23nKb9ktx8N2xZ3ciZch+8MqmySgZRm50+Lc4Zfj6ar/JxZCj2G42FLDlWEovTO5jKjD4u35ULlSg2eOg+YQC57hh07fqFYh1NF9evaLAO3I2N0B3FAs/uTkBviReVM1vaINJEIudy3ORJGrPXXq9PY/EhjU1eLaVRF2Kx5xoIFHSWzTB9UpcY09ZbSRyfJcQN0yCV7nUH/EjCYYsvmPVSWLeJ3soZpTEz0/6GtMZFO6YW0J0Xpumjvfd30IhjVPGTIiiMLbW1JP2NoWc93JlZ3QUnh8YH/vmDAXTrsp7t1sp/HZ+R9O4k4KDpsiXRUr8cD0vK0OnhNzFqlupV2ImRNrQY1NiSLSnJGFCCZ8Hw0VfTSph2TnIEq4qwU//Q+zaSiP7sGU+P4YGVR+9fELo9emV9gteP3pUfprQ0rDEHZZJDTQ6DEfpf+00giwBVs4kjYR+t+rGQxoLLFvs8RUak0krQskj71vfzM/hqmDkJ2dO81RYTLj7RvI9Fc4e+6diQ1QFzz6/0VR7Faozw6t2p1TjM23exTVeNT5NNXGGDGp8cXt3WahNDWEi4/3HXoPXF2Z7W4/BuHlfWg5Lg7mC+0EZfA3W/F0z40oNamxF6rXPNZh9GJDk160BRU5pX2PVwASbOjyrBp313wsFXvnxBYrCrhrw3vqVU+iswdzW9SxHSC12OYZjdLG1SDIuGf/LrYOe6Gx4Gt2G/wGp63/X</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="588">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBrAFT/jDlW0AuxihClSRhQrsv7j8wr3ZAiyC7QL30j0GZ9ppC0cbDQF/kCkL3jQNAHC2pQ+/LnUG/TGlBvP7DQYMvL0E56kJBPsONQOFAgUISyzpC2t9bQdZoE0GaPN5AbO8UQOI5qkFWlz5BRIaZQGQ6ekHvUZ1ALy6fQCL7xkGmyu5Ay37yQKusoUDieiNAhkX2QMUkzkCnhvpAqwT8QKoQKEATYihBFaR9QfYZK0BXfKxAopOBQLLVAUEJSaNBL1vbQZhNcUEmfy9Ami1cQTEnMEDvk+dBw3+wQNSAMECK/xVCAsgxQC+WBUGMjr1BuXGcQW9gNEDFggdCKrQ0QYVDCEEfB+dBYXM5QeV7uUC4sVFB8D0MQXVDDEFzl+pBbjWNQdtuDUEcxT1AtFQOQd3IDkHICg9BhZY/QADj+0FlYpBBQqdwQVuKQEEP1XJB0L8RQYQCRUFZgxVBHE17QWdUGEGArEtBm3nrQYPWUUFPKINB7a9VQT1Fh0HA91hBlOyHQer22UBTfipCyBjBQV3p3EBt6lxAPHDeQGcCX0HXLIxBqpXgQF5o6UFly/FBFYC5Yw==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="54" id="sample=1 period=1 cycle=2 experiment=22" defaultArrayLength="105">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="171.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11375.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.0995" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="22"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="912.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="912.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="53.016193389893" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1124">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxWtUUwUAB/DQkUmhpnYGljRm5tATJohuwuQ/nEmRpqIHX7SxB+wSY7v3bruMfDAHIkrCFrIiczokgQ8iItV8IAJCQLzcgk6lwMzCYyqCBzqhh+7vy29z34QmMnYv0rct/SY071OIYoQPef4yEMtbiACZHJJwTadsWg7XXSZpyk+Biy+c4WVKBcSL7o+MOBUYEAqDkoYUeLopg7PxJSW25EXFruQp0RN15lK0nwqSc/RAzBI1iMXta2qdauS0nZDfHVSjY+THOQP31EjZUFEZqExFxL7HlWmDqaBDvf+8CEnD9IeSjndyNLjQX5eYUK7By9asU8uTCRCbA4KYXALi0uJ7N6Wfobntg7Ujb2fAd/pyIcHLgEO1pfUGe2+jMzWfo8USA5O4XqrFkUXchi72qw9dOc1qLb78yjT2YGYmVpviP3ldmgnb376QUVUmfm5Ec39uJgT1HtEERwfH+eQSj0WHdbrq7zXb9WgS5V+nFXqURR09L7brcWCbpCe6UY+ahbf3jA7q4aoIAN+PRLX2+DM3e1jx7th4Hok0jzV4VSiJOuOpZ7ciSOxThQu3RpJ4Mut4TzX70tFotyqOxJ2C6c9L2C+erfdvZ38gC+MmbyBx0BE9JaJI9A+1ikttJMaM+91fnyWxkyteKL1EYvjxoV9vNZEok1ShykdiFrMzsGg+BX53xaMGdst/Ws4yHoXCLN1zAZ9Cly+ws4j9dLJbPEdO4Xr6yb3+KRRsyuL193MozK83d4/ZKLQd0B2eslMomPHEusdF4Tt7zXtx4xR2rGKac2fQaDObfpvLp9EeX3lIIKFxTbKCKNbTmOmN+5jbR6O2XPooeJgGccz9xeqnNDrvNHS4xmgMFTluvqE0wPOH8XDBDQM68y0V9ey7krzkcJMB5/IWjz/vNcBSMvm7hmdE+v6PSn0wgjwmnL213Ijglsmab/uMqArpj5nnMaLHlPCXgG9Cb8q/3dZaE15RxU6I6kxwvvvDvLAIBi1Hd3lXUgwuO6lXF1gZjP9ku9JkZ7COUXI5QwwOeiPfHKWy8JrAki2rzcJJ3yDjYE+8soZudJohnpTf/rPGDHN6V+svkmzY30pJSHVmY7uh8P21QRb8D4bEgAE=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="576">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBpAFb/vj30kEylrdCqhtwQDCv9kDchLxAOiGLQlTlCkKljoNAZndyQ/FRR0HeUAVCDaX/QeImjEF0MTFCmTcyQa3SrULsO5BASXbIQXaUkkCEVeJAvmWEQUgZ00GLfEBB+8buQQ6qIUCCq6FAkqwhQP81JEHqXvdACE6QQVfs90CAAidBnLSnQBvPIkKwZyhBrjnUQXYGi0FKKy5BqoAuQXReW0HFlOdBIBgxQfnFMUESybFAA1D1QT5tMkGKFgZB0zQtQgYaBkFgUwZBGBszQezjX0EnVwZBWRG0QOiyNEAvBTVAqVo1QWBDCEH7UTZAVUW3QKhdIEFZirdAY68JQYyWt0DJzDhAR7ehQaJxuUADxzlBC8w5QQAZOkDWwIxBGfkMQfnt30F9Kz1BzxO+QHDoy0HqNsBAA6bwQbZoEEFdp0JAo15EQLRHE0GcbsRB+oQTQVudFEE2v0ZBBWcWQXpfSUAPwHtB1NFKQAhbgEFKZk1BILmbQD+/UEDYxxxBD1BRQLing0Gv3x9BZqugQYtmfkKXTzFCMN8jQTPo3EAHP/pBbA49QQmQqv4=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="55" id="sample=1 period=1 cycle=2 experiment=23" defaultArrayLength="98">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="227.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.013286398331" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11165.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.101183333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="23"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="937.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="937.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="54.578880310059" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1040">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx3tMzAEAB/C7o8xOSxgN0/XLNRcltXbI1rfTeSSvzDwuVtc9iu78ft3VXY9dF7rjetDFFKefVMs6IQ6FHmaNpZtLtFiJjmVt1VapzVR+f332CX7o/HwwSgKHyLeJX3Aa+6ZHxZ50IiwLs4paK5OwLd20dootRbRoxdyVZClCi5z1TkYlq+dDKy3F5Tev7h/7LkXATy9ZIisZal0DJ4SXDAnXnDLHksG0hqj+S8ix2+5UOmk5VFv6plxuOVy+aSu98hXgdiXojg4qUFm7tKCX0dV5222fV+BgzcjN5YQS4zX5DROVSoQEFVwS0UrUNRnsm6pTUK3441OKVATNmg6wTqVi/vuAZcXFVEx+SdD3xpxFxROhdT0vDaaWwA+DUWnIL14UZyBUeD4ZvLU5RgUdu2qvSKzCWGhrX4hUBdf7GlbtQjX8PR47WmRq+Bqi/ewdakz3jA5JPc5hmLNslYtNQj58e9TtR+LT70gBx5+EZeVsvYAg4S689ywlnsQmRY2gU0piwNLnWm0lIbav4xLtJFqCyuL3synsWn/+pZ3x4sYKv0M8CpxbXyJF4RRGus30ecYlyqSWbSIKd878GKYZI0Zr6yJ3UtgSeyTGYKQg0VafKCulIOeVt74l0pHmHfE1+G46LjR0Jxon0zForbp6ktBAbfDssyVqEK0tOSCwasDvkgQlMN57etXTVqVBwgNrp6Bbg5P1JR/zGEvfCXsfMv57MZf5aoK5x8zZuUNaiHc42pMpLRxTXeO1bVoU5RkuLO7RYsj1YBc1qAU9wDfwh7QgP8WGSRivp4bOCJdm4P5IR3FzfAbYx4s3uOkMXM7hLlC2ZeCb4/32sUc6LCoOvcFr1MFsjGjOtOrRP1C053CjHsRRBd/M2B/R3/GRManJp1D9Wo8NyrLIOjoLNv20hXBngbtbIlzmkw1TXuzxKGM2Fniawm7S2ZgdKZfNEDlY8iskShyQA1m4cIwKz0FhoGZzGCcXtmyz/VpjLjTe4v1+rDz0V7y2ycqNCHjpE6e4ko//s4JgyQ==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="540">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBiAF3/oIpEEIALIxCso/4QD/zH0GWYYNCN2ejQUW6gkAQjoNApfqHQ3pWEUL++MdBiVcIQTpCdUGK5yNCl9ItQm6cEECoWb9BsrFaQAwxEkA9nhJAxzE5QS89XkFHDdBByHs/QeGFGUGuXJBB6e7QQRmAckHgCPNAsookQMt02EHZ7CRAPd33QMyG+kA5Eb1BLxopQVyt/kAue6xAstUBQe4iLUCcKa1BSisuQZqCrkBYngNBR4bRQcQ4LEKWVgVBxmELQsiq6kFxGQZB9xizQHnpJ0IxHjNB61q0QHgcHkGElzdBCp5oQVysu0FE799B4H7VQbC3PkDBuL5AP0IPQfbqs0H/5PtBW/EPQSl6qEHsUMJAm+vCQHxHE0I9jBNBjPXEQLBC9kB4whNBJ9vFQDHXeEEdWxZBXAvJQGBgHUHm1tFAgbNVQGE51kCUAfFBtDvWQIbfIEFaqyNBbFjbQAYUJUEj7t1ANHHeQZRuKEGzlOBAltdgQPWYjkFkMi1BSQjwQHFGukEQfH9BphSoSg==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="56" id="sample=1 period=1 cycle=2 experiment=24" defaultArrayLength="91">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="242.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.006388337832" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11061.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.102866666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="24"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="962.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="962.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="56.14155960083" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="972">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXsw0wEAB3Arcldc0fsiGnYn3eko1mX6WlYph7Cr2RrGTMn67bffHmiybK6Xw5xKD8aiF665Hu5EHneOS0J6XK4o0dOjW6Tosc8/nypdc7DNDj4qOzx3Tjfz0dDoUnghVAjuR/O9zXohvsQJmxxMCbAPLdXcGU5A8ezA2kmaCFdau+SnFoigzPY6yBOKMPvyhd/NJBHa/xTZ9JWLUF5wKSpsWASquj6fa5OEwSDeC7p7Epj/4nvPWX+sUbwbs9512ly/nZaM+ckiSUO5GGeb+IrOETHi+dBLh1JQH3bGfrRMgtxNKwVp5RI8aNPtWGVKhYvuV/8h3WEwORViCdIQNVsX8jM0Db4dTIOn+1EESGZqBJx06P5olj9MliJDqs5ji6UwcltvL9RLUXs2TimgEzgpGcgc2EzAqeymDRlNoGSq5cll6x8aVfOuIgKMZQr3ROuOXR56HwOB1YPMQrdKAruKnqXZ3iHgwO+nPzUT+L18/JtHCwE7Fhkb00vAPlAVsJUmw2vhK+8a6+S4W3eYuwzqykBHs58MtpwxL5a/DDdYbeevs2X4K06di86R4dbz4JVZTiSoksUneHQS2ZGHxvP9SHxN9xEzEklEaUrDh3NIfGRkHygykPC2PJzYWEzCjn+p16+SBHvFCCeyl8TuCK6H1npF9Z7wlj4S6TTplngLCUNgX0z3BjnsjWvqWAlyxFHrQ95o5aipHQw6ZpDjYkjjtoQ+OVw1Css168m0uVDRdzm+GUflx0kKC5w7e5SPKLydvOuyqJ2CLyvD7l8/hVVm3nfuewptwdV5X/YrMD5DwWhSYKHv4oKZNgWYGyjnEroSudPOxv0mJYLEZXVTWhVWNF/9fMagwlWFz/0R6ynrRv1HzCpEMPayLEMq3CvpWeKdpMY+tvaI0qzGUkvpp6r6DAgGdD9cnTJRq52JnWdnoqFqU7jalAXG14lfp4dy8B+ZYUm0</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="500">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBbAGT/lMH4UAAUKpAZeIxQCJyakKDrXhAiHj6P5hDd0L8XYFBWaQzQVZno0Hl/91BSV10Q1RnrkGvpKZBPU/pQC5TBUAlbqpBgRH4QYiJpEJK6OxBuSeUQF8pFEDYDNBBVe0BQv+zbkAF1eRBhoISQpBj90D9jZ1BeRAoQCxoKEAxKi1BoXctQUorrkBEoQJBRN8CQbYgWkHDfS9Cl9IvQPkUBEHqKUZBqXCwQWKUhEFROF5BqVYFQb3OBULUIMlBI8uyQDEbM0CJQwdBAkA3QQqwCUGI7QlBH9cEQopxOUBlPOhB1VkLQToYOkDEnaNB/v46QAHGaUHIqztBMZG8QONSDkE8zg5Bcc2yQZLoUUIv7L9A4ZXYQdXwQkEsAYdBSW9EQBeME0FlwhNBxw7HQNCKyEDRG8lA0x4YQUUeTUH/wxxBUfscQWj8HEETRhBC0/nsQWzlVEE5cztCoYraQCsUJUEK7dxAvKRiQA6GnEFUOpTr</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="57" id="sample=1 period=1 cycle=2 experiment=25" defaultArrayLength="114">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="285.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.081097987028" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="13194.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.10455" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="25"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="987.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="987.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="57.70422744751" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1208">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzG1QkgcAB3A13Wq7lIq5zM3o7fJyOEvUmhX/QFNnRynnKtfhBBVNoYcHDNEUTcuLrDtRtPMKyhT1djvFpYw631BXtrVANzHXDs0ZzW45TFetc9vz6fftp/tgxKPOOxVK7Rj2sL+EqKIgOuqcAKaPVvOmhwTod+69UzosANnQfWBZ8BX0teE3X3oKYQ+N/10nEuKtl+UHs0EI41J4X9KUEA1BNEmEhwg39NfsRsqBLPddJkMEh9+VsRceGeh6HVbP98zA+tBHSWbKxePJO2RbMsG6nXpPys2EtfeEuMGQCU35YdJFaWj1HNVez8Si09gzOpOJMaFPZZkzC4Px1ZpnejHMNMsrjUEMYiTd4nMzG3EhnOEnyAHtzTevtlbk4P3GaUErpfGN16ydnYvkJXqbNSYXs5MPbBGMPPzE/iTlw5g8PLya2OPyluDs6uBJZowESe2X9w5SPmYVJc6USdDt77g1lyHFvPx8By1LCsZ0hv1OhRTiDQffLRmWgn/iFjfN5xS6ii9dDig7hTzr17UVyQTCq6dce4QElnNZflPVBOjTnzHf0xIYWLk7ymIiMHnDcHVLPwHWyR8FDisB2/2Q1iRPGSYeqpuYDBkiq+Njcygv7j6uiwuXITXo+cU6yu8bXHQJR4aPh1zZdVwZ1C2r9DqeDEML/9i7k2U43/Z60JeUYTvvfqK5nframReO2GSovc0Oa15Lwm3eMe6knJGr6PkcEgMBKS3e6SSMP3/RkkA5ttS4OKcmkbAvxI9TSuJQFedopI2Emp9b32QnEevucLS4Sby9Eti0YrMcJ3NCggWUnHuNxRNaOXiRVfFRdjmiI4+5+ZTrtn46vs0th91W5CpdkKPTo7c/WqhAYrYlwXJdAa+Ng3HPKEcqy5q7+hTon2DP5/UrIAykrf3FqYDu3wsRkicK7C99PBq7oECaT+hfQ+n5mG32/001mg9xzUt9u+k0uhN6Sg5ZTyP86YSqcZMSC5eqHF6blags/2/Ng51KnOP+2qfWKrFCc1g1Rvn084OGP51KzNQevabXFmC+N25ZairA+sK5NBOlr1we9k5nAdqCGateGFRYqWms8ecUgh/k+i7AUIiRsKA1hZSMlO3BnR2FYH4rCjy7qwjHatTjB8qLwN5HJ2K8zoBfL/4jkTiDDXf3L/+dXoydPK7vnL0Yz3e1PlrHL4GS1dbA26jG/+0Do1o=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="624">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwByAE3/tlvCUG578tBUI4zQ+BZs0BCdxVBza72QKLhskJyxGRBdXEkQVVyk0MO4QRBmuKEQJ74R0KngsxBGpvuQNxZiEBWO9JAdZEMQKHADUCP6kJBBcSNQKufm0J6BfZBuzveQKM+3kBl9uJAsjCZQCv8mUC4/ZlAYrHuQDXhWkLtqiFB7BEiQdNETUHZ6SRBFU6QQTeXJUCsHAhDDBz8QBib/ECzGSlALHTpQbHgVUHeKy5Bs98CQXmdA0Gyfa9AxSCaQTGNXEEuf7BAN1XpQQ9PdUHizgVBtuOIQjCBX0F8S75BjB+zQQtZs0AMSmBBXAwHQZdNNUBg9LVAb3QJQU51CUHJKQpBoNE4QDyeCkGGEYtAcW45QHL9OkB1QwxBhboMQVVtjUEAlDxAYQwPQTTnV0H67w9BWoRAQR+cWEF5+hFBkczDQDnaEkGbX0RA/mJEQWL3REB8A0VB46F2QbxYx0ByY8lAZVuAQW+qzUByV89A/1hPQdqfT0HmTlFAZtKCQSz8HUEvtNVAFOQFQlbXyEFurSBBJqyjQcoRikFz0yZBBz96QaS43kDJnihBYpgpQSAoZEAasI9Ba69pQfNq60D/DDJB5YBwQYvXwcs=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="58" id="sample=1 period=1 cycle=2 experiment=26" defaultArrayLength="103">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="291.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.015010938073" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="12486.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.106233333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="26"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1012.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1012.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="59.266887664795" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1080">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzH1Qi3EAB3CbqFhUxuW1LZROpLlLGPuWWXnJWziJbZ71omQ921M9Kyt5y+Gi1VVUmtJOXGgUKalTK+e1FMVxC9d1VKfkOuV0fn99/vtQcbsfFUvCUFnXFS86I4eIWtKxzCLHyhFe0TVin4tUV94sR66+/OAnuRLDfirlHw6F1qz+8otcClW8sjAPNwr87OoqrwAKBltdcbaKQqlRETxETNvjMfDTSEGScqXbYKUQbF4y60A3BfbE8lv9xA7bC9bQCSp4bwoaryQqL8xvni1QoWnx4tvmQyqsjjmtmMEJR+xZwU3hwgj06/mPgo0R4GleZL4l9pa9anz3LQI5dyQ5CptIuDsENOyyRsJNkpPfToxzbKnw645Esrjlx03XKKif/TWPFkVhZH/PD+/T0WCVtdWXpEdw2DvGbo4gFkNlU6fVbYhFQoNPSaH0KMZFlzd1h6sRXyTbZzqjhmvm/aUDNnHgJYsdz56IwwHpS9O5XTRaFjQeD6FoeEWWej4nJtqtu7Usi0Z62P3PmytoDIsNzGczjfGa5XZzG2hwYj0Kh5/SiLlh/6TLSmNLBmPZxtGgxCV0zh3ivmLeg4/E8jx7NkSgQVnF+8E2ovNI17cgoQZ7txq2NYo0CDzidFe2UgNTa26+PkAD7sw+YdtxDea1Bo+ddNaikeNQJxZp8fiyYXRimhaZM/3SU7K0gP/5zboSLe7xX7svGtZiSo2yVk/MswwEVRFt9K0PaC6Du0nrHP8RV9he4Uc7MSjo3ajrETKoXCHvdHdj8LVDqEonZgzpUj1EDCxO29dO8WfgRA0Mbj/FYOypxTWwjUG2jOOT+IWBwPzmsXqIfDVBD5N+MVDKTNNvE8OPvnmZVB+PmMGDv4uI6Z32Dk/exsOZF1XdPj0BpjV7c9vaE2DjBeGpCYnw4dbJfK8nQlTt+2tVNgvpzg/7/a+zCEv1zhOYWZwMeTVp8j0W7KS+sVEri2nNEU1blTqcK823Ssw6NBWuqU8lFih6Qh8SJ3ru6PQ1JkOsWFD7e8YxFHh+NLrwj+H76/GUq+tTUR/NbQjZkQZ1b86NTGsa/gNYh27S</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="564">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBnAFj/nIqfUEvnZNCv1qzQMslb0B5Ke8/1a32P2aYdkIWtiFBx0OiQexiw0DMGvVBZxfEQG1yJEG8bgRAra21Q8iQJUGxfZVB5OIEQH2kpkE8NAZBBm6qQSowL0HJn9RA5zGxQfJzk0KzyzJB9ckRQbPLkUD1zBFAWEOAQQY8XkDMOy1BxC4fQetnCEJIGfNAinTYQcLWdkIlnnxBpsepQFEbK0AQLK5BVLCYQZqCrkCkEhRCah0wQQ4vXEH2k+dBw3+wQLvRBEEXOV5C4cixQFBXBUGE43pCTmuyQLptMkCnb5xBshRlQsfgX0FvV7RAPEW3QEjfZUH2EQtBucm5QC+TC0EJwAxBKHyYQZ6tO0Bp9jtAH/k7QEYwDUGtkTxA75K8QJVvDUEXRaVB6Sq9QGFvvkDf5G9CqDjAQM6FQEAhaBBB54vAQPoAh0FpX0RAL9efQfxiFEGkaclA78R8QVfWGUEXUtFA7jIdQQImg0GlY51BC/rsQe/YVEDqqiBBTg8uQnef40Gob95A0zSMQWhAKEHi0DFBPUB2QTBw+kB9xLEM</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="59" id="sample=1 period=1 cycle=2 experiment=27" defaultArrayLength="103">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="224.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10044.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.107916666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="27"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1037.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1037.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="60.829540252686" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1088">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx3tQywEAB3Bl1Z1jWaEcVtZJeUvnkWbfDaVQ6jCurLW1Zmm13289ttADu1TOVaPSqmViOQ7hPHIe0cuRrMJ5VGvkER0Wt9DD76/PfRzCPnWt4kThyjfXGx4aAcaX7nHb3iSAKSQscJpjDDIH7z//YyeCy6MhZoW9CO8tb2iRAhGKdpU7J4pFYNYN1zVT3h5UetfoRWhdmfV7lJLwGzeHmkXg7m9Q7p0gBi9Yzud4inHC1yulpUeMl6aQf9YJcUjVsXtT7eLgpglzt7Ik0M0OPP9IL8G14eU0ebUEcYv6zab3ErgHXZs/ODEee630/IjeeHxeIp3SSBleM1DuypIiz5Lr1F8lhcqnr3NptxQHHHOjp++RwUCzeXCPyKBjBYduqpGBYRyPL+tJQObMxrM/NuzD5+UI8vVMRH0TkzVCGePz4G4bJxHRjOqKKJocqq6CZckb5Ci7dHisPS4Jk6e6bMyRJOFX56BF5JAMXamBee9eMuaczEozeSjwNMB6URGpgK6+/ZlMpABnzVchp1gBnxmyZvoD6u0l/QJKxh3/kbV2BPI/DH/39yRwtHq84hjlhbac/dwVBKqWDCyM4hG4y5zIKKNcsErb4BxLoKDxXWdtEYEWsZNBWEzAd03e6McGArNenJOcfEigkvd9W4oLCdtCA/02i0RwfsKF134k7ncPlLbySCRePrjMPpbEtoOntpizSVR9+TFPfphEyXBL1M0iEs5X3RasLibB+ZoQMmYg8UkTXOn4nIQ2Wd2m+Emi9Zye5A+R0IREmvugREBfM21LuBKTNo8I5EIlsnZIiTFKrfgQHSYlzh4aw3GrEvZahyONOSnQOBgJviUFhL9n12hEKl7VGmNKY1Mx9e1u7wFKv8f7omdz01C71a78SUQaQtm27nln0nC9R9n5YW46tF6qbHZdOnqcNrOHetMxp/t6R5JQhXAv+sPCOhWS1nWsF3LUkORxcxmFanjHQ96nV+O0qjTLdlWN17In9bwONXY27dLQGBlYTAtklmVn4J3pr8VPn4HHQfpJfEr+0YACI+UtyUe2T1gmRlpLjIW92bCZn23kuufgP0VNd/g=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="564">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBnAFj/qspfUGQloZCkEBRQVcf8D+M9DlCtA1CQFj5Q0BVuIJAl7kCQF5UxUBnVsVApcVTQ9ThBEFcewlCmuIHQT9XCED9WAhA6iWMQV15n0FNpdRA2Lw2QkyM1kCpktFBmssRQD2eEkC5JxRB31/fQESGGUGse8BAKV0aQQsEnkDbIqlBu1oDQruD8kBxCPNA40JNQTucmkEdEb1BJhGoQOjIKUCJsVZBixwtQM/wQ0GYgC5B95YOQp1wsEEjcjBBDP/HQRbOBUHCaTJBQavqQTtTBkEYGzNBrrizQEGGh0E7iQdBCUAIQTKuNUDyRDdAqaSgQezoN0BdOThBcJ2KQYpxOUBRfjlA2cW5QN4A0UEyHDpBYfw6QUuiO0GWqztBIyo9QawUDkEoDCZBoMc9QKfvD0I6i0BAoDlDQUoDxUFugxtCxFdHQQ+DFUFyX8tAuMAYQX8dTUGcWE9BUmGdQaml0kDyB4VBWpYMQk+eWEGAOohBxTpaQPuLWkGO6ohBLFKXQbFzJkGBPXpBPHDeQH5xXkBmU21BDoacQUOMnUGdAqPj</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="60" id="sample=1 period=1 cycle=2 experiment=28" defaultArrayLength="99">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="186.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.081097987028" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11406.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.1096" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="28"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1062.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1062.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="62.392189025879" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1048">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXtQywEAB3BTOAlLIRe2fiS3G3bhiK59q62ORak49FhtrTxae2q2tlS3OtWlh0N02lZcHn+4hcKdrIZOSY/pJN2t42R2OiWUavh9/vmYtpioS9oS4He9OULPTkRefiuPiUSsS4qwhhalIKnV17njRQqoV7pdVH4qHk9NvJmiCNCkb0gMJAQwvDVyS4UClFAZg68NAiTxH1m4IwKIzjldXvOEaKpq42nJK9wnHKM0IY5UEgXhdCEGmAlDBCUdzJpO/TtChHtlVtoNgwiN7vtsq4wifG+Mmuj7JMKckPqVtjEDVetNJok9A/GYtXWRuy6WL/pcl4mQP/Z5mxpOIL5/uNRHfxK8OdWs8sZJbJRu4hyvP4XaX2knXrFPo35Jie4F5zTKczxq7LQsmCOPFu6nZyFw7pybg3x1R/ddCSGG1ki3azli9LiqmcXpYlzzPiQJWZCNscU9Y/b0bBTeTDOtLsrGysnjS/MWSOD9t+v3Q4sE4hrdqi8UKS6NW7pr46Qo5tm8O7KleDedEEKrlmJ8ZTjoFimsreYwCTnDcMEZTZEB/LsbaskHn/AuE3QZPAjD42hypu2e77cgGWJYW3fHbpchoTyv+VaVDEdGv++ZIU885jMd0C6DY33mng8/ZGj8xk5tIOTgMdjOq0FyDAbbCqdS5TCzz0jD0uRwb2Z0iiflePg7pGVmhQINZRluXEKBQLGrhJ+qQOS/Q37+fQqc+rz3fQx5aOvlO9wJBfxcrD7jDwWEB68EyPOVWNp5eHLXfSWsO929Bp4pkdnTNnLUqkTx5l7t5o9KnG9Pfs6JO4M674D0D9U5yJGY4xyVKtQ7OspmqlWgLWePPLWrwGV5iHaPq+Djr5MNV57Fp3Bnb5D5LAp0yT9LyXv1w8sGyFPMVnWsmxpDYy95Qyw15gcvXnsAahT4m/luRjVyXz6I4nxUw7eU0iT216AsZn8dfYcGC7eFRq4J08DYn2e/na9BaPy1WLZBg46WfOf0hlwwdJ6e4rRc9B/OapkltKjoenrzWKUWbFawi2spwH+LzWXF</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="544">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBjAFz/uplxD/p50RBKwzhP8PyUUO/WrNAYa/2P7z0OUKIzwFAEuUKQi9yJEGs5z5DkuAEQAXihECK98dAcqWmQYV4u0FvONJAfOnCQdmjVEBHG7dCpXCPQD/KkUFosdpAxzE5Qfr24kD5+xlBjF2aQIRSnUDTIJ9AI+FaQZIUSkHTgHJAXOI1QQgcOUHJX/dA7ZVOQS4Gp0AddeRCt54YQp47VEESuFZBlJpXQUShAkH9clpBH13bQRJ/RkFAZJpBVxxTQpZWBUGIZzJAmWgyQX7JMkCHfl9Bi4aHQSK1NEH4qzVBkU1kQe+WN0Gq5zdBAJ2KQeLSOEGfuWRCFTYNQYSTPEHqC6ZBeum/QDHxA0IIhUBAtmiQQFYzQ0B2JMRAeXh1QU8NB0JscQdCiNR4QbqeGUHVR1FBB1FRQND7nUELMh5BZ0EgQY/jhUGT5AVBtDvWQA2cV0H4X1hBtXkiQZaso0G+VNtAt19cQYKu3EAa5VxB4e/dQKhvXkGal+BA/C8pQTmt5ED7Z+ZAUm+AQEMiq+I=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="61" id="sample=1 period=1 cycle=2 experiment=29" defaultArrayLength="103">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="282.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11541.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.111283333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="29"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1087.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1087.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="63.95482635498" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1096">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzHlM0gsAB3Cx12nKknK1Wip2mZmpHXS9vgopEqVQK5tGICJ4cvxEeeYrRHPNjELUykpSdK1FB+tQaevQ8dLnWj4rM0sBK1pz2SqjqZu+31+f/z4U3YvAmpP7cKOYYj8WcwShPTzP7pMCtHBcE0XlAmwcU/UL7QIIq+YPRx4VwvF7/Fy/UwiDrmXmy3oRJt2BPvEmEVoelTV5e6dh5+PRca04DSGqPeIEZxp8ZXVY7SWGuoRmCA0S4/yl5zOGvdJhGUyJekWX4Muu3D8XmCSw1tosnaTUyergUocEi/Jpb+wfJMhOnRsg/yjBPzGt/gUdGbgUF2ROcWSAOn+X9h6p8+LboYF6Kb7JbbP0Q1KcFRpptcNS3Hwk619rlsE1wtpbQbplriy3G5kYrfFZyurIAqcj4kc1KxtLizK6aLuz0arnV60IykHrBT/vGYIcdLszp/a15yDWkvWglJULtsFknEjPQ3Piw1N5ujysHwgfO2zPw4XMxbWRM+Vw8++fKS2RY174mQbvGAV4c9r+5vEVYA4ad+5PU8D/7hivipT9bNbr8CoFipk7mjNJA7obK7c9USBOVaZf2KGANUWQkEhR4mvY6XWDpDy78U5SkBIc3bSUH6zEEieVlRitRKLvgfXXY5XYgyUVtw1KWBdHff9KGrthKjKQrkJCV5jNJlRhHmeCvkykAre6M+eeP4GR8eeXp4IJyGuGGrbEEHD++jRaLiSgWnnI06oioExfE8rVEuB2UgiPgUCSbXYP/T8CXX5mTTLp1mSGPtpFYG0EZzrsO/n8y1jF5eWjTF5vvN+bj+qMcsrCl/lojIhzBwyTnkit/EBVo0m4SVoXocZy3z9uU/lqnP7pWnOC9AruRA+I1LjZEMc4qFWj79qtRp+raoTH76BkOdUYCTGfSzUXoM7LRdncU4BFvdvdodGFSKrgXmxyFII2Ghv1ibSP+Z7tmS5E77ovLsYBDZavrBQ3l2gQ3+fP0Fs1sG7c6mE+1eCJnHtl0vQXXrArv/lSimDxC7Gs1haB3iYLcZAeP/rumb7hGF4nl7eZkoohHmT+2uwqxljp5xF2+3G0XxXt9WLo8D9Y/W+S</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="564">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBnAFj/ped/EDSvBFBcE+KQoovbkBUW7NAWbD2QLl4ekEt7H9AmvO/QJpLWkKJZiNB8HqPQzIZJkEoTWlBt2EZQYcljECfntRAU52WQbeRDkBBy6NC+qEOQMop2kAOyhFABT42QYgnlEFnZt9AI3nfQPr2YkBiUBdBDMllQYEgRUFLxm5AU8juQCwwVEIqXCJANXqjQDlgd0H1LItCg5F8QNQYqUHXx6lBfFSAQFzOrUDOKi5B96+YQXCBrkBxZdBBcH+vQKpxsEFxgDBARFWFQqfJMUHAUPVBcdIFQegkSUHOfklBf8IjQr+0tEBmeWVBLdA4QbwGZ0ERNQ1B0rZrQcgrPUD6U45AXB4+QKpgvkDRtr5Aq+k/QT7ss0GMKRBBjIRAQWBSQkBvuURAYowTQQgCRUCa2cVAe25GQXUPR0B9EcdAH1lHQQfnx0BbekhBuaPJQPsygEHxbhpB86VPQE6k0kB4pdJAszJTQC6kVEG/DyBBWOQFQvHeIEGAUDFCCdfbQMDt3UCQdCZB5ZziQGZmZUAmt8pBaxjvQKMdgkF/iK+H</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="62" id="sample=1 period=1 cycle=2 experiment=30" defaultArrayLength="117">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="150.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11878.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.112966666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="30"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1112.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1112.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="65.517463684082" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1236">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzH1QkwUAx/ExrCtagGBmorkWbISBMc4kj9NfY0mYgHFIEIy2wTbncDzPs5dnEAGCvFhUAoHBKbt4uUIJY5NLDGEvysQj3usuD5lOTBOJBLk65KTnr8/d94+v5xx9ImxvBvx8l5uefy8Lq4ucdSjPwtRviv+eNMuwkf00ftFLjg3ljaeUbDkm2XHOEJEcYkX1F+ZsOX7vSpmeNMuhIC6WJdySYyVooNbDeLawpjGWlY1iW+f6f7dl484724vBzcbUePyTRVYOWKGz92O8chAgfD3hL54CifofvW1mBS4UDaTWuhXYn/zd4NU7CvTz97o/mVXgulF942O3EqMv9+cG8VSIsPR1fNB6GO0hdUWC42r8UB3iL2k5gsqgurE/xBrYU/21EoUGDXfZW97g5sJbPTeoFh/FmzWZN9PEWnylfDvuYY4WfyavpzY/kwdHW/SCnycPdvt8tP9bBGabrbzUZAKPrdaZLxlV7elLtJwApy1SElJL4GdBRVUVo2RgUBhhI6AvU4WynQQ+ShsKXHYTmAterdzKInG5suxAlhcJIccl6WJMD2z6ZheXxKgjLOWekMSOuJLD8VEkCso6RY0iEv28mQc9jBmcpuZBLYmFpZ01gRQJ6dXdm76tIfE4M4W2OEgoq0eyfdZIcPCwqiiAQnmm9tAUj8KNJBbfLqTwfUnwC+FRFOrrkvlD71J45EMpXVIKRHLszDLj1xteqk+UUehKH7v4bAmFpdam20ktFEaGNfFPGXtSJflBFgo77h8RpYxRqMh48RgxzvQCcf2Wfyi4iLZSLDFf7wSni6fDaat1fgE65MUJzmukOvCTHFe2j+vwvtvp/pwxkh/z4ae3ddi27Cg1e3TYF3RzeP8jHeYXc3cXy/VoTYs9ajymx6XY8G5Bvx5bF+cMchvTGy4INjn1OKReyayY0OOgfl0H36NHT8ffQ11+BjjzyMRLMgPCQ/f0vmIzYG3iwRnNmAHKPhHn1UkDrgmuB3e0GnHXJj1eazFiujZy8t64EbIYx7U9ATTCrrTW7eTSOO8rJV6LpFHtvW/h7EkaLWu7wkTdNGQ5v8w4GE+1C4xsC41E3WZM22ksRY9G+d6iYVd1TmilJjzXSFYWd5tQ/qvGucJ4sDKffdligipi40jSyXz0mc6U9pvz0eDypPaaC8CVDXQrPIWINB3o9ZF+htXhNUEAtwgqP3bhiZ+KcNrjyklSlyBkQJR1zl2C/wGWAqmM</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="632">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwU1I03EABuDDkBkhhqMh5PcCc6yt/TOTHdr7/rYSizWGOSxJY6PWzEMSKREiDJ3kaGwO3CixotGqjVjM2jSlNAvFFbJLYBFRyOhjUoegOlTPcz6/xKe6AkrMEWEvDCF95IQ4WCK4Tg+843F2+mW4P0iT8sEhyn1nmbWkGfrdgveeLCaHs1C8kAvnc41wNklUB0fFpcMS544bRftUGfutYe5795g7727hqc01uvw3EC4YxFD3AByPYogEJFG33IBEjQb3LuxGXq1lg0aLeDLC4R9Gobwp44G+JAOxPJvL9bjzTA9t+2dO2IuofF3E0ysSvasSr3zo5uUdKYz9SyG0rZFa7yi2m4rp+tiEqHKD+XAaOXeCwS9pHGvMoGstg9L0Lc7KXVztnaFz3EepYhapV1sp/2uAT/YEi54eDta0sXhiDjb1PHNL86j6mmL5Zj0XmoFpbYC1I6A/uojanjIaO8zIOsxcaFMwkDFzWfRzl3WAYx0tDO9xUKVL0nemlblqC/VOC/PfLdQdvc5Sm5Xrk1Yoflaw9Y2NKmclDcpeBiOVNP35RtXtatYb7JzaGGHCaId7/0VG4yqu9HXx10MXXsbc0HwK8WrVXuZOXuO5urf8D2wovfg=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="63" id="sample=1 period=1 cycle=2 experiment=31" defaultArrayLength="101">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="201.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10915.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.11465" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="31"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1137.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1137.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="67.080085754395" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1080">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNymlMUwcAB/CJqcOuJoqgTIkWDBlqlDEQBVH+ikp0mxHQqBRLaaG18njta18P8ADExiMgckVoOST0g6KCJSoFYVilWclwUqppCVIUFC9EiwfRKPo+/b78xkODYzmxPEQeymPv6OKBYy8bjNHx0TsYURFt5SNMnDx2rTYN/P6CaV8vIeq908Q1IiHWdY99/fOxEPOK9xEvGfXlu26u/kmEDbMD3kVzRSiccAWoGHvsT6fTZqSDt+CTDzswHdNDlhPeyzLQYHbqO+oyIHU0/987moHqyfyNVTPF0NCpOZnDYsQXBSd6aiVo4h8e6HVLIOtJa2M1HET8ys3WEUjhdizkO1Ok0N3g1UUdkKKz9fnhythMGKImnv62hAD+rk+azyUw4A7lJuQRoAyN/5TfIVDVVjpl2JIF01h31P2ZJFJeuC+8TSfRUL3q6AEdiWcfPvUvspKw7ReSc/NluHdurWPWcRkCzSEjQV0y1BivEqmJcjhGjclCoRwnOzmC5aVyXJXYZLPuyvEw4Xzj1LQc1Kk30fwZFJK2WdbEcSk0+/5XHR5OwX+o9Qa5mYKfvvX6650UWlx7WEUkBRN9i12fS0FvLzJo8ihogtfbm0uYV1hyu9BHgSt2V4eZMal4k/ujQIG/BtXkh1IF1F/CCP8+BWIyX8YUvFdgByZLnD5KxByif90dpMTsCH2PE0p4eUdRewVKGOMjpBcZF3gZFvsdV6JJNT5nvV2JoaRKi47xuqCrM86jhFn9852m+TS2P4pfsRg09vGK57oSaIRUnC141U8j2Oga7nPQCA+Q/DIeqsK/cs+mz4kqXGCx9VyjChdTl7YveaxCrI09KSpTI9A68XudSY22Byyhxa5GXHLbPU6YBlUPQsV+Jg3OLLS1GBjpK9/c3ywasPTnq80CLfq3cnIlIi2GDAPCtSYtvg5bdSSjZ97o61uM3q0lI7wWLVIaIsVZFubROZ9PDGuxXXTpsvm7Fn2nTkucxdloz4qcCjqXjdpBv0pDXTb8m2tGJhmJI5T8iScHNm5KZ0jZMYT7Xg5b80cu2lOJjkvcPHQ34prSPx8/AESeerA=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="556">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBlAFr/oUH4T+wFuNA+Tp2Qtsj70AB8x9BRgA+QuPDZEEnN0NDUpClQIhRx0DfpY1BBFIFQFib7kBvxAhATjnSQB3BjUHCFJNCIgcPQevo7EFIwvBBne8UQO5OF0CyMJlAZYUZQI+GGUAX6MZBBaUhQM9/8kA5vqJACAyPQYU5r0EKhHpBTHCsQrWd/ECjGClBNeBVQascK0BLwitBGCuuQNtQxEEM+jRCO3ilQaa6MUAzOSxCZ2iyQG26TkKYUwZByVqzQGD+s0B3VrRAHUSHQP9JS0HtcwlBunQJQVbRuEALzLlApj0MQY6sO0FvRzxBzpM8QE50bEFt6LFBFMY9QGFpPkHH43VCmenXQa58tEHZKkFBHoByQey/kUESGgFCqb5EQNZvxkC3E0dAIo3IQF6iSUEP1kxBRQcaQTrwTUDzj2lBg9ZRQdbY0UBWIVJAxtrUQN2sH0GZqqBB+OtcQjF0u0EGPlZBpA+GQY8B10CQjFdBbvZZQLD32UDtTrFBlqyjQfvci0G9yDJB4snwQJqhN0H5FHxAqGyu1g==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="64" id="sample=1 period=1 cycle=2 experiment=32" defaultArrayLength="98">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="245.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.011561868436" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10870.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.116333333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="32"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1162.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1162.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="68.642707824707" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1048">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxX9MUgkAB3BwrGZYZnkWZvecOWvlDM3ycmXfU9RmRWVZNzJ/8KNUgt57PBCkUy6nHXm6LrFlbYIg/ZypbOp5VpBp2U91raadTcPWiutqWG2trO59/vm8kQh6m3kSdA+qINy0DzHKvjPv3fsww0iCqkV50C39cL04PQ//XnTW/lCVh57LMaV+rhQTlz3iapkU4daBD6tsUpTSPYM5k1Jsda0i1BwZjnE+t5xmf5YVxBNGyuB8G6JK5MrBFWfyucsUGEHCwCWrAnHPasICbArIXsy5JWb3csxG95QC1wiDxTJxAKIvKef+azoIpVizOcNRhJtv6gs7UQx3XGxH/f5ihNvnMgU/KtHamX6lQ6TE0Fs5Z1bkIfCdC4Lv9B1C0ujz6V6eCi6UCJpEKowFPfK9k6vxGzNCOBVq/OEqsQir1Hj9V0boE4KEmru3J0pIwnj0vFOXTeLK6AqzRkpi4byXdZEnSXTNZ9zl7I0zEUNBdhL3D2+sme8hoQolIszsweZ2fZqXhL/159mhXApOX9eGXexPrcdjTCEUuA6715VAgb9jqmbdGgoBtrrbv7LXuhaHJ6RRcF8dbsw1UYhuLJc9+JNConNFUbKLwkR8iokeprBErudUR9HI+7ul53sBjYeOwqTVFA31KfHKoRs0LkjaOIXDNAja88Tup7E7s2X/5igN4vObx9eOaEDaoyfPs9/1jhb52EWFc3cv8GuQH+AIbp3W4Ht77++3tzMYE1yIqdrJwMMfM/KyGZjrLf21bgb9S8PqKjwMPslXL4/wMog9k/ru1TSDjRr/nqwQLeK25fSLsrX4hVvctNimBU9PZOW6tag8G7vcOalFtcHxShivQ8PTPmbGqkPEzfF/BoWlIAJzDN8mSnFVumnZllQ9fCVh8doOPeaNpynzR/TYmZGQlHzCgD21X7sH2Bvpxx+FNgMKcqWLJOVlSLFMxQmsZdDd6+an95Uh9UXg3WNSIxpqfO/PNRtRUZc1Jgg4gg2EdajzxBGMJtI6h82E9W3+z11+E8jKiuTUn47if5YFW1g=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="540">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBiAF3/p3spEBtGG9BZRljQKk8FEEmMe1Aksk9Qjq+JUL/ZiNBRlfFQHW2fkM/4YRAjSh5QflN0EF3hExBgy8vQb6hVEEVwo1AuKTUQDRIi0LJ55pB4DveQLRPF0BSyOVAse6PQfJuRkFoL59BD8WrQbELj0GTNqRAGsNiQStMA0KJEShBs4JSQXt5l0EMdC1AUqCCQZLggkAxEhRC358DQTTSL0B/VIRBLnMwQVIksUBDVAVBNccxQpaUBUFVyDJASBiGQEwZBkH/HTNBPVo0QGQdnkF3WrVADvU1QFqWt0AM7M9B1yK5QFwIDEGqPgxBQ6O7QNklVEHW6EtCNvGPQHLtP0BcrnxCzotAQB1LQkFr6HJB9VVCQR9Hk0B2ShNBIQLFQE9RxUAw4MVAUUwVQXR6SEAqC8lAlzsXQacWS0GcseZBTZtPQEGSJELGVVRBbdZIQmLE1kAT+FlBZvrZQGyDdUEz5l1BewWLQTNhi0HcmeFASJ1iQXInZEETzyxBfZv4QFGY20GPHoJACJudLg==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="65" id="sample=1 period=1 cycle=2 experiment=33" defaultArrayLength="75">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="157.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="8962.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.118016666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="33"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1187.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1187.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="70.205322265625" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="816">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwBWAKn/f5x74k6P1tAzBUbbrREXkDNUFrIOYVeQOT55tEYhl5A6vqdMsyeYUClcHHj9gFiQKtWcJtMAmJAvE3TNi1eYkALtUvklWNiQNg2WdzTn2JA8n6aXFXgYkA5lPesOCBjQFQD/Yy4n2VARq0qYbbjZUBcWP9GfN9mQMFYqwOWnmdAmVQcKJBhaEBy1Is2PqNoQF3yzXrvQGlAOru+rhBdaUAdLT8YQaJqQKP5AuXRP2tA29vqRWVEa0BPHRKpwkRrQHaagA39H2xA3c+ZDV4gbEDa1KcokARtQKGTns1URG1A06EhHksEbkCaruNW7GRuQEyprmqBhW5AeWoQstvEbkAPAQOQEL9vQHuCp6V2UnBAmiNBBmticEAfvzPRAJJwQP5q+gMgknBAb9RWXlfAcEDtuD3MPAFxQJAvKfV+AXFA5VkB8DQgcUDBVVTBWTNxQMouKAZmYXFANF9Rb3+PcUBaXapVrpFxQN/65QsKsnFASuj9ZIEyckD51jGA+2ByQGrqD7oSInNAQdtYkTEyc0BQFlbCtYBzQM8k7/gv0XNALMokWILRc0A/+95wI/FzQKaC/kCO8nNAsC/qu8byc0CRd2+1BVB0QLiThkW8oHRAB6EDQ8O/dEAairVNIMN0QMNtSstHEHVA3sF0JPVRdUDMKnBZM6B1QO2otPdwg3ZAwYyt+SYxd0DkG1ZLobF3QPhT0RDtn3lA/2hu5jKgeUCiFGGJ9e95QKlobD82IHpAb2xjKDg0ekA0C8dyzUN7QKWeIlasAXxAqXiAq7upgEDLPrViVjKCQGp1Ebc=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="416">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBLAHT/hfHqEGK4jFBYuNxQoqiskD76/8/YIzyQXiJkUGT+hJBQ2cjQfFxJEHgwRJDxk3pQV93AEIMiqRCSSL/QcImFEG+JjxBm08XQTHJ5UAThplAOVIdQOwgH0Bsxe5AcS8fQNAUykDW4DVBI1H2QCPqJEA0hfpA1JCyQodpKEDyXVNBakmWQZQrLkBt4AJBdoWkQWB+L0CkjlxB2FSFQK45LEIkAl9BQp+nQW26M0EpqLRAZB2eQX9ZtUBi7QlB/njbQYySvECefdRBGcqOQZ7wA0K66FdBp2ucQWtoEEFjjEBARkxCQfTMQ0HSX0RBxW9EQZVkFEH5DsdA8HrIQKeNTEHznE9Bs2IdQfY6WkAgPFpAC6skQZVaXEDlrlxBXdQoQbQlZEFx3/hAaAkCQWJAgAQ=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="66" id="sample=1 period=1 cycle=3 experiment=1" defaultArrayLength="7193">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
+          <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="3912.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="395.090204995859" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="6.6057e05" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.122866666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="360.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1460.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="64232">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwU13c8lm8XAHAjicoIkcrIJhkpKeVYGWUkWZVEP5VklmdPFRpmw8gKRZQdLbuQPRtkp8gKhYre8/71/Tw9z31d5zrnXOfWe/maRWNmEDz8JDpxkBUEZpNrN7WifBfkv8myg4BTXl8mE7Ueu1G0OTgIZu9+4o5B1ZW0j34KC4KPFxo+BIUHwYvI2EDpiCC4epJx1xtNzx96tDoyCO59vrzki0ZXfhNeQjttmzkvRwXBTT6C9Ed0W3VkDX90ELjEf0xwR53i7fV/obff8l2/HRMERU+c64cTg8DWKyLvYHIQ3MoInklEd5TIi2mk4PcB0f056NGUb9maqUHwMiSCNYSOznZ/ePIgCFiiQbXqaUFgkMvgK0MnXr5273gSBG8epVj+fhoEcw+sn6XkBkHTZN6jyrwgGDZZifLKD4JrxPydvWjRWesij4IgIEhe2TmDtqQ0HA0vDIL+ImNGG7reiHkppCgIZAa5CwyKg8CIlZEQXxYEA1t8d2iVB8ElG+3aRPTGidoSkYogWF6TXB+JNq8vHfGqDAL7nqOX+aqCoKBFUZGEnu8SuPkV5aAMJd+uDgLJ1K3+Ee8wTwtKsw3NQWCa9jj0eksQNFIml7e1BsGDPUP2fG1B0F3syhmFOp4cvTSA/rtvbu7TjutlbzTtR0fZ95SSO4KgVaxm6xe0986OrYc7g8DPQ89Rvy8I1nk/5V/THwS85q+UotGm7vDMwwNBEN6eEj2H7tTmE7EfDIJPd9+9PTKEeWaFX61B9f72mjwaDgLf150vLKbwuWFlhQ50M/XG3bDpIJDmXnFZMxME5P53fm/RwZXeiYofQfBt3d+WA7NB4OXhBXFzuK+0hcU3VN6KK9p6BeM7kbiH+Q/7afFn/loOAri2JfL0oiXpt/gvchJgvckh/TbUQ1Qs5jgXAR5dTotaQE//zFsTwk0ApYX5xXr0+NOCQhdBAkgJT1TMoN/nViLshQiwvPlWYw4qvHntq3G0lmaz7qowAc7/p2LntoEAa7uShGrRVcoMnrUiBFC/mLn6Mfo2G/4dkCKAoaLr1TzU9lV9vJM0Aa5fIatxyBBgrkzNugxdMOBcPCxLgFzh1c3V6LHnt1+f2EYAMOrN6EMTZE0TdskRwMxyKi5eDePOuy7Wok4AB8lEa0MNAlC3xkETmsK92XpZkwCSoc8DTLQJcCnm3dwNVH3xULb6TgLc01v8Nq9DAJlIu/rkXQSws6cbXtMngEuTcN1BA/ydiGfUTzTpzOZV00AALfPh3WGGBLhjd1lK0YgAIs3SvxPQdJ7IglmUo2v8prsxAb6ojp3cYkKA+jVpJpymBJDzd6b4H8Lvl4cs6w/jPk2FWuJWBNi8ZHNFy4YAWeavpC6hE2buDdq2BMi/qN4ofIQA28zYd9+g0t5KfE52GOdgQUQdelz5iJ3JUcz/VeI2ErpDqvLFenvMl9KSbq0zAfhUKuw0jxOgwaX11ddT+FyDiMYeNwKQDc3HH6DK7qxol9MEcK6z9xlD6+nWewvdCcCff6/Mx4MAeqc4tg6jy6fYLhyeGGfr0LEwbwIs1cybXPLBus3SJz+izTaJWvq+BBBrMdqXgcpeELIQ9SPAzbadUnEov+SZI+f9CTBV+EliDM09quNXGECAwGt3RKUCCXDOj+dlVRABFOYbKPMUjM+nLGsDgwCfK18pSjExviozpyr0tm7vHx0W9tfLLodraNlND6UBdLVG++qvbAIQ3I/FnwgmAEuF/OEnahamLnf7FuZdqHt6VzgBzliR6Ksi8JwbSB/N0Z81jTnB6DerBoJ1JO4X9mTxI/rDLu1vdhQBkveGeCtEYx/sDLmcgwa8GOjYEkOAxM5q399JBNBIe8KOT8bzmw+mElIIoB93k7MbnTgU/CAhlQCUDVFDsg+wDtrEvZloyUpttGQaAQQMHgmHodLXXJuGUa4ZwSuZ6QR4FnPjzOnH2N+NtbuvZGN+JoQryp4QYLLQ6NWtpwSgKwf+jc3FfmSVBPHmY/6r+fneoc166x68LMD7Y5qxX6EQn384yshAE5Xkq6LKCaAa2bfEUUGA0jaB4gOVBNBV3XW8Cy3kHqCtrsb7EJl65Bd6Z+ndkz/NBDC6UGRt30KAX/cEvdvQ/sw9jpptBGhZiEh8i2qYL6XvaSdAbDTkGXYQwCnn1cwjlPy03UWhE/O00axHvBfv/5lFuQt9BCDy1B3U7cfnWcefLKA2srWvcgcIwJ1i1qc5SADLg5OezWibgZ+b8hDWseh8cyNKYd2x2DBMgGLXtbIR6PHATFeFEQIc1BTkbR8nQN25IzvipnBO+Z1T0pgmgMTEQP0/lMfk8cnJGYzvQO7y4R8EcGyb9G5B18y7gNQsAdI2DKTcQKcXhiuaUcodeqrrHAG+7q8OGEcdjlVKWM4TYK8775Ezy5ivUzwsmRWcIxls5wP/CEDa+/XJDJo6Fmd2mYMI+woshtLQtm9PXxpzEuHQC7bHYS4iqH9t41xEWXZ/BF24iZAzLHb4JXqjS6XimQARLmXeOX9EkAgnbn2KH0e3mLAJh4SIkMatKD2DDo+X3jkoTARJtQKrblQ3j4O6awMRVPjIE9FojpTTW2cRImQGcL1xlCDCk8aW7VVbidCx3+KSjTQRnAuLm9+iFftfrEmXIYLPXdEsVVki/BZiH85HbadNCcbbcL1N022J6K+u9SRLOSKodRYSCtCJrkyNTEUiNHKRTB/tIEK83afP0hpEKNjT5x2Bmq1XyahA3544ysGvSQRRwfTgDFTSi2/ETYsIYydVmnW0iVCm+PlFBTppytm+dycRBONG4oPQwPY3YV91ifCaoalRswfzwuE9a3mACPefnBESNiACz4EP2xfRjYHUh3pABK9NpVbl6Ik7arrHDYlwpG56/A16jXvUXsqICBKjAYe+ozrtkyfyjIlAehtP0rbGz2F6Z2+i78UMv39C0//7JK9qS4TEN9MeN1D/Kwe0/qKpMjLr7x0hQtKt7APHjhKhfmdqxyxa0vuHddse86I5PnfsOBG4NW1fN7sSoai/OvKIGxFoSfdOWp3GeMJK/YvR0M9kfSF3Imj4DpQHoLHbpz/IeBDhQRl7qRCNC0/8c8ET81WZPKHug/l9GB+9wZcIKZePHKaiffe4hj38iFDV7aTQg9KnD7v5+mPcg4z/7qIsLYf/xAOIkLe80VoikAiKmpvLStC7yw9j/S8RYfAZyzaAiJ9ji/9MUjEPdq0SiXQinLcwIB1hEOH0OvVAJybmt/O08V9UlqXs7s0iQvQox8YH6Mm0ci5eNhGgJlAhDJ0VqO07GkyEakuT+Xfo8ehO1S1XiOARcXc9Gx1N6xXhCSdCq8ao0mVUpfYb9zxqSWxeFRaB5y84urQ+EvtFR2Z1DErYEaQsHkUE3310qEGHTe+Er6AJlRvG6NFEINJKz3jEEGH8+10B4dtEKG6pTs9CbQWfSB6OJYLBf0d1TiUSgaGgtdyWRISP5veFuZPxvI7RM87oRrfWzTtTiHD7y88HZqlE2Dax+Y/4AyIIhPT/CEET996w503D+KTOVyWh7bHbwSydCPL3tlRdfEqEVac5q1+gi4LF+5RzibBpa8SzIvTa9xjVrXkYn/y+Wxnot9VPPvvn471tDul4VUCE5LrHwV2v8R56HaTolePvHgZvVarAOi8ryESh87aHa8iVRFiQ2RLoVUWEU8TshWq0+kzp3FQ1EVR5+X3INUTg2JV76kIzESIvZOcrtxBhaL0S6T90LM+2IActsXjtdLIV54HroxBKGxEUvC52sNoxjlhJ7R70vg/n7O0OzPds38okurK+Mdy1kwiuq+ND/LuIcC7O2SGuhwhaJxZsptGSRz5ChD4iGBuXLcv3E2Hr6M/nbmhn/dWkcvRwu4LJzQHsy9UDnj6DGF8Mi1diCPvKaM/fSDTUr9zn6DARmPsNhQ5/wXqGnhz5NE4Et/2n6S0T2KfC7Ns3JrFvm6bTq6fwHgftC+GdJsLZr16fs1Ff1oGNsjM4r5ayEqx+4JzyvFKweZYIMa/X/GagD2r/G5OZw8+3/2v+hJqIrVJi/MQ5lPjwYve//8/Fe3v+4yBBvX6JXxa6y0tJbR69ytFWfIaTBMYkke5xNDicbUTiIoHCXZ4ULW4SXHizsSmchwSbJ40edawnQd1aqy1DAiQIEWtJeydIAtt13ww1hEhQkbY1KwXdkNKkLSdMgmqZzbGFaPvTT7GRG3A957kgQxESjEhueOgnTYKU6T0C5jIk2G81yjGMgsCLhgZZXI/D/MTBbSSYVMknvEAlJPQJKnIkoCT/YLWij1NCympVScB3//4eyx24jljx7mZU5nZkPEWDBDYKG359QHf7ucUe1yTBV51dH820SGBOPBf6Hk34wtVgqE0C7Zwq/+07SdCaveFzLLrqYgJhiw4JAjQbup6j26XrdH/qk6Bo2ix4swEJqF21ZBJaInJm/yx6fe/9zAwgwTjn/gNRhiRIG6hPOWiE55Y7ZWdlTIL/tlANZ9A0zt6MNyYkkJJ4qPLQHNe1oVD9LEggLFuUm3yYBL8eGsxxWZFAiZFXUGhNgqp+3x5RGxLcXj6/yhTt2L7dexw9u1lnusSWBGyq9pjGERI45n6OCEY17l32fYmmnjokcNaOBFwRlOcl6OEru8Z3HiXBpvHSxDH05uEU2R57Enw6l94b6UCCe03mOXMuJCCHH5led4oEX/a4ra9Bd5/zPR7tRgIj0ScNdqdJsKXYrH6tO8aX1PHBDd0TrerK7UGC7vdJHx+jTymrllIvkuAiMfvdvA8J+Gc9ZT77kuBhz1p2sB/WP533wBRq9Wdd7hl/EpjJ2f5pQnMUpR1oASTQMiTL/EZtND/lhASS4PIB8sQvMgm+L67y38EggUFB6K1/KGfpT5dXTBLY35SjXWeRoOf03eNz6GC4R4I6mwTTZQfFjqIFIfZ6H9ANPVaC+sEY9+VZ82VUO+T049wIEkTa3/6jGEmCtldn3fJRMX374qIoEqhahD4wjsE+yFkz8zeOBMyPDSIl8SQY2vZasvM+9m1WoWFWEgnenxqQFU0mgZprQcd7lNK+iSMuhQRya0NWElJJ4Bvb42T/gATvRJ//4kojAWG6toiMHrgms0EynQTxqd9OR6Eya9s2fc3CcwlrbWp4SgIhYZt3UrkkOB/94Xgj+vxzrWhDHgkEMoOdEvJJYG1QbDKFOnk60a4VYF16M8N5CjF/afSBOJRzuCBGqowEsV6kIzvLScBb51fUgoaG+7Q8rCBBBtHVl6uSBM/6u66fRf1njAUtq7B/7+9+VI0W77GkRVWTwLVrwm9bDQmcs//sHW4iwVqjKa7eZryfUX/i01pwDrys+y7YSgI7eR3jnW34vOjk7W601tBwu0s75neokFqLVtp251t3kEBv7kZRJHoveuuGDZ0kWPjtt3PNRxJI2q/tdf2MfbJ1LpKrD88bVS2Tg6ovq1xU7ifBGcqUYzwqdyzYQmGABDqNNbV2gyTw+jjTqzREgqmbUedNhkmwHDPK34m+37by58UU9nOy5DWeGexP0UPjX9AvEn5/Y3+QQPm9RMFLtLVbf1h1lgRBHEo7htDtIz4z++ax//57aiG3gvfkgdjiag4yxJ5q7qpFy2uch9I4yaBZGlQtw0WG7W09w9fQhlfc9SNoDC347BpuMmiVnNTZjQYm3a+/iMaUbP41J4C/q7H/+0uQDBc2b6+YEiIDD+ybMRImw9zey85LaL7gJpuWDWToSlrH5y1Chj/HlKJmUd97r8OebCVD0uMSbzVpMvzwtbKJQLfuFJefQrvuv9eiyZCBoy7IzEGWDN5ngq1foJrF78qdtpHx75BTyeJyZAhRfOFWiBI+KvuryZPh5hrJHRfRA0Hh6s4qZOhMVVi/RY0MdbenYsbU8d/TOQR3aZAhIk/qdQ96166c564mGfj8H38eQgvjmlzMtMgwqJP+oRGd8391X3In7lfecJ6NLud9/ySqQwam8irmNDpbtvMvvz4ZzPnWpu8yIMMYyfO0DVo/Tu+noJFryxmcQIZToX/Cz6MuJ7M5XqCPdZSuTKF37DTOBxqS4T40jE+gId0+dY1GZND+KZlrZEwGz+J2AQUTrMvetylbTTEvFwi8jVaY7+YgGXlrMtinOZhts8Fzr/7ynzvqG7RzqQfl/8H936gtGeS4tEP/HSHDSW997Tt2ZLCpkaUto1IcYu8vHCWDu9bEtL49GTbEvM4RcCTD/A6btkunsL5Z1Lkv6POGJ6R3bmT4L4ftvv80GcwE877dRw1ErUyn0VuXJY98cCeDz/61lBseuH/SMd7dZ8iQvKwsG+RJBoHdNrNl58iQ4nOlK8CLDAOdQ7oCF8hg6GLySN+bDO0Rx92IPmRYNGovXu9LhpeCotfi0NLflvNKfmT4fP/QDTd/MpicKiH1og8SqWqmAWTouFrzLwh993Htr2uBZJD3KT+oeYkMv3cceKN6mQxxv4Z9r9PJYPTr/fcNDDJIhrbrhqO7jutvsmaSYSY2eDyURYbcdQW+LWwyPE39Unv9Chl4NT9MmEeQ4dnetpvHIrEPgtPKdKLI0Mr1e/QxuurlLZGn0bj+rLmZXQwZxNuf0J+gr3r/pUMsGSxU99O+JpIhbEQ32DuZDC2TBzn1U8hgF1Fyqg9NctYvNUklw9RTv9lLD3C/PTZWYmlkSAvm4jJG79oEtBai3lWBrRnp2AfKJRslMjD+hPm1jk/JsKmBrsWXS4YSK+7+/1DFY6V3NuVh//2JkwhEv9WNKXxEbbnabvjmk2HCj9adgupphUt+R4/7xf32KcDf553wVivEPuaihKegrTuL3QnlZIiq2pujVYHPNVWYF6Pa/+L2Pq4kw+iqE3d+oonnOq5bV5HhEtvcSa6aDI90hFZKmrHPQsg2Li1kuPfcYfd9dPQc/0fuVjJkFudYW6HWYqubUlFD6jM9kzbMT/KtSOF2nCcMp6/QQYZPww/brqHyE8M55v3YL5FvV76iGpPODtIDZFDWqlK/PfD/+xRKFxwkQ7pK4QNrVEP003r+ITJw75SNu4k6Dsbt1Rsmw/V6k7sJaIaPpdgYemnQqfDuKBnW3e962PcV+3v6036eKTL0xKkXC0/jeW12El+jFcVCxptmML9jvBuz0Hm+4ssnf5BB7eHGfo5ZjHdFbjAMFVkobphFPThulFnM4bqnPv17hGYfrjrUMI95dSrpHFohwxUL+cbOf3iv65gRYRwUCNgmVzaItq478M6JkwJa58ru30JDqDunvbgoUNRxzZrETYE1jzO+cKyigJyx5/3z6B1T3S+fUckKHYmbghQ4Pu16S1aIAsW6s3vz0P4jLpL7hCmw6urO3mE0bLrmetgGCog8z7TQF6FAS2NE8Vs0+JPFKVNRCux2LWIKilFg4ktpsJY0Bax1WopfoHpq5OV8GQpwzOc/0pOlwL8bw/GdqPHHz5LK2yiw0fi5OBElLcw/WitHgXtSFuQotI5rOQ3k8fvTZ/VPKFCgoW9x1Sf0+M3oJFsVCjj5SJO1duB+91+OpqA299jxlzVwPwUn3wq05uCpT6BJgTmzac09WhR4xWR5jqEKVa/y3mtjHNlz5Vd2UsA3xOvIPh0KeIkP7nmCmn+V1r6sS4F4DkOavwEFBCU7ajmAArIa0TxXUXLkVOsOQwr0nOF+EI7K0gJtthhR4HfU9Ok2lFNhE98aEwp8sN9vFYZq74rZl2VFASXlWmthawok6g3sjrGhQJvotmoFWwrwUvPNAtGH9m/EdY9Q4Py6450vUKMp98HtdhR4fvzD1DDKPPD6H/soBeh0wsm99hTQIdOWGl0p8HIooD/4FAWanI83rHKjAC3+hywLFWKY2HWhOWEFnsGnKeAfmsM85k6B6t9c72vROeYZ7VceuF78eHeRDwUqubc3vPDF+m7m/37ND/d9LbnyA71g+1kwyh9/ZzfTHhOA++7fbuIbSIEoVf57WajFYu7bX0F4fkXP6nQiBUTXsHIl6bjvuZNqR9BjjSTODrSB54ruXQYFIovbU1yZFAjVfOzvyaLA7ZV3R7nZFJCmqlmeQDWqV/U9R8+cC85MDaaAWcRblfVXKEBMfs9/AN3ie4e35hYFJj0j2pLCcb/ZtP0HI7BODuyLeyIpcG0kWygcfR7/fatMFAVm6roTS9HVNFc9y2gKiG/tnUxEn3EzDcZQvVNdB/RjKHDA2nnoCqri0vHfCNq3NVw3KJkCcSMHzQJTKJDuN/tuVyoFRiX6vj5A1be+5T/7gAJqNzI8hdMokKkREleCvpD88LMhnQJ8stflsp5invPSSmRzKZC/49YuQh7m0Xj67xi6OtzzZ2k+BQ4KHK68UoD5uUPjNC3E+yuXdmgEvedkrM9ZToHhN091p9DADfsaaRUUWHgxqLu1kgInCh59vY2qFjce/otWJzg5K1dhHR3D7QWqKWCa2vPzMpr49vePb2jcpJCpQQsFbl6v1WlDO2WrCz1bKXBYgxQo1kaBj3sW/FxRuSs5uz6goffvnzRpx3skHrrmUAfmx3Of3JYeChDe3n7k/hnnRrrrn4E+CiSpnOB71E+B77PXGNsHsA872N/uodeCNnRzDVLgUYabXTq65sPZFyFDFLjRHWa2bhjnU2vDHRb6ubh43nSEAsliFK670xTYnrpnf9cMBcZK04NEf1Bgvpsu3IFGb68/JjFLgYvSzxKc5ygQZJH3hW8ez1mtTPH+SYHFq/sngldw3ul6suP/UeDyKh+PStSh0CN5EwcVYi0tR2PRd1FdrivorjNZUqu4qMA+4fR5LzcV+J8e+12PGkz4kRiCVLD2cexXEqKC2NLPZy1ohI/N9evCVJBpvLZmzQYq3Fp8oLdBhArNvtmMJ6ikg0GbvCgV9nmvCu9B1z/myZ3eRAX/z94vMqWpsMVeumoetZNUtP8sQwWK+o7bGbJUuCgpCOLbqPDFM9j1I6qYXiRhIUcFHvbJ6iw0nCx8WVQe4/WveiagQIX+q+/eCO2gwsySgO5nNCzSUVdRgwrDhMhV5uixCfv7uzSp4Pov4etTlLfHMXSTFhVS1isnl6ISRxIU92hTISP+x61A9Ln/30jpnVTYO92kFKNDhey1vfoP9lJBS7sofvAAFSZMXJVfGVChRKA93gyo4LblhWUWWk3IsF1CC2oEnWsNqeD+TcRzxogK3svHRIKNqfBZefnAi//rv7FKzIQKMWJmzS7WVLi+kZq7xwb3uV09+hH9vfbmixpbKlTeFb9RfIQKHs5smSI7KlDvJSmePEqF5QL3+dfoGjtF79uOVNDPV8u0P0WFZyn5grJuVJCWkWzMRe0u7rt49DTW879kdg2a4ZLTftedCkKOnlYNHlRQo4Us77tABRXLa3q+PlTo/Jis+Q89reqhWuRLheBol463flSwipfL2udPhVeeWyLH0f7ButPeAVRwOCQ/NITOGuyOaA2kArklqr6LQYV088xKEpMKXZnrEipYuH9p4sMQNhUSErUDfIKpEJ1VlP4MpQS0SPwMx7yJtQXeiKDCw4JH4Z3okTNyClaRuE7YSZ0HqCbX0gwligohT5asGtElPQ2fndFUqJqTM7uOSggPC26JoYJZWpBEAFr1sIPf+DYVNlvGPPuViJ+9rCp/JmF+fJ8/6UimAl+88IW9KVS4PU12GEfHlExvsh9QgZRfqimXRoWKzM0/MlC50dWGf55S4VqmUadPLhVGTkwbcOVhvffZSIjnU8FYz2LlDJrcybtlDCVeDTurV0CFTMcdumlo60RryM1CKliUZb6NLabC1suXHqY+o8LQTaGn2WVUOOG6eEq8nAo2LYK7OSswDhfyWwLa8uvgwCf0wavMgZVKKqxu4Mnxr8Jzdp/wWkHVW6as/arxPpQpCo6h314pv0ypoYK9f+HTwloqmPKFqj1txu8/RVGILVR4I9mqwN9KBeYhngUKanjCeY6rDfvbofBkBJrxpIep3k6Fxw7pCuHor0MnzQ534DmeDkmVohJnv0pYd1IBAty676Mju4m38z5hnLz4aumjQqpWM2WhH/N3MPFx1QCeIyJz7/NBKkwHlX/bO0QFOteZI2rDVPgkoDmpN0IFjtfR5wdRuW1uGxcnqCDe+XygbIoKf7/tmZmcpoLJxyXywgwV3t8W/8L+QQVhgfwrO2ZxHsjJr3OZo0JZh+9u/XkqBGq5L9xDd7qGZA2uYHzEp0qj/zBulvcFPQ4aEAW5op6ht3e9fa/KSYPEsQL2W/RHcN1+FS4a9HIKWUly00BBQjsnGh2feqjktYoGXdbxea9W06Dux0Dh3HoaNL02SD0hQAPe6FzaCEpcOezsJEiD5sl/dfVo2e9FGTshGvyT+i0xhNYcTWzPF6bBlV9b50w30GAuZI4/Cw0romSIidDg10atxbeodyVZxlGUBl/kRT82oh/7nbb1bqXBDWrDuLw0DQJ4TBJlZGiw727wm2x0T98lMTVZGhiMTLkVo6lpvC0CcjSoeL8p9eIOGtgFOKoLadDgQPUFhQjUJntJgUeTBg9V9/EHoq117ztNtDBeqbqGXNQpZjptmzYN9lp9FRtCVw+snKYcwPM/7LWWM6DB6UnTunNoEMFebCvQQLTt0pskND7BhrnLEPMmM7i+AgU35aOmRjTg93SdHkTPNgXw1hljPL/k72qa0GB+uu4chyUNptpOc5lY0yA/01BRx4YGVmmlzjloIbTQLGxxvau2WtnoJNkkSO0I7n/07DUhOxr8/TnldxM9o3nVW/Qo5uN5qNNlNOCChP5aexqwP/Q2pqOFOxNoSy400D15YNnkFA22p9zrPeGG8e0oyFh9mgaubzzf5KFXfe6vsnOnAfdMu+QY+viBV5KVBw2KxPfseIm+Tl/SNvWlwX75QVYOKuAT/PuoH+ZJ73m8gj8N8lZ0Q5+hzmo/pSUC8HejFRUXUOZzl6Fu9FxGa/vVQBq8Ousg1YbeNIDnXnQacMqF1H1CTzjpbE9g0MCU7ry5EY2D5bHzTBoMer3L52TRgCtKonMtG/PQedHRDb0eF7EkGkwDzTAV66orNDi++/k/uQgaiJzfFd+Dvl+iLO6KpIH89VGySBQNZHh45YtQq/94N+6PpoFH/qymXgwNtnF96ruLhuRuqem7jXmMmS29lUyDHO/0TxopuA+xcvop6pX4SiAllQaBXqZLvA9o4Nut8Vc/jQaOO9L75dNpsKV/vomKBhGFmjtQ5cnC7vinNDALM7Lgy6XBz6LCI3p5NCB/K11sQUsdnVSi82mgo+neL1JAAw1fpRf30LRUvr4fqHJx6YBTIQ1MLLZbZ6Np0lYaokU0iDycWXUOHfsssGftSxpkNhOevCyjgeCybcUSalAdLCJWQYMjbq2rKGi2S8Yaj0oaJDzW2iVURYP6p0cPSlbTwDqH6+NJ9MTKc+EGdHa+5WxUDdbtWUUxbwvWtWP7PToq2srfZtCK9bcbi2tFz+1wNDvSRgPKENnBvJ0GPi5zH/w7aFAcUlWwrZMG+hyyNSnog9Qnl3W7MG/X/ea2fqSBe/gN6bx+GrDohj+1B2igVqtMZqHzybcExAdpYDH8cZGMHr1yaPcjdIlt3r1qCOfR8tnPR1Ej1mB2P2p1pNkraJgGndmcrc9HaJBV1NW8/wsNvq583xU0gfXZ4/KQMoVxriqe0JqmwZBLnWoVmsNLDd85QwNjrV9m/1Ct7jVGbj9osEG/W6sUpShZDZnP0uB8N4/eCzTCN5dInqOBGyOP4jVPgwE6ZXvYPxowMks8plC5lIaM+xx0POeJQwacdOB1+EtpRF0ule0+y0UHu/wftGJU+qC0zXVuOkScdFE5toqO/+8jjAYI0EE/kzPeVpAOwlaONV0o1y3WzF0hOmRyvVNbQZNLTa9OC+P3pX6yahvo8Kllg+4Emi51xz1JBPc9xmWRJEWH3fIyZ4ul6eBJq9mXLIPrNKUf2yFLh+4v2xdy0Zn2BKsX2+jwUz3dNEyODgo8jxyF5ekwKkLZ2IcOFhp7WCjQoStDgqtpBx3UYw85RGrQoVI6KM9Ekw61q4oYj9CiP/1Vxlp0uPMk2vIX6u1txHLTpoN2yQ2vl2jhVIa+4E46PC0v1GKj6i+/Ry/tpsOAc8PXtwfocCtDtH8KXUWspz0yoMN2ddHoZVTy8tmENqCD8Q71ms+GdHjJNSOQYkQH34Wvb6jGdLi4UqD4D31+pVgmz5oOVbt9Soxt6PBFc9foE5RVti+r3pYO+zbsl7c9Qocw1d7kZRRSQ/an29FhwjPNg+MoHfw/yHbcQf/eZaxuc6UDnxtRi9ONDq2dmfavUB9S32OL03RwOCNnmohaWl5yE3OnQ4v69sDL6LYp+6wX6KXvcTW2HnQ4eNQ19R16/5BU3dMzdIiWjhau9qGDgfD14E5frNN7+bQQPzrcZT6p9vSng2Ax30XRADrEDJ7zaEdrFzj3+QXSIUPdlq8HHeCU9Qhi4DnlhPanMTEfFw66Mll04N84d/wfGtUXs9cimA4F46Z9e6/Q4UxDp3kHqrmugr0QTocG2aSq4Qg6HIsyCZeKpEM13deagV7LaV67iIqn9Ww/H0WH6743FZZRthjHslQMxhG3g3QV7Sd9Ph52G+MkyLHW3MG47A7w306kg5reR+LrZIwrc+dVyRQ6HJIp7XiAjmtdP+Wdiv3q4pvXheo+3FOy8wEdcviOOz1Jo4OWa7Dqh3TMk+i9kOandFg42Sb5B41+8Tx7Ux4dnjnx1K7Lx3isXzz4iZJ277a8VoC/50moPVlIhx3pUvd60Jq9jvTLRf+/L6WmPK+wL3j5uv6W0UHRc+FkeDn2lc4mJdkK1MPI5xoa2c2yk6/E81qVJMpW0cGRW1VFuxr7vr8M4tDFkcckmRY6KD3rE6OgJJvF02/R7XyFp1xb6SDRrpQu10aHqYKmDzNoh0VdV3M73tuF9x4XO3D/HxzNL9Bro3v6jnfiOiLeOvVo8mF5Q5suOtxkN28b/0yHtbx5Og79dHA3U+YNH8D8lZ47Tx3E/vlyK+Mv+qX7z8qLIbyX1ldC9wzTYSRjrV3GCB3axHhpf6booEe8EfFsmg7xLeP1P2cwrhuxPqd/0CFYYziiD71wg2pImMM+Hb30cQod8htrDp2nQ+ynrO3X/9HhuHCawkN0Re34+CoOBiSMDO+6hOYcjFNR4GTAyHvRljj0rE2GzQYuBui/CP1ThPbNrT77Bw2eKGZ6cjPAmNR3ZRS96T3v77KKAcqiPWLd/AwwyeVR+7yeAZ4zNd+DBBjQLjh7bb8gA1IzpIxK0OSiEk1eIQZId/iJsVDZGocQU2EG+D8x+7l7AwN2F7uIUUUY0DnQpz2OWs6tFzcQZYDUAHPmgDgDMr8I6etsYoD3wdl9w1sZ4Oj3b7O0NAMenI8Po6MHXpqbq8owQDDG5rW6LAM67B+t/4dKzLzMXdzGgJcMEedrcgz4pje5WkueAav+lpr8VmfApxOjasYaDOi+pf2lGZ16fZRzjyYDTtaR+itQy9QdKlu0cJ8zQ500dN2+0HIBbQYoxqWVbdzJgHf711Em0BP/eSwW6DCgS+C9jbYBA3j76CALmL+W1Wr3UcEHKgP/0M9tfK9OGDLgqFkOx0P07P7RfEUjBqx+OGjLZ8wAVWKudx0a2JBb8t9hBhDOeodaWzNAl2+XrJYNrj97KEvRlgHiCz/X/kCTt7+aunqEAdxT4ran7BjgN/lkcQ4dff1ft/1RBlh36zW12jOA731qMq8zAyZPdj2LPMmAnv41M3RXBhR79X5cRrPjZqqaTjFA4Ws5UdaNAZXaL06T0dYnTzUm0JVDi16WpxnQzJvLiENlb2zISXNnQCyP4mrwYEDL6sm0AR88l2vRVj0/BpQIzjze7M+A2RRd9xsBDHh8lrClB/0h8LVFMZABa+8FDE6iN5R7uu5fwvzX7vxFp+A5lySKYxhYB67Hga5MBtCv/+FSZDFg7Oa1r5fRFcrmGHU29lW4yp9YtPXdf702V7AuH51XOiMYEF+nHKoXyYAXBmt5N0UxQMvx0q0UVO3veMSJaHyOWaxbh7Z4bYq5FsMAgVRr3zO3GVD+9sLO7Hg8/7yWolEyA+6+rgh6jqbdDVjwTmHAdFJGdQV6sfSNwZFU3Ffu0tEmtKY+vuPMAwY4xyVpuqThvfh++k8R2rj8zX9NOj5/PP+HJbqP1lVXjhYGXBF0eMgAw1xBZm0uA+qk2RTlPAYYPXzkPYL+fa+abZaP32eU7LArwHx5VBx7V4h903Uww72IAdvtc+dG0KLujyPdpVi3ssY3O8sY8Kjbt2d3OQOif6nRw1CVuCbbdrSH8426eiUDPpKfj4WjrldlX56rYoDV3su+/Wig5AE9lWoG6H3Qza9ATX1Gftc0Yf6md8y/bcHP1Bk711YG5BPCX1SjKloNEefbGHDJx2q1WTsDco1q2e9RsZ4NlxQ7cA7Yq2csoR1l539adTJgoD7h+EQf3uvnV2sU+7HO4Ybf1w8w4Io4M84dNXh3vukTamKrnBc6yACujJRDpkMMsHhM8JIYZsCpNolDh0Ywb3brPr5G3xS6nQidYsDtcDP2b9S6MP8NdZoB7yN/alSgEmZWN9k/8PdPQyVIs1hv2S2BC+jyFRcu0hwDtvSZ+52eZ0Dem4nJVtQuovem3wIDXiUQvIT+MeDOwnU9M3Qx+MO0EQcT7gR+vuyHlk3VVbWgI9biLA5OJvRaeFcIo4bf1Aa0UO5bTsap6OauU5PtqHuaopQMFxM+SBpevbKKCaddFPZb8DJhNONgeg9q2DLQVbmGCV0OvMIifEzQVOyKvYhq6KsEJ6J/C8ePDqG+m5vCv65lwv2wfYq3BZnQvy5vdAjtuWqktlaICUqNp/SPorYHfr98g15ZM3H5B5qsQpBXFWaC+sVFuTDU8rH7pWF0NkVxQGADE/6ZZp4+iNYVaSz0iTDhZ37oKk9xJsxNJ7pXoztsZtYtorVTfzqKJZigtmnh/gxql1jDktjEBB3yg3/GKM08szAcnfouUVuB8pOEydoyTDAddUwnoykcqd5v0Vouzecj6Jnf3+OtZJmgS60UnFRiQvBzz4SNykwI2rt88Rya+1feJAY9lVDRX4C+uLO5/YgKE+6yKSadaM9bE+9Nqkx4bbW68OYOzFPZ1QNvNZhwwa9BfwW1SicfVNPEenmpCDuiGQ7P4kPQc3uyD8+h50XW5ttqMWE67QUpGqUIqF8sRnPSrVqXUUfhVA1rbSZY9C35+aJc+/lUNuoyIfOm8usc1JBW//4zGpY3tG71HszD3bFHBHRTu3HpO1T1mGyXkB4Tum9WKB1BybEn9vWgBwxPcHLvZcKv5G4TA5TnK63+DpqsbuCQbcCE44t5JxtRy4p1PzYCEzpVuZQt0CtfdkdGo394H9l1oWZrCOLLaIx/k5StIRPvr9z5WPTltdSEcdT+6LlkbSMmLFxnGgajY11J0Y3oZTGX98fNMA6GX2EsWvejcbkClbPVmzU1Z8INdVH+EFTq0eSb12ipRjOfkAUTbK6e0nBC43edCaxBv0jNWayyZMKt9jVqeuhU+Puwi6hQlchljcNM+H7FWTDZmgny4zlWxTZM2Bf5zcvclglbhPpot1BJ5Qv8Fej0ha/P/qD7BvnPnTnChKeJX1pjUcU7nDf6US92719XOyY4nSt/8sSRCfUB90T5nZhw7BOHcBga/8R3qhZtueTLy+XMBJe//O0K6LvRqzwO6GlOLtJT9EbNCeOPaFNCj7CMC/Y/v7edB+orcYQSgnak3Dh96SQTjJjNDhWnmOAR1Zyh7caEGRco8ES/iX8pTEZVG93ku9H0d+SA3+iV1wQLkdPYl/2Bq3TRsHvmTsEoq3PgPrc71vV+mNQBNNJPNIlylgnrljiJOehqT7d9oufw3lCyOO3Rr75FPMHo3/ad+hloD3F/7cbzTHhcFud0EK2afPz5Hhq+/YDI9AUm6Cfzi+X6MmH/ZZ0/0+h/x/fw8Plh3fh22+5GxT9XiASh0ekL+gXo1owBjq3+TCjsnG3MQrfhfzc/oI52h+LkApjwRDRVxYGA8TnOHohH9ziZbx9CpW7F3lYiMmF4p9xgAOp2nbv4KRohdkynEx3xiErnITFhzdfcTkP03YvnhlGo7B+6YSlaTvcseoMq/R6f2kxmgsMYl6AFSrH1FudgYj8s/z1xHI3JavYMQUs7TPNHUaW+Lu0dLCZcfK237IbmTh3+XILSz1iSfqJ/WeTn2mycm0fE12WEYP3JOw32huK8MIV0R3RLzrfd4WjUXc2IWfTnruvPIsOYkMhTpRgQwQTXUvuZj+jlcWPX2kjM11ZGn1MU9g/DUDIBjda5EDiMWmdW7qdH41y2bZ+pusOEg96Wd47fwzw8Vt+7Phbn+/fzq4LRNRE6Mt9Q/pjECbs47BOQPJyHnvicOLEmHs+3bkuvMVo/ePJuSTLue9EjXjCFCX36/Ieuo2HHTurNor81RvrOpOJcJrx1yUTrzAQVOB7gnDwZme2F/nid4p6N6jfev1+RwYSazND6kUe4jnb90u1MJshMRC68Q5WvXt3jm4X9rh9Y24i+5Lp4TOgx5u+IbPZJNOixdbRjLhNeJT1+HY2O/exRmkTfunaXieQxIfWJ52dnNKTcdyYaVdhWLzyEbrt0LXRLPs5Ba85tx9A7kU3ZOag/L9eDUZTwu6hKrQDnmuWZDi80KauKn4bKrSmlcZdiXRWSLS1Qhz6hpjT0pEyP4Cf08WiIyhQ6TLt1Cp7j/Qgj+LPQSwn3XpegGmIXbhu9YIJw68igWzkTjBO/nXuAfikrHltCaYSmiogKJnAUtG1sQffsuZu2vpIJV99I1h9FGy+sXqxBbz/bKPkXvbPqv4JLVRivncz3LDRew2+ltpYJH3mz9s6ib17+jZCsw/eg3EuHDLR8/9eLvPWYD2HbejO0JiQx9j66oBRr+gZ9IGX1dRxNeZ/V4PwO6xOmbRTWgu/LR6JB79G5qNhoqVacC0rtPq6oo6t93z00+5Osziw6fbD/5/E27NvHJ8Tr0LdrP8VotTNhrQZPaRgqwPfSK/g95q/zgKHOB5w3XNYrZ9CO+peJD9CGOhfCN7Rz2ZNP6CP263xj0Q3UhfRyshJ1luad1fjEhEnL1+Xy/UzwWdW2Jhq15VV0nUT1HoZ9URvA98/PioeX0LgjfxiNqNUbKpNvEP9eUcq/64nuLUx+mYl6G+QtbhvCOlyIVs8ZwX5Yq8QT/RXvaxJH5+5vOK/S97BIqFn2pgtJaKWa0IFqVOz6IHkJDW46xbVjjAkbp6ih0aibnP77BZTKO8KrOY51EOpp4/qO94vkt+bYNNat8uZoKcp/uZKiMMOE5o5HNwNRoQLDjhfoTbM+2ij6IV+6z/IH1snvv1d30Kgq+eZBdMdictCmWVxX76q9P7q9RnuCdw7jm0wbPbaA75+N95uiUY+8UDuVRZzHr18qXUBv+VWvX0L/O6hecXwJ5+Hvf5N0NIQhho2H78U3VWTR30zYpdxnWvuPCSXnD03LcLDge/y0UQz62VrDZwb1jmUmGXOyQCrbQPMW6vTreYMRFwvagxY1D/Gy4Kx+Inc6mrDctNSCFr55HvUbDbybrb5jDQtCuQOqXqPtfqKcl/lYQOVwXtEXZEHQmvqRp+i5BwWuy2iUSNVvWSEWdFwwdb6MKhzbz/0GDfWR2aEnzII8r/ftF1Hps9PeMei2SrWyNlT8ryz/6g0scDf8k6KJev9pK3dBZ9v6eNjiLDColRUpRQ3bm47bSrCAI72cpwTtrUssX7+JBQz7mQRzNCHDd2skujt1ZOskapakbLVNkgX9AYl5Tuil6uG96dIs/Pv9+9ZeVK979YkV9NFS8vN9Miy4v8V30hOND9MSrEXP87TvlpRlwdhH0lci+jL7d3kpumtzy77V21gQELfWcw8qlO/NqaPEgp3k6KQkdC5lS0APqmMcG2OozIIPJs8mc9BdU8RfQios8AhM4XBEaTct0mvRN15x/zhVWdA6DFcuouqH6S6GGiyYlxsPz0O7/raoz6E6YaZz1posyPTaqFGK+ly5sO6IFgtqSVFpyah4VAh9AoXCbYny2pivA2d2XUVnOf/7dVSXBT+mib/q0LUr0V9V97CgpbL2visqYj5zMh79fjtWsQk9WjwePYtu9FBT2qvHAt+IDWLRKHuGX6kcNfiteUpiLwsoidTs9AMsuJESE6htgHWR0W6sRoezGie2AQsGLknZxaLvm09MyBjiuUuvzTDRiZD4mWL0xe+V47xGLLj2jFvVA9WlBoT9OsiC7F7f7EozFuRu/1rxA4UcgU2XzFnw+O099Qo0j29hk4oFC46HHa2PQaUaD7a1ojqLF4lWliwwObPrKw01P6vA5LdCL5uXNtuw4ElOuLi7LQsi6tbGJqAm/+3q2naEBZobzUWSUUPO3SxtO8xH02E/TXush3z6mwQHFlyfdH414MiCLK+csnVOLOgc/1DKRA/H96/9gVruWwrUdmbhe2upMBsNvvdNUcwF87LuIL8x+nW8+W/iKczfc9POT+iwzbWg3W4sqAi2k89C71m5/GlFN2taVHCeZkFzDE+TOnrvfOSjRvTm6ObtS2jLi033ZdxZsP61obYjOuxfu1ThyQLmQyc11lkWpEu6aFSgeoZ3j86hjdu876ieY8HPIoqdMyp4MMQkHR3j5lmYP/f/Oj/4cvE8C8rsXq7l9MJ9Vrpe70Ydns+37fHFPM3zPbmFlvqR/D+j/qVJRA8/7PO9Nk3f0P/cnanm/iwoGtxD/YVGxkWepBLwvl9vmvuMjoXfOOxIxPpt8R2qRXPvs559RrmrJgR2k3AO6Rzbz0KtFGxiOMnYP3u0buxDLXTzPjahMpSnDnMMrB+9eL8RkwU8dudEUtCUVL3xD2hWBfmKAIsFApJjN3TQfokLq81R3S+55ZdQ90Sl+G+omrfGEXk2C9bNC1s8QjnkL/TMh7Cgewe5xCWUBUlbOUx6UYGyc0lmYdgnAqnBN1ElqX/nu1AfSZN3Mtcx71QxPv6bWAdnbQtWBAtecYyLzqAvefb27YtkwUGBf50tqBj/L1u+KLw3h9MszVCanJSMPyph+/ZhFVqaHDDxB6WnkdYeiGbBasPPW3xRmfXfyyPvYT8zXy6OoW8/fWvTjcXn9tcevoCOpflvTUNDTVzX1KJL9r+P9qAV+4WqdsRhfB8/vD6KvihXt45GTwSf9RKKZ0GieNSv3fdZEH2B81B3Ms71yLpJcgrObYULdrnocPfjymXUsiBHd1cqrq/DsPVEe4VrrbPQbHEd6lu0I+1H0iyqoXBR0/gBzvFwngv5qNLfuhC1NBac2bFw5OIjnDfqkn4RaMH0q//eomuGq16voMUqrsInMlmgSChtbEQd9pndVs3Cfk+waPoPTTodzt+BNh7aL7/qMdb7au9TX/TKHZewHnSa7Wup+hT70nqwdB79tc2FOzsX+//rzLkl1OE236RiHs7ZEfPP/uipgmKZt2iSiLS7YD4LpkbmncLQD7JlgeQCFoy8Xns4ooQFWr3moRVoaFtUKV8pxstIubcfnVhtEO2D6ltVLr9BUzyTb6x+jnXLObPHCI2S+aBYgvaoTT4yfIG/P1SqwEDpIr/fPUPPcPW8/l3OgoxH1rf3VrDgzpzXfhJKK2TT69HAHFUB3UrM717y5Xh0u8j3LT3ohcLLlpJVeB7FvY31KPnuzx6eWrx/W9slUtDrsWkmK6h31t/zW+uwn5ZPnzZGT8+upt1Cf0JCbgUq8cPUegL9MbomSrCeBY6nQwP2oW5y5X8foF+CBzQd32HcVw1c2S0sELXaYPARXdzSe1OllQV3+UxGE9BRTT7X32hl8b9s9zaMT8y3/CkawrFTxqGdBXWGuryn3rNga5/qwh30rOlC7NYPLIgZuG/ogM7UN4tGoY+Ol4t9RN8ffyXK+RHn4qEND3TQebLE33NomNSnR/fQuZknDT/R90KXC8w+4ZzSXO1r3o/5JIy7lKPVwkSxMbRk60cX/wHsl0fiMX9Q39r0zVsHWcDyURqyQeNIIxGvUYp+oAX/EM5rD/2nRV/xfv0bFdf8xgJh5SORZ1H1cxtkM1GWaZJJ9/8//3SIkRpjwapULZ9Q9JyR4Y7AcXxfyNXdejyNn4szlD6h42E5Pqoz2Dd9Mfm/0FvRLxs3/cD3ZoaLpi86WX8lYwi1jj0ZYjqL57oinqs8j/3Uax9ksoB193Fwz0TbNs1cW0EP31/ZZbKIzyls9YlBpXr/GNSje1UuvlFaYsFlsvNNNlr2TlCrEZ0tu3jf+jf2/7XzDjmoWFb33Vf/sB91unVkONggHZ/V645OO2tLfkfj1tAYJpxs8Ko8aRCCVp66kJuK9ij/9WxFtfzuy0lzseHDOekvF9G0kzUlGahrlqV4GS8bbso8+aq2hg3bb6pw3EDZn9yLv6OvR6k0WT42mOYG+Vmi0pr0AiL6coJT7CU6/FM3ZQj1bNuWL8vPhjdzmlfvoC4WRmkMQVyHry+4CL106U6bthAbDm842fYC5fOyfD+FbuEwyjwgzIaBnP2mVDQwQv7da3TwRdTdf6iCiC/1xwY2PLdJXdstzoZ7O90059AJNe5hHQk2UE7sCAxGbzxS1ylHvRhmnjyb2BB+9LeFBdqyTp/CRsUvupxtRcdG7LVWS7LhZHSIR4E0G8p1e5N+o88DXGm2MmzoNjMsi0WHM7JSlWUxX8X//XRCvSniwddQ0ibFby9R6xwP3XQlNmzyszg+jO7v6jVQV8Z6jIRWhqNnOueC+FUw71e8Pjigd4zUG6VV2RCdyp9aqIF53/FsYZUmG6i9LysOoSrURec4dPNF+qNedKtRQNpfVPpM5MuNWmyYO0G2NkLpP5Nt2tE7iU3rubTxvH8y3u5Hh1TNwwPQwjP8v8J02RBc4reNaw+uW3ZtPhoNfBUrtoLO3r1fpafHhvFrnu7P0KmZuLGNe9mw8334vkNoSd7e5igDNlw/KLB6FeC6lStnLqEmmxL829E1m3UHlAzZcPn60uJxNE/w3sOrqEf4zrAuNOjkCEnViA3n1hdwF5hhP3ktKPOYY92GBKevoer2LHIPmq3qF+puwQaxoQNc+egAXaCrDtXJuhIrYYn9kxGocxIdld0oFm/DBn25uKhmdEvgkzVrbNnAyDxBv4AejGxcGEQDKzYnBB5hQ/5ficRJdCfX+/cydmzg3GeasdmRDeuvfxx6gRbWrocl1K2GpXbeiQ1Zm3uqnqGKUa+3BTmzoThotdQvVC9NxHyPCxsiLaoePzjFhs4NSo0T6Fb+koxQNzac+kQaeINevvLUfwEdm2bNnD2NeVqqKFN3Z8PjL46PX5/B+j+muGw5i/s8ORl+DP2tdzM9Gn0V2sszgn4Pmtmjeo4NzgLV556gcDqDNoZKS21i7jqP/R1xPpCJWobx//7PC5/j4b+e5IOfG7+XF/uy4VrAiruYHxueXXVX2YemmHt9aEa57RSfrfPHcx7L2uiCrqsKf3YTzV/85lyNigd+CuULYIMEoSFWFy3lNuLNCPj/Og8jiQQ2HFdq+fsNted5dm8HkQ0jFXEPDdH40Znd19ETlYdP16CrRvx2bCFhnTd/SnVCRz1+8YWjP3JPEdvQhf53N5TIbEhPTrHyRCcS3AWa0G/3LOcuMfB7VQ9SIfrh4e/I1Uw2OJxR1jmFtr4/zI5H83c6ajX8/7Pls+Ff6LPP7WcPsdjwTzVkcw5az+dDOMbGukrEaZFDsM6XLW8+QvNHchwGUI4wv2sbQrGvbyX1G6Fek7TKqyjPKseGQdRJMWWrfhgbNkqQY6tQ7/gBV9MINhT9mxfKQI2tumcW0ZE3/aIHI9n/o9C+w6l8/ziAaxBaSDK/SUkoWRFJHyqRFC2SLYVUVKJFnD2EhlURKauIBmkYDaNSEqVlJSNJlBD1e//+el3OOc9z3/dnPedcFypocVhyBgb//qBaB/9JqHAnxWIfYXvjzOBZ7jfaBW+4at96DhMerEsIOBVJ+jx1rVWn0W+G4rfEEiIp7Wx+1WJ4beLUCjtYqHXaMBXyFkuxDRIjaU5q2+ATGNcvaxafFEl2s7fmbk+JpMybzI77ULszdOaSi5GU+uvohBg40z280yYV/bH1dnQF/DF7NGMMJg0Ni1umYf9f0g12Z0TSivDo3fnwn/Fe/gCc4lr+WT0zkqSezSy9AP9tf0KtUNk10tY6K5K25Ew5GAOTniX/eQzX+EdXMbMjaR6/dN6yPMzJidfOp8I9818+boC2RsvNf8D9a/l9Ltfx/Klf+UkAi6SY32TzMf/V7w3dgM/nGKa3wGl/NKwWFSBOm2OV993GHL3hv7iyEHH2jpeSK4qkDYN3jbfC5nEbV52GThVGRZJ3IunqmS2NjtC3QfTWA1j+ZKvYX/ho6aGTdsWob17s/J3QvsY+cXkJ8h1jM9YI8yXPay0oRX2v22u8GWq2nWs4AyUnCbkTyiKpabzGbSd44PI685tws/1HEdnySMpY3rfMFcpH7NrcWBFJHRKHR1ZXRpKuqu3tE/BD3h/n+/BufOK4fqgfYc77rwr19NS8MRR+9WYf+gX/HnEbePUC+2pwsZV9iTw5FI+tgcMnx526BR+3/Pw0BM2iGyfq1qI+up4W3IY7kqREpF9h3SbZWi9Y1/Sz/MIbPL9GfFJrodq+9d+GYLuenNWst5HkcPGhiSdUT205nwljhfreXfCKcv1ek8ZIevhyhud+OO6FeUwxdKhazFJ8hzruqL+RAQuC/OuWNUXSJ/XNd+/DFBJbZNYcSWNLpwW0wtn3w/TntuB7h12grgs8HmmZHwPryc30Hpx2jHdAsRWfb11UsQPGbbkk7dqBOtqasKsVjv96RFOlE/XE2WfrCr8oin/PgW3aMtN/QUnRa8WmXZE0eMU5ngFvScxaUAu94h8s/gsVTJ6nb+7GPDnvHZAGg0XufK2DjrMDumO+4zmy/s9oH7wi8Hs4vw+fv6Hv6QqDllgYXoHrs827J/1A38ySe3oWVhlkcGX7sf9zO3kh0Crr7IG9vyMpZEn+zj+w7N92v+tDuE9n+/yZw///fjC1IgDenOy1dtUInntyX8vZ8FZliHj0v0jy2ylP9ZC1t79UXYRBbhtS9rvBgk8uLRVQq/zszsnjGDTJb16JEwy5nK94Cfo1WeeIjmfQTyetl/nwwGiMSY4Yg1S0f5kfmMSgTfzXL6LFGfTc1/tGN3y1wUi9U4JBOXGyu45MZ9D63G+PJkkxyCnmpicP/nZ2ZDbB0//lifpJM4jXPyD5FF63/nVRTIZBk6edG9gIR63P3fSbxaAdv/P6N8szqPzsvRAOjLMaL3YDWkzUJVEFrLO3RH4fTLZpPX0fRny4aDJOkUGPHykuPAKX1zjIB89mkGpT69tcaH7yRpCoKoN6lu4c3gqddzA9P0Hpvyn6qnNwXkW926HQafrP7bXw2SSrCSvUGORr1NCsqMGgsHGevl5wY87IuxvwUf/MvG0LGPQr3HBiGdQSD/ogqok4nVnHEkL94UVz1bQY5N/ZqB8MPz+w6JqwmEFV9ltmaMPb7E/Ne+Aln6keBfDB1sygVhjWvNFFShf3G5u0Zh+8rWrQPF6PQXOKdtiGw5qb6Rua4dMnVaXb9BmUV8GRcTRm0Lilp/7lQrnrl9a3wEyNl77WSxkUXTTx5EdY/HjBRUMTBnFHiucEQtPGaQuTYA351HZDz4O+hstMGeTyfFJvGGzRefQyaAWD2gwdX1ZB3V9+djqEdV3nZtyHGwMPZHyB+WP1S+daMEhnxqpvZ2FWW5paA7R68HnhVUsGpcdXyV1Zw6C/ak9cxlkzaKVk5/twaGUwbl4jfGKysvesDYPqFvjG1MMvo5reQ1AQE7du21oGzS7WF7sLJ9iJ7M3ewKDLjfGX66BKnUOyqD2uK7YNsoYzWxrCr8FUbleQqgOD2NLfdhTDjaIVxU3w/l+D+P824vyH1XPGOTHoUOfoZl246lRWKRf+Jzs56x2sUPpUYLYNPp/o/wF2Ki/9oe/MoKRx2mU10LxQclDojuvXWIxu98D1Sfk/H0G/7FeN4zwZVM2V2mIAkxtT15yFdc6W48fgjA2+YSO7GDQvVPzQHF8Gqe1W0D0E570+UqPsx6DWP6aRX+F245Pcwn0M6goLf9kKb6zL+GAUyKAjR9WWnYBylW+mNkLr+9rzKIhBudNGc8fvZ1C31lLrA/D1eaW7ZiEMunvjpT8burZLpOiGMmhrAOvjSbjn+56EJYfxvueLpDsw5M3vKQPw8TxJ5TVHGKStxpqfByfzm4JWRCAuB8PM4mBg+DP8jGXQtoYrf4SRDBJq2qt+YzNI8677y2McBnX05rPKYP3+0LvjuOgzmaCfwdCQKXOvDMo9aVC14zHoVqPas9ew5fPThYV85NtPacafaNSv8d4lL2Jw7iW9O3vgkin7p+vHMqhfvV05EjqVOqvdgJ8csh/3QEe2yuT8eAaNBTdMaIKlT0tGB2Dcq5LiswnYx3QX3Rew+MfEU6qJ6NPjiX5b4bLvj2Z1wcgqbopOEu6/b4dJaQqDtnzcPWXGRcyjtWd4b2BesGuOXCqDmqOWmpjALydfHdkKV89dOf0BHPnRvl8kDXUcnt9hCgP6Wry/XcE+hmZJW2UwKLZhyfY1mdjv5Ck7BVD+fNfIM9j2pMvxHzzU87tqQxaDvq2viz8Cf+iJdlyGmY26qz7Anbe8fdfnoZ7fJ6Zfgq9Zd1b+ggk/z+dsvs6g2ruuCnvg9n8/x87D/uYkse9wZoHZAcpn0IZ9ma9mFzCINVAk1VKI+ZyprLWrCPcpkb/zBOquXhlqdwd9JSFpmABbG7ZVvIJ/EhPeri7G/N3hfe8C3P3UaeryEgbxY7adOwvDGVNa7sD1aadZuqWoi0u73J2gQr753huw/FjK21b4zzoibW4Znh96mzWtYenGK1cOwsPmr/dlwymZa/9OLmdQlHt+1J7y/19fY1pWwaChoYA8jUoGXVgg7nQdTqDY8VOqUIdXU4J2wh/L5i7Oht9XqTxvgyy25rst1YhHptP8shcMGm6dqj4Kz27sP5XyEvOnV5rRAOc7TF8yvhbzJPzWFXM41LDy2Bm4rfTK+zqoHTK/f+orBvUV/W5+BtcsPTFg8gb9P99zSjYcvHnbSfwtrjOZJxIJnZZN8PwBE3cs3ju/kUH2lrOWb4PjbSSqlN8xKKVOU94VMvVL44LhnZ4DSQ+aUD+H737wamYQ49WvgKdwpvG3d9taUGdV/b2P4VF2/88FrQxa8OzccW4H8hj+RqIXTggvL5HtRJzKpyt4wcQntsoCeIQYRVXwTvGnoS5ool7IUOjCufXsT++GZyduvq/UzaDFPPXuud9R50Mzkgbg0x+bIzT7MBefirTvhxM1lCOkfzBI6tPBzY4wYfDoV+V+1Lfpu9//DWJuRtQyE36jj/6uOS01hOu8DcyCoJKx2Oo2uGYNO2XdMJ7zY87v82Flc9bKv1Br2Dt99wiumzii+fYf1rnkdGKFCJNSZeM1vOEY+2Kn5jgmvr9slDwCV068WVQJ5/40il0wnkn5V7ZSINzVc7/n7CQm3fd342iKM2l+d/OebGj6bvcucQkmPcvZxnWA4zbkxt6AQytrojdLMkm42O94GGyQsPf+NJ1JZeXMDkcpJt1bc8U+G9rf8r0rKs0kq6kdcrOhxKVUFx9oMPfTm2roZrZfbBDOZl16uFSGSVkPDMr64IKhR+8+zGLSSUH2lI3yTBpQDQ+LgCoT7Kd1wvcj/A4LBSZ9HTt/YR9sElN5/gROF08drJrNpH1OH65bqmK9RR3JcfCWmuLIMJSsf/7McQ6T1Ks7HbaqMcm3vVO1W4NJN9xnxTouYNKPr/FGX+F/CsVKlppYP2A0UQhlHOb3tcE3G67FKWgxqd45UysDHhhUaL+1mEkT77U9bIAOkyLWb9Vl0vrXpRck9JhUcvVyjBP8NLuTkwrDPlrer4IPc3wWSOgzKb7N5/0KKKzU2q5rzKRji0KyXJcyqUbuWYyICZO8vR7/CoZarnF/LsNDi1JmNkGjD4f2Tjb9f3y61pnByQfHHgTCzPfZKs9WMKnqRm2YGzFp5kzr1XGwN1zvnowFk3ipD+daQkX3hdV3oGF2YPV4S5zD05uhCv/qhxiawCeJpjfr1zBp/GppaxtrJvUYH19+FNr8+StdBVe+NA5faIP7/HOauxeOPA06Vge/9zeckF3LpJyChUEETyuLtgk3MOlq433StEc9mv05cxLGR4m5bHRg0ubkR7bPoZtHt7zERiZd0D3ebeeIPOWuPr3ciUmjjBNLuFB048zeLrjIcMrU+duYNCHNaM06mHnuqEoQrNPqeHwZlkbaffkAC/inVNSdUb/JknKL3ZnUvOu9ahBUPPk64hbcHFsSEuvBpBOLWUJVT9Tf9w1vd8Bja+y9S+Dz1p7DL6HS5onnB+BB49q9UV5MSnh9JXSyL5MeNHBazOGf/uRBD9gQ2XjiJfRxij12zI9JnsNOz77DU7X92Tr+uE+JlUs0DHc2qFcKZFLwRc4zB+iztdmt9v9/T+wNmxjEpFdvA78fhmcHWjW7YN4NsXbd/UzSMYnbx4Le5l1jJ0OY5NqyblQ5lElJF8PFd8L1xY9Eo6CHj96zz7D4eWNt8GEmWa/SWdULJV6Uf1Q+wqREzo/Og1Dbqut3fjj6Xeij3QNT32edXnyCSUe27FseDIdXSm3JhxuEcqUzIpi0411g01GYmPh8/U14+kuo3Qs4clbpxa9IJuUeHnS+x8H+NB0yJ3GZFBKzRN8HbrroX34ZXj3862YDnPEreUCfx6Q1ZxqVUuGWnhmH+qBepLSKWgyTLtf+OM2D35SnJl6FCXE1xS1w3lWpR8axuK/B2s4YuP+KRFsx5Mdnn6+Kx3yw1GZLJDBJ5CjnkwsMU7K1uA4lc9xv/01k0tque22cFCb5dbioSF/EfFoq9rsY5jldCJJLRX8ePbrfAw5OjnyYDI/ZLG6bkoa58bpitQcsrSh98xCKfp0zSS2DSYWx3oXZsHfdm+sLM5nUUfvgSSlk6il9nJOF+bNtwexLUNh11bcHdg3liflnoy9DzzjehvmlKrv0rjPJOGTmqVjIejVV/j2sd3W5MDufSSmTQmWOws3tXzTS4YNe1+YXcOfU0WOyBYhbon6XBzz7zXpKPqwelM6qLWRSqF7RmVFYa18SpleEvBUH/xTCra97kwuhnYJButYdrBfZaiyEO/pWzHwER2+7yXTBGw3DogbFTPp1pf6DF9w1slYnCx7wmH3oTwmTLLaWL5xTyqTK4J9kA+UUB0Oi4Qnbzesfw3sL/Y51whXvSzYrl2EuT2v0jYHqSiVeOuVMmnJrnIdVBT4v8Oxshbxh0UdzKpFHfVPnCFgsm/ZfBbQTLBP9AxuOiJw3rcL8WTcyOwE+Xynv2wg/8GrnT6xmknTQOXEn+PXA9snx0HDAqWbKU+R/0d8/7i+Z5O6QqpkMzdbsiv8MZ/bcdtasZVKn7q1/PLiHuWtdL9Sd7/ss6BWTFCx13tm+ZZL/0lVV8VBv3yurMsg4tGGbXCOTlvhVLjODO7YWrzwJxZPnxfTArg3xOoJ3TJpWuuePRjPWs+t+cwi+7WuseQevWvDGFrWg7hkNOt4w46fxxVSYHfiS8x7KSdveEG/F80/G8PgZKD32IeY6bBeJf1jQgefO6e5f/2BGpuKmj52Ik1Iza3kX/g53S/GGS57qZB6D0tuLf3dC0yk/F8d2M+mLe0NVyXfMl0jhFJU+nJc1o303vBr1MTQLThqU8W+Ax9u+/J37A/NxYMVyD3j5xO4nYbASXwZOw+tbBcw38EiW5rGIfiZpnt+q9ACq9KZohQ0ifhtkPb/AzbqaC//9xnNK1nO57RCeYw8mhIbD9NFuhTGofv7luxXDeL66hmnxYfz5nY0/4Qm5vs8BI0y6Y5Nxf8Y/9L1fQn4hvBLfu2e8CIuWHDMa9oEOHTeSnkDZgjecqeNY1HP47DFt2Dey5WEmPDx+qc9fmKIy8MZlPIsUxg6a3JjEos8VaT0fYX1R5P2d4iySuVbRfx/Os/ncP1OCRZsGhvashWLpeyLPw/17q6s6YFDVoLePJIusQ1vWVU5nkfxq8VwnKRad25zsNEOaRavbkls9IftH4Pdi6JL0O7sTtizpGp0iwyL9G2Gb18B3K0dyjsxiUeSB5x/yYNitS3ua4btsu9VceRbdF+k0rYJ3957OPKTAol6WUkIZ5GX3rHFRZFHIxbBFm/9j0ebZIuZ+s1nkU9rm1ALvmzz7tUyVhbrPORcEJ4hpnzsHyc3n0Gu4YGNo1rI5LDI7sOjpXaizQVO5G9bVzBbOUcO51k2wMIMPd4l41WqwyKkycd3RBSw62ctyfQEPif800tFkUXI51y0Auh+osoiH5mlbLzTD+6HOv/W0WMR9dTn/w2IW+U6o+yyty6Jts1zX+UIVQfeXbhhyt+aomT6LdM91+842wH0rK4xPGrNo5TH3b/3wkMKiRx5LsQ+pBZlVcFltbdM/6HpOgZabIC93d5XvgsZ+gpgr0DzPNUjFlEWFl8stv65gkUZdwUwixPXqc2sO9D85I6ENnpS0yje3QD7u9qiErmGR3EeNed2QKh/NjrZm0VzGfzsHoVT5t4WbbBDvSwH/fYczSjtzBWtZNIeamrXskZdG/t+jsElRJbce6soakp4Dizp2yxT5Q5EGP5sqePdHRfEo7JrRcfG/jSxqr58RZw7D/hztzXFk0fXJY3TCCXFeUfizGR4NPiMyaxuL5ruGfbOEFlJN84JgWGP0ttnOLOKfVHwV7c6iWxvdgvtgRtEj9fkeLPoud/vBXrjdoqk9Dt67rvzpB7SvTq2P9WTRKtGgw2NwB/Oe5k0v3H/N92ieL/ajdjC6H+pa8pX2+aGOHa3GWuG6O7W3CgJxnlj7hHFBuM++WRuDYdmoVW07tHrkuvVjCIvea7XG/xeK68WUPp6BX+64JPZAkUzv5i2HkYd/b159hJWTvVTnnGBRa9bT93lQxmNh1Vf4eMfMWZYRLJoWfel2JDScsPDiQ/iFTQ37I1lkZKvcnAFrKLGqE+7J61zO5LBovLz4mblc9HFl4M9zMO72hh/N8IR3UJ8sj0WTBjTPWsKz3OcxYfBQ2XSDCjj3qWXzYj7qRne48gDs8W04ey4afdTcO00lhkV3pN4P2UHhxD3JB+HkuPymBqgjZ/R1fiyL/qZl59tBn5BnUVxo9ma/SDW85hqSOO8Ui7rHPfodDB3aP+2neBYdvDu89wp8tTrho2wCi1hDmQtD4Zamnj998MRHA5Z2Iq7r318dAcsefZlaDF8u0DAfhB2ByW3rklhU+9l102Xo/j1DZFkKiyQU/vuaBh/f6lI0usiiZh3lqVHQ4Un/768wvvHO1MepLPL6YKs/Jw3xPZEhcxxm7Pn5vQLe3THlY3wG8lbk3SadifrzuvcmDrYoz1r9D76LvbfKJ4tFF9Kvpj+H7pwfOV3ZLBruyLdtzmORouvKJVOuY78Tde+Ywse7/xmI52Pfw//EDSHPRNnyCnRU3JivVMiiNWs5kj2wIGjbq4VFmLuzVe6egq/CeOWjUEWy76/LHcRf+XV2Awz/btLwHRZO9dVNKkb9uC381QffG+9KKC3BnFipqmdair6fse/nd1jGcnXaXoa8Mc6n34a3s0NODUFBg6qMfTmL3NJeNGfAj4t2e6+uZFFw/PMFMXDH+V1T11axaGT5h4874Mz+8GtjMO9LyWHDahYN/N10Y+pLFkX3VZtug1+Vn6gyod6fx7wG6Dd82dy8lkW/bmh0iL9ikcncNCWJt7jfq/wZtjB2j6HcUWi033BLCdQoUj+6spFFW/9GZAhhZvWnxjL4WGLFHOl3mCcmNy8HwsjgBf8Km1iklsiv6Yev7z+ecbiZRYtiNj34Bme4+LDdW/B6VC63AGYH143ObEWdrlddWdrBIunKtJfdcP+jKztyOvH8KNv13+4uFkkefXg5HaqLuQf9g01H93gkdGMOhCxdb/WDRVf2upZXwG+Bd01GYMOXsamNvzE/bVYr/YVp+ZuY1kMsajt4VDcdrnf3mdMMZfz6ZqwbRp3e6sqphHdFItZOGMH+o1+OFv9j0aCU5bhFImz6fFnDMhrOM9r2pQLWdgxP1x/Hpu2N/KeVsFO7xX4E7g148tlkPJt2V94/skqcTXYuzw7lwTivi+9lJNhkqRVzZwccDZ73Jxf2nb98QEOSTT9nv7jtO51Npi+PXTaUYpOCz+GSG9A+ZwF3EA6d/GGpIc2m6tEMw8Nwml155mP4tW7aLlMZNnE8VY2TZ7GpomR9n588mzaYXRx/GaoZMDXnKbDpm1aIwWRFNiU0nT7mO5tNd3oXu5qpsim88nZfPCzp7ZAVm8OmqN7P8uvhOPXow+lwMOrZkReQTNMv6S5gU024yAk/eMjFWltfk00Ca/dCPqz2t6rrgTXFc4xEtdg09XBl8thiNmV9bfLx1GVT8eYJZVfgi4JvM630sK7WpX1ceCe8RLIVjmZnB2vosymxLSLzuzGbROMOlKxeyiY/xpSmm3CsVPMc1wTnTSgcOGyKOAYWlXBXsGnLceu8fmh2t+K5I7FpUUX0ibuwaS5LchReTu5w9LNg00me6LrbcJnJfIc62ProV/UwbPmVkLPNkk1nWr8qsNYg3psX5LZAS/X0ZdOtcZ4pZao3YFWmx05RGzY9VnlbHgS9lYbUrNeySf2FQnE+zDIrX6loy6bDdi/m2G1g////xph1cHpSdxnXHvXz5vzx9zAo2tM9yIFNNm008gMedZhwb+1GNm2SWK2ZuZlNdffi3dhOOL/Bfzl10PfuIRWZbWyav7vl6GHIsk1WtXLG5xfYJ+6GrTdSNl2Cz4xyljz2YFPeQu1SC082+ex46a/ihX1GGbbvhSK09uXGXXhf1iz/HAxclBzbB8/lzKcNvmxK+VWZngP3jF6c/BHGzC+YUeKHeFxSZXyG0vKm6if92VRpOc/fKxDn+DKu6xVsa540LBbEpgXBT9VNoITwV/s+qH3Xyi4HGnW8j30NJ+5IsxHbz6YRsWe/wuCl2+otx0PYVDQW0PUKFhYszlwTyqY/S1J9D0ENxqza11BpQ0nQV+jPyWQvPIz6XiX61Bd2/F0YEA/bH6k6tcOwb/5fHI+wyUJn+e04eEyH0VMVxqYdahu21oTjXJKtWzvg51VPCotOYJ9u087qR7Cp4PZW18uwqttPXTySTZOOK/SshocSI7Z8gG8nnVRazkUfnD84dQe0aqkzVOCxKdpwQh0P2nq/L3wFJwnzuk35bDK2r46+DDNKFM5mRrPpafj0B9tjUOeMv9UMuPjgBXHDWMTlPXNyDNzDurHsAdT62Xpwwik2eWmviE+E1Qf7TDcnoE4uDeWcgVeP1jx5Bp/NUtixPJFNhn3vpBmwV+B2txHablqycUUS6rbweMOZFDa5Xn7R1wbFS/+2z73IJmZonnA/LJ9dXdcIk5eOO7U4lU3vNYLXsf7v3itl92D7XzEV2TTkRW2KrhcMFHxyq4BDhz78XZjJplnhtm8qYfaRJ1NmZaH+d200toAvTv0b8oYP2I7RjfBWr+cxg2zELeDR5XXw9p1fz3yhcemF8nt5bMoR8XvscB1zU/Un/zNULZag3fls6pYqEZtQgHpyezIqB4eOiG4NKfj/fNE6b1fEps06nJwn/7f6+OiyO2zKHImZmQKrj35UGoB9xQe7LIrZJD8vac+hEpyjre1TYynm27Xv9rPK2LS1YJ72Wfg38I6uQjn6KG/N24gKxOmSJKu2kk2/LEyT11axaVew7LckuMy3xVSlmk0zAvU0V7/E+WSDDiXDSScPbm+D0yYKMpRrMUcGFXR3wnfLn388A9+clHs5Aj8t//pb9g3ed6l+vuQtm65vEYqUQ7FEK1+JRjb1T3aKcIZtMgcq4uC/iQORE9/hudKxZi3B3xv7rt2Fn1b5O7Gb2bS2NsVUpIVNyzPTlXRh0VyLsmPwzwT3/jo40PV5/opW1HVfR21iB+ZG48nPOp1sWrc34ngmZLda5A/AlVfO/7PsYtOX4ypGrdBgKErZo5tNDuWGP/98xzpRRVvk+9gUyy+57wbrPpy2CocjmbYzi2FNdOfVmT/Y9MNml7srfBImZXMFzjdoDGuG527sdxuDbddk+/b043XbBxWzhhCvWRvlL8GRZ46sf/DQTu20Q8PI287f1e9g//BvV8sRvL9pjtF0EQ5ZfX+U7A/ZiR6XSqAucc4eHMehpQnq7FxYdmHvkajxHNoUfM5mujiHLgnX2OhJcMjJ+qjhcfh63/DhMSkOjf21zjOX5tA3CwVmGFyY2e9WAE9NWNj2FlYYxM5hyXAoTUPuQB30fJ2UOABd27yiBuSx7s3hOh0FDh3a4T8jDl5e7SP0VuSQwZyVt9bM5lC10HaZ6BwOnX0ucXA/LN3leTAZft246r64Goee70w+sg0a79eOS4JHHSvVSqDLfyXz9DQ4tP7DJe6PBRyaSL2+apockr07NdMDdl8y49+F5ttvHLXQ4lBX4pujjyFDVDu8aDGH1JcEnwzQ5VDK1YSD6bDY1md3Dbzw6qbHRD0OlR/N8SiEfZnRfor6HBLOKv+aAG+wNXKWLOXQ7L0xo3thg6G2xHf4+G1ogYMJh5Z8mri8EpreiT8XZMqhmUYRJZrLODSQUf1+FXHo2uiPkTBYNmk+9cHZ348esLPg0LapJhduwA3Xlg9JWHLondGw59o1HHIvOLfRBr9oTVLMzoVY//++by+MQDc/DQUPGw7l777vXgW3/34/T2kt1us/HXYN7l64UKIHKpw0H69nj/he9Z5eAd+six42c+CQ1KWny87A51++dHXAM+VjWbc2ckiuunhZkiOHJLRCz7k5cejYrHXntbZxqNBmkUsQvFVp/LcDHj4zoS/FmUOxdhOTnrtjHdvs13IeOP8Cvu0eyBZRvV8ETW8HxFt5cohZUb7oLNSUlBx6Bb1TOnZM9uLQydb26d3wgu67ouhdHDrSn1t7Dw5+EwYF+nLovCVPVs2PQ5liz++sh6Se9CcPrv3zykHGn0OdAer6n/dx6N9AaM2mQA4lVSxMEUDZ+0nTJwZxaMHbP0oHoMLkwdMlcLP6+KqZ+zlU1LWdvRW6CjtnM0I4tF9aPOczvOkSt8cglEM7Hf2m50Al7bqnSw9jX/sn/PGEH2f4hRRCA7vMM5OPIH/pZzxrwzmUYXdf7tQJ7O/mVQ1mBOJwcvs2jUgO/VpqbPiCg7prLVYx4HIocVbN2Bb49em/vbkw7tsODx8e8v114Z5kmGmn8aYHzhBrTDTgc2hr4HvFIWgxJc95awzOsXFa2k0Y36soLx+Lfp2dsCoZ1rf9mmt6CnGYG1v4KR75Jtlq9QTUK9Vkp0Hx6JR57fDPwcJ7ronYh0jxyvtQbG0+f3oS+vy7flIPDPky7rhUKvrSSGd/A3RYYZ/lm4Y83/cqvJCJ/r14W/Y3vMWqaV6bxaHTgUxhA3TQsy1al82hDy5f8o/noY+DilTsrnOobYtTp2g+1r/nP7gdxj17Z/4Q7lGTWulTxCFbaraSvIP1l8XmOsCrHwWF96GM2txl3+Amu5f1s0o51NIqYpkA35zXC+uAmk8fBYwr45Caw3Izf7hIvkX8JbzKZEb8hff+ZLy2LMdcYphnhUCj/QvT7B6ivgMvnONUcEigvfzDpUoOtQ52frSt4lDVjgN9GtU4/xy5toPwu+bs2nwYEOqh+uwlh1JrzxYq1XKIJTtwgw8X2/hwrsIQjgpv2ivEYVflkh2wNmLPd6W3HBr3XnxdDhxa5evYAdPyi5rlGjF3OGzHnbDqrYfRe/hiaWi5zXsO1RQKLxo2ow8FHs+GoFiZ+b6wFg5pjQZ4ibZivgW9yd7YyaEfEfpnBHBxQOXMXKj3O/LbACw+nlCp1YV5d+aBKgM2vBNR6oRm/nFr1/dx6K6U6s0zcNLvULk8eOxZY28l3PeJN1XpB+pz18LEA/DYTI+vWfDyXe3og/0cSv6mKHsBXtp9dfKBIQ5JVgxZ5kBvUc+HH+E4fW+//4YRn6H39Rth2Ftb43MwZXllbh+M2uWygzvCIZ/3lfeLYKb7fflrIlw6uL3lWR/89N/1favGceljq6WqEErrzdvxBZ4v2n5aZjyXig8FTtsGe88x6ouh/9Xg5z+gULG4MXYSl1xO1m1REOdSR+754VBYanfii6wE3jef+rsNjmvZl6chyaXAttpfyfBtVr/xI7h0BfNPkBSXnAOdjErgmWyxA7OlucTKCNpoA5Walmmlwj3ti/f+hiv/qDQvlOHS0J2DNvMVuGSvlHcqBeZWprM64bNPtUY6ilxi522S94RnBrMn7FXlUrbiTZObcNKLVdY6c7j0YcHE+QFwkV1wIB/OXnt+ex20Oju4dQiqeyVsXqTGpaaQ0d+74Dy7jKz8BVw69nfGXmlNXD+1caYj9GqftjoaXtzjxmyER9uUN5/Xwn5dCqyr4fus2P5aXS6NTggKX63HJVERJjMRHrQrt5XU59JxkcFxpbDmjNyrMGMuPX8Q8/bQUi45XT9mmgWzHlU/fwRHqt2btUy4ND02T+4C3LRsWeFCUy4daolrvgi5fT5LHxCX6jQDb0624FKG488oa3i5XfXScdipGZ4XA8/uPir/AQ4y8GPaEvG3El9/D27yaLmw0Bp57Sq8VQE9tfdt1rFBXsNTgo7A2a1v57TANctqAhat5VLt15L6QzDR64F9/QYurfriY55nz6U3D3VK5By4lDO5SZMJjbYnZm/cyKUtvBd1SdDgfSh33SYuScVd13Z1Qp1JPvpUCruWxYtobcM5Nd5fiocssuB+gNar/hbNduaSVpvSp72w6cCDFc3uqIvlGifNPLg00/nMuIcw7/jxnaOQNxJK/p5c+nwuVOEtLLepvjjDi0sr4lKnCKG0zvr/lvlhfzPW6abAqiMdkz9DlYkP1K38ueR2ec5v6d1c2rkn4XTqPtRz2UO9Y4FcmproEV0LC+Zf8zMOwj7+C98TAisz2pUfw7m1YvyvcPLaiqjCUC6V7RB79x0uDDNVNjnMpa2DvICz8MCt571NcMLBZ4pTjnDpr7eLs9UJLoXUib6IhxWzLjytgtcq02+aRaCObgdM5MItZjL823BfbxpbkculDcy8wQNwZGDeuUw4L+/b8+/Q7OKTTgsePv/HdWYmdGGMG5Lnc6l9Sdo7JQHuZ2q09XM0l6atWi9FMYizbOLaM1CxuF5hcizuN4Op8x0uu8I6fu0U4qxZdm80nksy82y2705Av8RJD01MxLxYrnHPE5aZjHjlQpmzGhmySVzyXpK2vxba7WYF7rjIpdfb0xUb4DZN1zeeqYiPuis/HFrvnLfpNqzdNdfNNQ19NCZefiSTS4VJZYfcs7hUr+wYlQ03ivaKKmUj3ueO7/WBhx99W3XzOpfS51q1z8jn0tUKw/3rYPD2U0Vh0Fx0q1EC/GehNtoF83SSPy4r4JKpg9fzgUIuDRiO2iws4lJ3i/nkHrhaS2PKpjuoy9h7aSx4LDzE4yHcOuXsiYRinHc052MHLIjZ4P+xlEvJs+W+zCzjkry4yUsXeDLQY1M1FPNyc5tXziW6MfQ5Bq5uN0x8AoOf7TcOq8R9PFWzv8OdD9dVrq3iknvKz8h2qOUq0xRbzaVmlfVyRi+5tPvOr/L3MM6lu2llLeL24M78z3D7Qe/DF19hfvw2OHbwLfanV6f/AR7V6tqwuZFLN+OVmG/gw2GPIIl3iJt1WNJFuPjqkNwTWHAicPXdJswP8y4t5WYu7dh8tTEAPskKtS+DL9nPl4u1IJ63vm31gk/Dq+Jvwpi73qG/4H6rmHqLVi5dP9W1UbqNS6pL9gyKd+L1o89rguDSNn3WGLTN2it9rAvzP/3c5Yfw/dNG+4ndyIuXcrs+3L5q7fjR71yak5SqE9CH/VQt0qyDU4zK4w1/cKnHe9MGH6jp86UmBU48+lLnJ9wUZLlRpR/rdc30vTWE9eaLiXoM4/nyReZ5EZz8NDFtzwiXRDa++aYuwqMuibly0bDw5/j0B7Bsrmq00jgehfYuHXSHPiv+TqiDjjHSL0om8Uhu7goxZXEedTg9DA+Ecj2J467Artiatz+h6/bhlQskeMSx6drhBlcXT7tXCjecN1unLcmjAN97FfpSPIrnX73Lgs9T50h3wPQu588W0jzKmKZa9goqTtvDVpXh0by9OTYuMHh6sxkP2hhc1EmB9uZKCyfM4NGl4cDvvlDfsm68mjyPVHZmFVjCj4uiun7DQe3SxQcUeLTeWP7yIzi4qX2prSKP5thnbU+GFTqB9gaqPBLP7dASmcOjx596mpfAbZKFh9lwcOCAdu////YLvKymxqMoPb+gE7B1ltKV5Qt41JNxseYIdJb8z0hHk0dmSzuXJ8ORge1SnfC84aJEcy0eGYaEG16Am7Unp5cvxv4duD0RujzKq95Q/xCGXLl/YwhGjfd5paeHfeQ2ZUXD02Erf32EKcnu+8iYRyWJ5ua/liKOxl3Xn5jwaGuIZthpUx51R275vmgFj0TPacVNI8Th+4/9YhY8qr3ZEOIBF9UUOZfA8IPe+35And9cDVNLHhUFz9RbZM0jdn3KyEuYfW2LnKkNj6QDFK+ehvt2Gy1sgzsnpZ0yWYs4OM58vA8+aYxMrIAz2npenNnAo2l+poqp9ohH36D9K1jUFu0zwYFHRzWshtfCYzmT27/CjAfBtGsjjx71Ot7IhB8jWr6ZOfGoJc56jgCmBpSZtUMlgUH89m08ypreue0pPOeolrHImUdM2dCqCPho7uNvTbC0LE1PzAN1eknM2RzWXWxa4wHDylJqyZNHJpoNGp3wu9RSNQMvHt0bN9fNw5dH/dsDT3dDj4g0hZV+PHptU8DYBU9qqUUz4Zqdb6+Uwd2K9RKDsPR1gv2RQNRx0e+Mm1Bbcd8K1SDEZU10mgd0uqo9JxEuskjvfQfnm+Zsld3Po3VuCf9VhPBo9q0LzfqhPNozQXj3ILyWaJ9bDm9LGKckHubR+2uPVJphi3G+x54jPBr1CituDufRqU1BEQdP8GjFP5d78yN49Gd6n1kMTAra27I0kkd6Ob/+HOHwaPFy3y/OXB4NLXF9nA4fSnSM6vBQN/+ORe7l/T+vJieKofmseSeW83k0aTMmAUz7wnk3OxZ976v2dyfcyNSxuQXvXckfL3uKR/LqESe2JvDo26eiFbMSEWdru9evYcPMpzWzk7B+4S6VKBhwctLbOvhOWergq4s88juUbzY9FXnX8jJeB2Una34NgDaq08yr4afDG8pHoK3lbBm7NB6dCc+fWAit/cefXJfJIzGJS1Fvofu0sN/qWTy6Et4zdBZ25RuF/YXTOI/lN2fzKLloVR8XKvS5RkRdx/oLcqaVwVVzv62SyOdRROrdE+bwU1LoaT5smFFiLlfAo38uPO/nN3mUo298YWURzlFR2VEHDSXFZ7vf4dHvlJzdQjj/qOLvQbgnOa5KrJRHau9mxgbDjgXjB67Ax3rmqxzKeCSz0cXlOnR7eKtcohz1pb15igPc1xdyoxPKfjm3ddoTHl1QfKY4rRJ5/jOXHkKtZkl1mSoeGWmrNe2Bny87v86DVprfN/TDCUoyXi7VyMNw+PIXcJmC5mrHFzziZm59Or8WfZ+/IjAZskMiVr+GqWVBg1NfoW90mbljMNXv0YbgRh6dmD6H/xzOtd6kbPSORzUeL1VZzTzaZflAPh+Giy0KHIXyhgeTbVuQPyevT7nwxI+M9lWtPPqwktPzF8oveb99YiePlo4+MKuDE67cvbCoC58/cmpxOHRIfHd1ZTePci+p++f18Yj0Ck7N/oE6s9uhlALbPX6ffQ0Pl97Vse/nUcydxIA42Nuq3nx/CHk+puUiOcwjF6ML2legxVGN5c/hnuY5ywNHMB+rZl9dKcIn355CZz949/t6v2T4jmV+qx3afPnU6ziOTwO3W5YUQMd6O/3PcN9dd2mr8XxaHztxJxfaq4it2SfOJ8mL4oq3IffVlt19UG6CzCwfCT5t9L23KwF2Rfp+aYaKO7P1bCX51Jm2YcWP6XwyKFP7tVyKTy8uXHKvgF6bX303l+bTlZeLAs7Ao10DD0Rk+JR1afXAf/J82vnA76MxVNap0hBR4KP//juwHY6kq/FioI2G4SYvVT7dYph7LJ7DJ63XYn9LobuZ6TMVNT5FOBUO2WryKUN9OMxSF3/PGRGGwKOf/T0ewqlblpGMHp9Y6erBZ6Dcw6+h1fDshLkzp+jz6ZVAWscexuxm2qYb82m3VLxo1FI+PX2h+rQFrm+ymK9qwidB6a03PvCEvNrsi/D0lsiYT7DufY67oimfkicmV3jDh5JbQrNW8OnACfvcGcQno+Q5+yPgzzXh/gNwk4F2nJkFzt20ycULnmVcP3Af8lpaz9tY8ulf1Mlzx+H5CyZvE9fw6ZxKQ/sJa7xe81p5DJ76LXlZaMOnDsl7B59BN27jvqlr+bRq5zotZ/he7ffMSns+fi/v4is48CmYtq4whVXlhiVpUMdk2ulu+J/oIvF3W/jkF6O+Rnwbn4wlJ9psglquXxeVQJUtr3YrOPPpav1/t0o9+CSrvE1R0pNPy6T/3IqB8wa0Ili+fHpQmWf8Ge5+d/yMmh/yKGW4/wjMTZXxzIWhX2y4P+B325yOQn+cO6Fs7xD881In0z2QTy+fPXbRCML+5z5v9YUj++6mnoH6n68aGu9HXJ8I5gpC+eT5vkde8zCfynk33x2AFxPc+m5Ag3Q1O+UjfLJwkSt7DF/2LOfknuDTMbXPEhTBp3DNN8VvoMLU2CuakXxy2Cu18DkH+WtvSYjn8kltn7x4DZR9uWKaOo9PztNyx25D7U9HlaX4OAeK3wGuPuNRujWGT8++z1vMhH9cSqyfwozZ37WnxvJp0bojNnvgkhe+Aa/g+aVWunqn+HTfcPlhTiKfSmvfCHuhRVD3sEESn7bJ6XS4woqVmg/qL/LxvXDTl12puO+H8qfr0vhkdqxR9jS8dqr0q+wlPs1NXVf5J4NPUySsrp3M5FNt0IaQF7BheiJzfBbyECyeFABTdRe+lsrm05vP9TM2QYne+k2PoUNTgNvZ6zjHO6fcIVi3Vl7DMR/5CA6efhNa/Od7cQhu4Le3HipAPvPuP/ItQvwSl2Y3wDvxF8IO3EH/q7VHPYDVuq8tHYr5lFIXGZEES14XzvUq5VOTaH3BDfjK3NkvowzxfFMjMa8cdZUSMv0cHJryyyP9CZ+8NZylxCv55DKRfXBcFZ8mj/ysXw0HrmSH3IXNDtF9mtXonwlu9yRq+dSjOLT3MDwSlVh3HRac/Zf3GSa8XM/b+wqfH/xy0qiRT2O694/tg8655/qfwUj3MzW975Dv9e4u65r5NMvghdeUFpxr4bXbznBSujD9CpRiq+zsgx65nZFdrXzK27Fco7iTT92ll49t7EJ//PfFJBqK3cw9/wQO7xT1m9+NOZb778tx+OFm9eW4Pj6JK+Tb2v/gEzO6W50DPyrHZZfCFpnC26b9fKqP8Z0VNYS+dukKkRhGnrX1/2yCydqHjoTBxGWFl2aPIB7bWXqOUFIyfpyRiIA+2LzwOgK9Ptwq1x4noDGDOtmDsFCLnSM2Hu66+X0dzExZcSZOXEBtqx4qHpUQ0PWXqucSocdbm6nVcPBCnI2ipICUYkp0z0kJKMnn6C5JaQEZLM+ZdA/2/F56ZKqMgBInmRY7whL34WcCeQEdafxh8gKWzeYXaSsIqCldVDUZqjZkHP0MG74e0juuKCCnD597RedgnRbNpS9gsE9TjJSagK6dVtrjCWeNGAgHNAS0Qn405OYCAW1yfazroSkgHyW1dR+gx8jSP6t0BfSHczj5GRzZZGj2D07dPbPaXl9Azwcdf52GL6f0bHgBh97uUp9iIqA57hP0MuDK9Me2mqYCCqtZvSIZNtW/zcohAZlXTxGTsBCQrcbIZD0oK6kscshSQJeEd7JuwbUuZ/N6rPH53oytq2wEJJLG1voDtdWc7ySvFZAWq0R5jT327adwQwi/PLpOlXDV9BTlJQ4Cevcv08jx/65fOdl8o4DiK1vOTNgkoJRVtTEpTgLqHpAbnL5NQFF77A4dhvtEi9n50Pmq6d8OGJ/0VNbGGeeVbBYmwVWrTxQpe2C/PWfqC+G5CFErLU8BRchWPtwHa/b/vHQbik2c3CTmJSB9p2v9s+EC59/1p+G5jPGrd/sJqNirdnUqvJ3U0DjDX0B5Oh27+wMFxKpuy4oIEtDJf63CSnhxmf5n3n6cK0AjrzRUQNbsf09VDyMuY85yYdByvP+Peli9e9fq4RMCSnj+1IYXgXPtk+fUwoqTIrlzIgU0yczE3Q9+k6uPZ8KNZWlX9nGRr4MvPUvhhau+PpN5AvrPcft5T5i3eP+vArjZ4HKEFF9Ay1e/G4mAXVUiNRNiBSQ169Ysa6j2pbzvNRz6dXql+Gnsf/EPC+sEARmbcT2/wm+yUpWXElG3lvt3aiThvGfNLm24KKD3VnMOFsM9W+pHpqUibt6igXbQZXtnyB84vyA+dn+agOz3qiqJZWLd+pUfZLIEFDjlxrfjcNHBt51voJLsPpnF2YjX2oP3u+Bv9hL/JdcF9CZO7EMdLF4b83dOvoA0xS9GxcFPEbmRFfDv/sfXJhUIKKZzRdmGQvRbqtMyvyIB9Y0Wp6ncEdDNQq3pPlCcOePJbWj2LX1lDwz6MXjepVhAAdrr1deWCWiaV/vDBtg4mlnGLUf///hrkVMpIOk6200BVQLS0fZ++wC+2Xpzx9FqAV29a3j69Evso87tWz0sa5Z8pFwroA2TAgYPwrEvgQqJsCrbeNdjWK6QdKMNLuQFaOi8EtCyJmPHY1BT+sP2q28FxI1bdce5UUBzvTVZ16Fug/r9te8EVDpiIXGyWUCnHPwfmLdgHsRdzngAfxlPllFtRR8FZF8bgKfys/dXdGJOrD+mt7sL91GfLLgC3+1cb9cE8zyMJhb0Cch9e7HHhh8Cmr7l24/H8OQm6zOrhwX0MYb7+DLcqXd61QDsSZRrzh1B/h/IyriJCOlj7nPRHthy2WaHzjgh7XC1X8CD/o1L2NfgMqsnIZvGC6lox0PJVvhw97I7vhOE9HnbhpvjJIT0a9rpjgD4cIXPpSJJvO63nn7A9f21oqZSQhLEn9XPh1Iiy/J3Sgsp3nhy/A2oerX/+SiUF336OF1GSL/btm01kBeSW3dQewucfqX9grWCkO56P5yZCH+nPhpTUhTSivNXuCfgl1kHGnfOEdJQ9c+dL6C60M5FXk1IxdbP/kYtENL9jq1Lr2kKyWvGwTJZLSENOrZl7tcT0o3+F0vvw3bHJ6Mz9IWkfPBly2bYmn+8XM5ASH7rfXIrlwpJsd7yrqKJkJy8d+aeg5EB6YlypkKSEAReM4RNJZMlfC2E1O+xwWyKpZD2uFrpiawU0qmu29rTbITUeacryBEmD1x5lgbHf037NGutkNLVHB9FwM37FtndsRdS3Fhxs7KDkLa5BH0/vFFImRufrHkHjXVkFXqdcM4G9fbL2xCPdXa5z2BfU4ejnLOQxt3lKDPh02ot2yLoccZx7L6HkF59mmjxFXpH7F2d64nPK92MHoD27WfSt3lB3RoFLpwS8TWyHD543tnl4yukWHN/v0b4y7XY67CfkE74RJqmw0XW9+8OwxXv5o+t8xdSvUyCyxG4leOjVwpf+CeVGAUJSUtGWtsfyn7N2TBlv5DWpBavSoWHBpZp8UKFlCdWsOs7jI6KD//vsJAG6t4teAMfsmQt9I8gnsc7tENheq1fQc4JIal0LU1dHCGk9/ZK1WXQLWRXoHQk4hlv9n4zNLG1qdzCgzU8rXTodCv0pQYf+5nax4qF1WWbdJNjhPT2+KMU0Vgh6fukF/vDRc/+Wd2C+84ZyU85JaSfc35HRyUgTgcuJS1OFBLLcvxHFtS71qZbD39l1R06fVFI83vWL1RPFdIz580T3GDBFKux+/CpmUXJrDTE3d89OSoTeRuOjKmB77/9+cjJEtJRpzE7t2wh2Z5/W58D3/TduTh6TUgOBa7/yV5H/KtqGgrhmPLCQpV81J/wmHE4nLm1Vq4OSmSIRUsXCOnYp3eSb4qEVEXFYcF3hLRkE/9YM2wusuk2KUY9PHY+1Q0/2CiELi9FXV1SHLpaJiSRtfGLfcuFtPzpOpeFD4W0a7VQPaJSSDWV9YY6VUI63v7XjgvVtqR4dEOj9acb5lYjrh2ZbTteom47Ym5mQ4lbC6xW1wpp9NSauEboN+PtVYlXQgo3qr5Q+FZIt2Iqfhs3oq9m7LUMgEcPCOX7YPftwBei74XUkeV2ub8Z+8lde9K2RUhbCvMWJ8LKaz5yj+Cd9dGrprcKaa6x5UJtaNxSqu4NSw43+V+Dct49U9Z1Cuk03+X1Fbh9d5JxL7wa97bxVJeQXn/ffVKrW0iF46apH4K2XyceqIABt4K/NcP2Yrlfed9Rv5P8L5n/wBwy+K82BQa3ZswaguackyfX9yP/L/8yBbB9wcmakiEhKf39Va82LKSDByysPsEt/HU1diOIQ/s2uwKRKHrLaRQKxkXRuBy2n9r4KIq+zj/rBkWiRBVyJkRRdvSsQstJURSae006XDyKrjzc5/sCZhnICU5LRFFuckRKF9wmttvfSDKKAsTzA/bDoYBnzuelosh4ZmLrZOkoWtTqncKBOrELXT1loujrr8/S1+C8J68fPJaPokNTD7fNUsA6JXm+unDupMWhp6HEuYr19+Hr4NKlb6BsVl6wuWIUlVop6CRAXdOuN0WqURT5vm7X7DlR1GsQHBoOiy/0TGyAC0Ja3xepRdF9GdbvsgVRtPa/AcEsTdz/wNlZHvCj2qfuQuh/4+R5d63/v293qAxuFPqdatTBepVRnhP18PrQtAkGsOziLKdaqMD3feKmH0XWDf4OK0yiyNRC7sxXKLXa3iLGNIpmXOUcemseRaNKxkWBhHjYqbi1whOeKyLnWiAe+R3BJfCHZeLiv5AdnJVnbx1FTM2KuSVQXJfr8gca9V4aMrOJot+xKjl5cMOmJWEjcLloHq1dG0WdFs/bdsOhF+4qLuujaNnF3HOr7LGPXaHaXJgStHbGP2gjUfHDxAF5Xl89KQge6x1m34BHq0/UfIM8m4FvIduiaM99LrMfCps7MvSdo+h45N6ntpA5cXzSQ48o+qQ5lW3lGUUPIh4s/wcPsOMelXpFUc3FNbHBvlH0R1RZfZdfFAXf2aHyGpb9aXWf5x9FQYzrW+IgU+nelPNBUXR+Bpc7DONOxlcb7o+i0yuedFsdiKIxl4Rj70Nxrgqtp4sOR1FMzAYtJqxoLtF9Aefbnz6x+kgUJcZeskw/EUXXle1sOmDwikdP/0ZE0d9bQ5ecI6No2uTx60O5UZQkWPCwAPbuiDJawkMcSrV7G+C5sf80Z/CjKE2kyDMEjl59GVICZbQrljvGRFH9qUeX8qDbbjWXQegf17J7eWwU7b74O1bqVBQ5Hrtp2BYfRX3GZZ46CVG0dKJO9GHIrrvTviUximrfxI6xYPNYaEonlJpUoVqSFEXqTJkZHRej6PASa8vtqVGUfDdoYFIa+kzS3+0ZTD/btWYMLnbMfpOXiXNNf6O2PQv58YiU/AnzS6puO2ZHkVXk/NEoWBn1eLAbNhXFXNyQj3442mOeBpe/netUUxRFirPP6m69g3x9XlDTUxpFmRdl9NzKUL8CgxeR0GT8Uqmw8igiye3/q7i+46l+2ziAU4QilB2i1C+jEIoyLqNCFBpoWRmpbIlSREM4+xyjVEgRQkMkSVQkUok0JGlnVaL9fJ6/3q84vt/7vu7Pdd2ngc8wy+23jHxDOvWdiE8OaEonVbfyse+wUvf2LMdm1C2lUPMmPN/0bd3+u+mU+2vfi/72dPJtdVS3fZBOz8ITS/57mE7sBM+gDfDwipd6KfBxXZt93CPUy2rKwMUn6cRfqvqhvDud0vkR/QZP0+nfgSGXY/BYsM7knl6cB6OiVrwvnbY284OdoFp/5/RMyCrf+0LhPfq3Y6LNtA/pdKqhrosBT4svvtoGd37LF5P7mE6vnus/iYVX2mVmtg+n09ftsffER9KpxuB4XBhMoOrwXih1ZUBg8yWdvN9bUgTclLiZEziO87nnOD8fnt69P/gV5OVtPTb5B+abkNurkzC+qUf1O9xU2fQ082c6KRQMpXRAh86n2Sf/pZOu5Nv4UCEGWe8tbZwlzKCVc+0SfCBbQepNIWRuKn4yOIFBuvOZt0LFGTQyRXZJEVx+gc8Ik2BQrVG7w1MYYGWs5DKZQR0lTL2P8OHftHJPGQbJj7Eq+2DenDZhviyDPkYe8h+GVqZJ2SrTGPQ2Ou8ND/qYuq5ZqsCgfbOcpbcpM2ggb1HCOVg1pNT6Ey4t1LxzWIVBcVP3/gvTZNCV/SLsLzDQxlf9v1kM4sbdzmHOY9DftrKpcdoM8p2/5dEkHQaZxAi9MoXHtgrZHIbmlpctlhlin380qArmNDvdmrOQQa4fxpbFwMl6bf9+L2ZQdvBo5Q5TPHdcNSvSDM9rn8F5D3c9szuzaAmDinuf24gTg0LSeGnH4Ozr/3QlrBm0mlFW6g5HdldbsyCn4aV5JzS/NCqqa8Ogf96Nq2Pgxl/b1m51YNDRpjsFyx0ZFBQ61pHuwiDWylnfbsNfcbP3xbnivWPqWTPdGLRb+nyzJxyfvUhowhoGrWPJ2i6Akxwb+zZ7MGjDRJnDkp4MmtW8yiYfrimv+jgMHe8NBplswP7bxZ63+DDo/sM8U1Ff7GtB8p9wyLxwN2vHNgZ5DVeEVf1fkTs6Q1Dp7+AT82DUVzK9UnE7ztchfb5YOM7x4+XbdVAm9/i72REMmuKwYNu2WAZFF70pOQJDorqaP0IT/UWJExMZJGxh1XgZlvsmzhiD2xcmPdl+gEG3F+WI3j2M/Xqnhoak4H2V7rUtsMRx8uSlRxm0VqFBoofFoOe7CoyWshmkP69a5ix8rV3wuQfO36i+1oHDIAevWzMvwe73k6sLMxl0ZstTp8osnI+01iKFbKw7fMN0N2jgv3x27ink062u1yGXQSdOJh9qgzu13cRm5jEo0XftuCec+n3nr3Iof9bsjHk+9j9j7T27QgYpSvr6jcDxN6JaAUUMOl0RtTkXLrKT4A3C85rZl0zOMWhZrYRSFdRZb3Ns83kGCfyV5edUoE5nm06sh1t4kZduwu2zPvkFXGDQjrc+b8/DFRK9o99gTviik1OqGfj/+3OnDGgTfL7mGbw0nDsqcxX9U6i/amk9gwo95vYcv8mgPzuXt481MehWibTXqWYGnRtbvL4RerPrFR3uMsj4ysnNx2DlMu90kwfo25rvN4OgZ/Y6nW6o5XHF8dhDBm0NFS7th+0vX5xwesKgn5EhfTnQTjQqbASGqJrMnN3NoEOPV5/aD5PO5bwTesqgqKOhX3PgjjiJu0d6GeQ00+Huf68YlF4np+kHs0tm/TbrY1BR5NHE/ZCTdPlaxnucp+7X8xfgVs7ruxIfGLTnryLNhrcfWv+c9xH5DGha9Qrqvt6jeX8Yc+a268fAEcwLl3/7BuCEd9etZccYdFaBE7dxHHmIislMhVo1S9vfwkaP5Tb0g0H7O7xCUuGa+U1eG36irtkvL1yBxzNP85lCTOoscZeUEWaSrmDfvDC4++HISAeUXzHqIjeBSasHs43coW1A6PIrUDF0nWy5OJOiFZ3yxSSYNPnpf51W0G/DybNH4KsD6X874N/92zqmTWZSaqmqajq8plH29qwMk7bGrzd5DDXuViQ5yzLpn+XJZD7sEGx4+BKSyZ/KtGlM2q5nnXhLiUnaLwdUOMpMyncKv3cfPpfIutGgwqQJUr6mwRpMurHZuXKXJpPmhIh6WcxiUkTX8qBEOCSWK/R4HpOM3Ux+OWozye6EsT0fXjx43mEEjngs3LNLh0kzzGf8izVk0s73lltGIfvYu6QTC5lkMaDz4g/kHAhoqjdl0usfiaVPzJj0+3nRNZUlTFr1omKWF2zdrOzNhf3OmteuWTNpdPWUvL/wa519+GIbrN9j+aoTMJq/9M4CeybNc1gpMcWBST/PX2hzg3tPbSy9C4NP2wyZOWLdMa5+01cySXnPDe3XLky6sKzfSsOVScKGlYtiYM/+Zx0/4L7UqEY3NyYtP0Pa2dDzDfG64LQiv7EVHkxqcSlQSfVk0sqOxznjUM76blH4Bia1G4o+m7+RSZmemXseeeO5qc4jS32YNG6RqX0Gzkma4/MJij5clBfry6RSkeU3LsKJ6S6sE0FM+mT8LWjaNiZ9cN04Nwi2LPzQ8xQ6z+Mutg9mkkJ9nfpBqHvWJagpjEn2FX3HLoTj/NryE7ZHMEld/n5CwW4mJdbXi9fGYr/LPnHmxjFJrIfrcwv6tx5I/JHApN65vKiliUzKvX3+ZzHMEZnKnn6ASUL/LelfAef56uWmQlnntoCNB5kkfr3w0N8jeJ6In93MFOR16o+WQMhR9Ih4CZ/HtIpvOYpzP7/h9iW4vjmv/BsUtii6octkksEaKyVbNur07/yLFGggMsP9CrTrMK56C0N+CRQXcJg00PhxXiHUXZ8U/xTyZA/tschi0gFW46ErsHB+xOo30KLtSP/GbCYl50XsPQVzVtd8bIMabQ8N3XORu+TUlHvQZYtJqmQezn/3y7my+Uwyv3WhIa4QeXqUuu9kEZM0O1Z/m3KOSVYjlQ+aoH7fikdbKpjkwzN9I36BSXHMSUl7Yf3C69PPw19Wa78Mw+KJ2qPXq5j0UXBYLKSaSS/PXusqgCJTz1aKXUVOP76o2warnlYutaxnkqpLYN0IVCljF867yaSZ2Xe/n4Bmk9aWFjYwad1gbajnbSbN6p4pfx+qvTpxTr8Z+fsgknYQqiXd/zUKpRfEZiy5i/5094z9fp9JSzk+khceIDeuJfVSD5mUXrLzTCrco7v45xM4crF2Gq+TSY8zp2fe7Ma5f1WW3fcUnzvzIEb+Gc7f0XJI9BX246hwtA4efL1r0WfonP+hdm8fk9Zyrz28CH3v2/hffc+kxQYeXx5DvnjXwaQPWHeMsEQ+ND2cNSr8EX0Yt2NkIVTqzIqMg2/rGrWDhlHHBudM4REmnSj6/NH1C5PcDAusasYxDzoDn4v+YFJU1/ivY7Aj92GZ40/UIagke6sQi2wbP05OgC4z1w5lQAtXuanv4Kwv/1IlhFnUkDi+wQpm7t5jGQwLpqaqZ8Lm6/kHl4mwyG6L/9rpoixatK3g0yxxfK7MMyYFSj//KjpbgkUaDWZ95yRZ5NkfM6Eelts/7B2GS+J9MiWkWDT885L3PLjjdBa5Qr6FcMFeeKudd11fhkXjyhX3j8O42ZarWmAtJ7ruvBz+3rspVV+eRSpS75e7wmam5YVU+OSleYebEouiv1w4mwwLzDolr8AVll372qD5xKVGBsosEv4QseI4bDPuZbiosijP/UccGy4/EiN7G269ODxxFNYbduQe1mCR4WDevlLoF9ib3wV3ab44KqLJou2Dz29awNt3h1Zqa7GoVC9x0T7Ik7gWlQ0L7bgWMnNYlDKz5NFc2OJ4KGsVdI1vr0qCEinPM6W0WSSY/yl8EfRfYu3P0WPR0pS1t8dgiWLEiRXzWRT65ZS3vj6Ljmjsesk2YFFIaR7/Fly8cnzGEAw0Wd/wF27PiOqcacgix0C51yuNWWQ1aOcqgGb6Nm+uwLGgdzLfYa9fVMASE1gl77wf3lafsWuZKZ7zK6l9MzzGSQi8AsWZrfu/wUxz0XhdMxYl2Hos3ATHTvqeOQD/lPsqrTbH55SYb29AoxPuA8stWPSgaMLRKKj14+XJ7cSi065+s09B1wXyre2wcZ12s441i/a+3jXsDK8YW/iGwE2zG41K7FjUuaxp/D4U+9nrMA6fFP7WlV/GIuvOsY1uUDDAyK63Z5H2Bb3KYfgg5dN8TQcWzc+ZfGAd/CPN//7QkUVOq9UlrzshL8aMd12wc5R/6xPcN0XE3MSZRd6Ljoz7w52mh2wqXVC34JmCxzBj4n71/1yx35Abx4NgYZNJFRtuCv0yVXUtiz5kO0k+hgta+xNN1rHo0oxryeGwTSrm1GYPFr0+V5+cCqcGf+vsgP7f5p6W8MT6RM8sD93Iovyzkpb8Tcjht+dtXfCIqk7PxM0s0ll7nPZAzQ952xd5I69mQWbR0HdWQPwYtOv8fGqxD4tiWlLDZfxZtHFa5cyjQchVluzNHrgsPWGKyDZ8roGnNRP+Klxu4QKTQ6c40Q4WjX7Tf/YY5uXPTxDbyaLgkHVbjKDHhNM3vcKwjh2vrhyAR3NVjz2B3ZPs0uTDWZTIPx+yD35+lZW3JRJ5rt60cGEUi+6fPmvXC93G9nirR7PomuwFpcO7WbRtYw+/ERqszV6kHsuieNbqFC+433qZShZ0KN2Q/Wsvi/REzv88EI9zsS+KXLwf88EtLzA3gUVr1bVCGuGO36XdMxJRT6tjPyzhvKBUxkYYLjy/5Eky8t/xr+cPnLO+Nk/tIIvkG7skbOHd9rrc7fCD03z1c0dYNFtJWn1CCnInemfJPDhwsa7NHl63HjY1TmORaXD3hkioW1kZngNnaMo6jEKBvIPvlHScm9KUt+vgf/r5Y4uZ6LNGtcBgFotYjdf55TB06tkJb6CsxcsZP6CS1DydqWzMLdeTDuYwW2HjcAV8WtcrlcZjUWvY442lMEmqs2ESH/nfMvprJXwR91REIZNFg2nlShfg97TXmYpZOOffAdabYNhKWy82/MOzuHTyOHI1q/TnPShe8dlOOQfP/zrD2QgullLi7oT9GfryC06x6EfwDJ1LcNrXoC2DkJvRtiAwF/WptRCwT7PogllLYTPUSzlzdFIBcv5FudQKzvL5ODECXpOs/7i+EPVn9kTshnuqRBOOw8a7y/Kvwn/TFlepFrFoQ8LVMwvhqVm/I9bDnd+FfeLgnuu/EwJLWGSsa1lRBMX41TcH4Kk7WplLSln0KTEgdBtcrSxdblWGfEszV8SWY259qy06Az1dtU3FKljUfqf2yHJ4yCw9LQS+XhM9V/8i+ukn94j3JRZN4npmNMMrjZ+69C+j/7rvLZe8gvx33/mrU4X3pa8bC4MjjiE3UuF7XQ2jmdW4d0533HG5hj6eUqW/G17NzXhVC6fPN137EtrLd9kb1aJ/1hXGroNST/Vjkm+gf9Y6xt2Ga7m6ZUr1LHrUc4ljBJsnSQ7ubWSR3DaDubdge7PfsSF4d27jvrm3cL90VbQ6QCv96deToQz3WJ7GHdyHizf1WzWxSCE0SD4W5v8KCjwL2/d4LLnx/5+vWsceg7eHg1KUmll0Yv+hi6vg1m3CmolwwlC6qO89Fq1cU/OtEBbt/eI7CFff3l1n3or5IH7XdBt0O2VG3HbMm3ijxhLoH6Bq9wXquoY8UX3AouPPb4c5wLVbWxVjYPeW4Ht5Hajv1TDPX/ARY8Div8cscvZuEY6CnVYeIeuesOigyYycavjf5Uk3x2HzmoWvFbpZ9JH3eUrzU/S3af2/tmf/r4fy8MXnmN+7xXRGof2irwHxL3C/1xckx/aiTrP9TqbAH35XRDNh15Lqr99gTulE2WmvWJSlsdNJD/bN+8LYDXPNW94+6Me88P57VuQN+q463Zzg5LILDmHQ/HaW3Wno4ejS7vse30umcycx4WKPozdKYe/iyPwNH5A3+3uRSp+Rr6cDbSnwa33cI5EBFj10WXNzDfwbYT41bBjflyQGZl2CASoSbz9D/qPPqxVGsG7TrdaukC+atzoCCiVe4CZ9w72ww8BMZBTfa+pCks1hTrzwmBd8f+D63/ewMsp/e/s4i9Ra3Zi/oHtrvZDnDxa9MU77WvMb/TjJZ+QhzFp14+3EPyyq2/RilTtMDNPwmPUPffn4piRPiE23dv/ufwkrZQPFpgqzyf5dU7gtLP2xRykCrhDecI4NT5iLup4VYROnOFfiBux6a6nzFoaPGHyfJMomhnl3gAtcFZyzMwmuVxwIchZjk7BLaU00tJY5W9oCH5U5ux8UZ1N2X5P3FAk2/Xhj66kNk66YltfBdwdbiu5IsinhW3byW2jG0D+oIsUmJcai8gDYfdy9WkGaTYeNR9zeyrBp62a+lKIsmxaY3U42gF8Ka5kp0M2632qtHJvkZny64gu/jmV1V8HqzIJ/fXDxiqsaU+TZ5Gf2NskQ6t2zdvCDabyXWtGKbMqd7Jy4QIlNz3uPqDyCCWML8iYosyn08fKMRTCoI/yuJ9QM6bnfDudOE/ZKUWXTngNGAiM1NhmrVVQWaLCp4YSF32vodN84VEyTTfcl319fBNP3MjzGZrGJ2X8golCLje+R5V2vYPmTzkDJOWxaKOHCCoFKPSp/efPY9FBWqrYBxhmlX/4IhxpO/hLXZpMhNe05COVDakOD9NgUKPtmXT70XmfyyGg+mxKP5StaG7DJJMlNQgCXUe6qarhL2+jYHZh5aurTGYZsWhR5ZI0bTKXeowJjNsW3VTfchxciEiLUTbCuhV3nlsLQP0tL3KF+eFd2/SLs4zX/TKQpmzz3vLFOh2Y+r/oGYeOD93vMzdi0++mLSSYWqPd/cf1O8N1ChR8CQm4ush8yrbGOZ+rLbtuxSbn9G2ccauWVuM9YxqbxyOsyFnD+QMXP8zB1WssvKQc21R6992QTjFdWEd4Nr+0Vspyxkk11lqxhT6gis31krRP2a5ku/J8zm+69K5sfAmdfX7k+wwXnetjaTHsdm4QqdAt94U+FPd9a4H2Lxpe3PJAbmwdRCzxR36dLLLbAaVdZFxnwYMCuteqbkHtn7kkXaCUvMfgCyl20aJ29GTm5ujtuA/xyTswnwxu5P6nmvNwHeZKYkhqylU2P5TNyj8FZqc03hf1Rd5UnYsuC2BTcd8a1Gm6WCOr/AHPL5BdM3camsQUDncuhClPrXzBkpDo/uboD7wn5s3EUmn+vezRhJ5u2GHNOTocTri9pjw9j02/2Ul4xDL6zNuo+LDou1TQCY9VOTVIPR72/JEREQbeTTO1MWOPjsMQuEn0bamJ6MQrvY/Ef9ENn8WhDlWg2udqtvGwG/x6zVLeHM3SfzMvdzaZPMXM2NsH0eptbk2PR3x16c+bCh9n3v6yCaezmhXHwZ1d4y6O9bFKfkcH8DLPnfGjUimdTyoYzWjZwpu1C+7kJbOpb7Hv2MYwLnjF1fiKep+bW7QyvWUXb+CSzSeryxeC3sG7LB9k5B5GLoPrbh+DH/xRXNxxBfURzI9/A6Q3fesRTcC5Ft10NYW1Blv7fVPz+8Afb5jT0ida1tm/w3nhS7aR0NvmYzxdZCW2G239yWDgXruTUITh9/yELYTabxCPVX8pAS9f4Jl84tCKqNhVKa5pJC3hsulEUNOct9D3Vd3QeH3lpb/Vwgu1/K7adgS/fhcrGZWCdY/IzqjPZtPdzdNs4PJU46ZJmFpuatlZvs4eauq9n+ED3l7dSFx7D+r4cd488Dpfwwk7BazoveOo5bAr4fM+48BTm4IsTChq5mDejgvtvTrNJNbNPoFzApkOHhi6E/99lHYGn4XFNp6UPC3GuGXpzB2GtKfeDfBGbekPy1VZAte+fFibAZ21vpxoVY5+ayR2vSnBe+Wl7FpZinWunZf0rR7/xJ1zzqmDTyQ7DziPw1uUUjsolNlU0Rb4tgz5ilQm/YEq4tKfBZTZlSUl93wwTbSwtI6Dzmhdax6DIugc7xK+wqedsdXpwFZtW3ouyvgDbuU+uPoav69Y+nV6N80+YfXMV/KBdPcurhk2rT08QnlaLerbuUlgPbeeXqs2uR/42Oa7aBIcnaE5RbEDOW3VVsxphkfflJhhRYZH7EV4bOWalcgv7bYhsDoLXc+zCWmBanGfmGMzekhQxvRn7nHbW3QxOa9zw8RCU2yNUOHwP/XFNVlm3lU0xkwx798GTMVI179vx9wpxitMesClESdLLEvbMZ7HC4MKNJbI3YP4Sr4D4DjaJ9Z1QKILHqme+mfCYTfMmi5k7QyOX9FXJUE867s2xJ2yao6ajeQvu+bpBohfWXv6vV74bffjay4sFhxTb1hQ9x31mIOQv8oJNI90n0xdCD/6iQ2vgW4FNmQ+878r7kwx1AuX3/ullU1RDaJTJKzbtvCJ60hZ+2D7p7XY45UHPYj5s/nOUndvPpgN7t5Y/gHanfX2k3rBJt+LQkiXw6huF/g0wz+bwzznv2LSBL71b+j36Y1Xlq9fw7J7EtdofMF8u3Ys9BoWXq4hdhynVBxvOf8Z9+KvM6+H/Hb363nOATa98/6vpGsb3ix5j4R+wjdHrLTPCphbfyYv94Z4rT7O3f8P98yjNLhWa2vroPYHym26kKI2iLjVhPe7w/CMLYsC9456yAWNsKv7dyeGMs2mqje9wGWRstdn+Gdooqhaq/sC9zTTQcocObS/Uk3+jP/oCra7DDQ9uWvRB5pfylHl/sG/Vlpen4ZiimvUWIQ7dCpu19iLstZ43XUKYQ5lh6ufM4QPWjqKrIhwKzTBVMxflUJyVoq0LFPiXx0TAyXP69lSKc2j0QHXbILwvarxroQSHxE8k5EbAM8tHbblwq/E6Zjm8VvTmsqokhwo63JYlwZAWf/laGK8gdUZRikNSPUMG1nDHZomGDhkOPaUF/iPwnfJAm7Ush8rWe+Ry5ThkoBV57QEsP79W9z95DrV9THb2VeSQ+82yk/lKHBIb0r5UD0vCH59TUuaQZLGiaQAsrQ1aOG0Gh+xnfGnPUOXQs4qXFQNwRURrg5IahxQDLxSsg447nr2Jh18NFq72ncmhke8i3XwNDl3+62jwHAYK2TZKaXLIrEFiizc8fDZr9hEYcqZ/z57ZHFpnYZBdoMUhn9wIab05HHLTO+oVBqPWXLIbmod6xTS8XaXNoenKM/Qv63EobVm84jPoe0MjRXI+h+bJlB/ZCF1SfceqDTgU6aDjMQCZyTZfphly6PaDJyXe0P1v/a4kIw6ZGG6WOGbMoVn1Ntp98JvCnzxREw5Jl4v1yUOxkm0vdWBw+C/VQNgi/iA4zpRD2jcY515DxzMdU6ebYR1DxjqbYe3EZ8HF8OOL9UKN5hziuu5O6oUh6/M/y1lg3SFF85bBjRXrp/lDcTG16QLYV/3v6Wvi0KeLGQPS1hx67dd/kgtdCjyuOdtinVWBGsrLOJQtuUU9FBrd1TWutueQ4SdrEX0HfH7O2vx9cJ/HA+sL0Jaf6lXmxCG7NY9uDcJniu9E5Z05JLtC6W/Gag55pBbX7XXhkBo/VLgZ/jde3j/DlUN6jy8OLoOcf6eu7YfqGtrfDdbhOZfVej1hgoa7l5sHziP8Rkkm5PQ3Dop4cihPpua8Hqy3uDYlGq52b5h0ehPqUa5SP3Ezh6pqPt41hNE3naJMvVHXLKuXp+Ga09Xlj2CszqGRv/BSc5fpRh/k6vbDuoN+qG/C5N7qraiLjt46dX/UoTzs0WI4aFSrcRj6NufZmAZxqNHy5o2LcMWXrkvK2/AcUfUnZnACz00nEor+sJ93ageHrK/5r+qFVPdeVHMnh9b+Xt9wCmaVDqWcDuNQTxonTD+cQ8ZmWZtc4Vjl87TtkRw6GV5ySy+KQ3yD1SWZ8MWxw8PFsCtll5RBNPIaVbLbejf2dWpdfwaUnvDiwT/4r/ZCt3ss8u55rOzhXvTp0c1SJvHIhXtAnidMeze96EQChz4c3eZfCTUVPDhCiRxSWf6kYjVUm5CwKByGBB45cieZQxKVPdzfUM5J3cv4IIeajESWmx5Bvt3a7+ikoA62/mY+cOLDKSNV8J/NFdqfyiGWwsvj69M45LxQd1ksdHr1649KOj5X/ktsM7TvG9H+zcIcyqt+qMbmUHpi7Ts7KPX7+YEoyPh6+LkxF/PA7Aqzi4d/Kwr9Veaj718JnSEYRzv7NsAW447DB2CyceYWhwzkmjN+tjYTOZF1+foGvrFICFmaxaHmsS/bvGDHUqEVr49zSMfvJE8qB3+3zXu2HfQpDHlXfwp9MrRAVjyXQ9Pusw2N4FjZfbkN8PSeOU+L/2/mar+60xzalZ6hp1uAuafctKOtkEPFKn+q1YuQ94+MIZ1i5N/7yZS9JRwqvHF5ei88mLpmn3Yphyb9ej83DO45zbxVDM/GFj7SKsOcOlmb4FmO+fN9l9YrSAs/vZtagdypxRYYwgHvA9GesD7mqmkiTAtbdS4blqsHnje8yKHO3Ubnv11Cn+az/+pcRi707PMcoZOOdOU2KJg/wXZVFYdWPrGsYsP5eQ3Cl+EX/YERm2rMp7QlT7zgFWOneTuucahbfEHMCzhTnrtiBPrWu2wQreWQ36tqdWPoyvHSjYFZq4Rkbt7AvbEu6KZYPYc2Tf87ZAlrLVQaaxuxrhcWc0eglrlJ5fRb6L9C5WJ/ePRsS8QhuPnzh7FbTZizpsG63+A19aSF05s51JD9YZovjL43fXPVPQ4Nr2IMfoFzRa8ZUityetveIBFWKJNRbjuHwpYcN+mAWo/uCSY8wD53fPIJhs+tnLIudmBOf98S+xEuVdhzyeIxh/7U2qkfhf/m/2yW7eJQzAUtVfNu5LDQZ2kYbMwdXbvsGYcWLB+/+Po51uNiN9/gBfp52SfJwJeYox23Rw/3Yk6f6/JTfYV5c3GPlQuUMTf8dBAesn5bfRu+3Wy0fcFr5KRq927/fszXJ5OUFr7h0Pilnx0boPyHA1WJsEb5wJKE9xzKSDTpn/KBQ8cvHX5nDz0m6ZxnwQPLJF0UBzh0Tq3thhdMk1K3TYCjW1oki/7vv+s7LYY4dNcvvkljBHn8zTjnC6fsV1bNg8KvR3/8+YY54tVaYzuKuvh5ugbCWWkPDj0b59C9D1V9qj9wn//3vNMGamUO7wuBlXd2P8yEM1sYiRd/c2jVTZNa0z+YkzObzXdBmXcLl1v849Cv3nm21kJcWixS1nwGfl1UPsFMmEtnzKl3Nbx+SPfLTvi+pewgAx5+cKvMXYRL4YEmgkYocDh/wE6US95x9exdsMbF8XWMGJdyf/jOtpbg0rn+dg0RKS7Z1WlkzIG5k6Ntl8PmUaG1TBgl090XKs2lR3OMt47JcCnafvHkhbJcqvK+uWYtfDhpfEoOHCoIHfeW41Kp1eEPd6Bk53pdGXku9VyPSOLCkUMinc6KXNI2PD27TolLTc5qA+LKXLJqLyqwhwP/Stq3w4jA9l8MGDLHr9ZIlUur8vaL1kLu1sRMMTUu+Y0Euy+HVla+wcHQVmmOXDacmm/UXgmnKA1O2KbBpQVtfsnnYQC3a+METS59yYleMwf+Z/osQX0Olx5v6/i2DApmHXLfCmPKMzsrIWudy1M5bS7VL/I5sQLKKKuqFkDOwYlpgbpcmhBTZyDQ49KKN0crheZz6UapzeZQ+EDn5Y8TBlzKP+/6pxNOLuhcIGfIpcBFfjYmUMprG2cDtLGz7IyEs1R//R0xxvPd6tdPMOGSXrbVS0+YwH/w85AplyIlvIo+wuwZYYPKZqjP1N2CnZAnmTueAhUevu3atJRLcRcv0hwL1KHoYjHDikvMc0FKl4hL/+4IZH7CfBO9nabWXFLM6XywGv4tVpC+CI9urS4QteVS7WRyYtlhH6y/2ztgw0mjGbbLsP8srUoBzNwl+LhlBZf8ezVWX7fn0rZHld9cHbi0ca/HpyxY4lP2sc0J9a07OPAOmh2qVJN0Rj0cyw+rwZ/Wi1avhZLXgwwjYWubeKrJavx+V0fLHFfUR/FNsTtcmK/MU12D95bJ7LGBx7WmGYauxb4aL8jcgWedbMdE1+F9E4+p/gdZOl8m7YIhEyWLY925dOk1U/2PB5eCfi57Ze3Jpb68mtFN0HqWY4XwZqyfsVtbB1bt1biwEpY8Phu504tLFuYDRlXe+Hn0n85JPlyK/5nSPgvGHDT8HQTVFpt6psNOp2um2/y4JBrps/XaVi71PphpreGPvrR4cqo6iEuMZAHN3MalO0wT9VVQ9m0oMwNuMJR10wjm0ts1D1d37cA5VgeOTdzJpa5GNWctWP/jTKgzXFKYFBoLv+3/78OtMOxX4/i5ieFcSjEYNvsPaj4Lq1ofhXq6XBi9C6/t1hnUjebSa8sihYNQtebMgcHdOH9B7Xb9WC4Z990bdYRff60oOw1Tgj/NvQsrdrRGLd7DpV96IzYNe7n0SnG/VT+UNvpeZRzPpf6gw9Wp0CBiREgokUtiwR/Zy2C05TSnXdBn4VnJIpiXYtvum8SlT0NzRQaT0beqgt7JB7m0LtuhzgZOiNd5sRV2z12adwy2nP5oUn2ES/cU+r9+hjavjmsppGBOBRnHOcE1Kls+7YKb46JmtUGRjYY209PRBzvcsu3g/dwL0f7QIt5SP4/FJf3JPKlx2NrA0FNlo08WaG5wgj+GxPt2wKglcqcSuVxysd09LZrPJU/NlX8XZXApduG+DWfgO+nS+f6ZqKflrg6TLNTBUPrDenil2C0iGirY3pYVHMP8utk59+JxLhl6LW3RycHc+bvx2Wb4aP/r34XQTGv2jsiTXKp2rhBinuLSWvO+wXro1X2L/wb+9X6Vo5LLJfHBOSqc08jlpg2drXDot7v05AI8d9v45pVw9aHHb7bCP53cgzWwsX/o4L6zmCM++ernCpGzgc8Jc4u4VOQvY7sdnl2ycbi0hEs61y47TSxFvo4IfTOESXcsJvnC/HVXunjwGblq7C3jUsfw4eXJ5VzKmZPR61aBc4j4PXvfJS6t7O8VS72C5x86taa2CnOqMFdkCNZqlp6Sq0Z+TptqdkLLr32bltRwaf3r4rGd17iUIZOi2gHzH55ZLFrLJaWu4MK9UIuzhRtbx6Xzn7Yx225wKc3KoUu8Hv0VGnjVHk6frP+IAW9eVgie1MAl/qlTQcawJF5Cmt+I9yiLDP+APRufrg+7hfMduOLHgl9+H/rCakJ9Xx6Ua4R/pG8XyDXj3jv+2noNVJA/8qMS2stF/3Zq+X9/LF7RdQ/9ZnsjQrQV80FpxykzOPvu7mMb4H2Nm5mb7mPerZAYknqA509wm2MFjxcwr/vA0uU3W1NgSn63ivJDLhUyLjE3PuLSQW7HoqsdyP9zpyLLx1za5BbdnQTr8+bJdTzBz/kzj5l0c8lI7lKsC1QY5F87AxNq80s/PMd86vnsYPkC80RnWvZGeNNW0HgC5hhsu9/ei/6SNRb7BsO9P40veIV77cLyY+HwP9uorbnQv/tFWmk/lxxvXj/+GPI8y/bMfoO6uh2L3AI/3+Deuwd1h9wbk97hXulolFv+HvdN2jSrm7A5/LD7ezjv27/qmR8wL7ICdwXD0Mn7xk/CHKHmngfQ8cvKo62fse8EN1XxAczbmrwZetCl70XXEhh/zmxuOJwvJsV+P4z5p2FRuWgE95kVq2Q7bFR/NxT5DTlPqmsohj0jPL0BuODys5fTR5HHJwZXPeEf9QPDeXA877BIzziXKrf9e7TxB76veD04cQKy+gOe9ED1f7duvvyJOtLJOdN/oS4/Tkvvhwf/zmWd+c2l/Wvqrceg3u/dnx3/cOkA02tFKmzz/Ol/CVaZ3on/J8SjLtWqWbOFeeSkLJKzBQbO+a8jDm6qiP+jNpFH+md1Q/kiPLqxfCL/OqyNTBP5Aq+flt0kL8qjJ+tqr1vD7TaLJLZAJ636LGsxHm2bdnNvgziPFPlMlzcwaXnKJScJHs3jldbshak1o/HeU3jk7OKs+EiSR22ttYFiUjxafMPr2CppHt1MmVT0FW7hqMXNluVRQ4rKxS1Qc+aS541QRWC0ZJMc1pe5zuYMTF6v3L1SnkfEUG8Mg3aP/dx3KPHo5H+/Wq7DVJPkuTLKPJrzmDu8Cr5TXCjTp8qjwcWbf0qq8Ugt7fuaeOj+KNi1dCY+19R/5pUG6hD+QNZak0deFxzdpszhUfDJS43L4dI12XcDYWvfysFr8Gr3ma8D8JFH79xd//FIa8hIqmEejzoazBW+Qc/TgqnTtXlkeD/CYDHcsbG+LRh6zxE+kQzTvhhenDifR7Pj5P0iYWxLuscaA+xTr06mC+73YfDUDXlUY0krV/7fn++OHoZXS74UlhnziEmZwR3wXcB/PZomPPpkdGrbJrhScb58Enwh3qO4ZzHWpVf+y96MR1Nd0lKZsDbH/ab+Uh69CdrcNmLOo2Vb31bqWyAHP5rmOcHRmMlZe6DNBbfbcVY8WhgS9rGSeDR+42jHV1hsdzxgmjWPKj6MnFwNx1T9BGdh6c5Lv5JtsU7hj10ZdjySFhkP6INR9xevlFzGowUrjuXbQN1ys7wQOEu8L/IstFKWWCHlwKOc4U0HufBcRuinCzD4DXP9Byh33cjmvBOPEj/8+fYVJrDqMvycsS6XZ9LJq3n0i2cVIuPKowHZ1OOrYNvTyTMF8GOaUVYJXGbA0Ji/hkdK8lMKDq3l0d1+nucPyPi7sTp4HdZTsi2bDRVPaE+vgfoxL/pOevDo4dvNHX9g2SNJ8vbk0d/JNwqTIW/Hpku18I0uq2fFRh7p/J45/dwmHnEmjTVM2Ix1Rz+74Q3bjm+/cBUOPbkfmuXNow3MwxoiPjyatmYo1hi6bWgbj4MK+4bZzVt5JCNWMXeaP48k39nnaMOkznMcW3iorN7VHy47crBQPZBH8t7/NFqCsO78gp3TtuG8VBcOOMHL2+bmRkCDaXduf9/BIyMfC/P0nTjXl5kTLEORx7w/M05AhZRin7owrHf8yb/p4cjD4dDJTnBNEzvpKIye2J9WDH9K/d7dFsUjoeWrO79AUbX54lrRyOuLbl4GnK4W++rC//8tdS7nZAyPQuTODrbuRt8FLL48J5ZH4QfUtFLhrcx/3GHYNGuah9ceHjmyL/n93Muj51FVflrx6F/LLXmOMHuaMsclgUfPvF3ZronYb+J3Cz4cfD9YO+sgj/yMlfPDYMWSSc0CmN/qxvh6hEcP7O+KzUtB/5xzc98OK/IGthccxdwxVS9zSOVRc3rU11tpPPovTdX0DVw192zTlHQe9SV9t/Vk8mh1uceG6ywe/l8WPdWIzaO9Yzn7u7nol8NXXcp4PBL/nthxH9pk/Y79CJ/sfaisyOdRfGhsrTtsj1U/PyUDz5d9FBsON8uvVJfOQp8Uvm7s+r85F51vHsc8uVupMzGHRy0zvVblwqe2Dcr1sObNzMyYkzyKCDBZ2fB/j58xP38K6/+c9Ec4l0dTxpIr3OFI3qIDBbDqht3DjQU8EjaQmVEENy4o5vUXYo52CUWoFqFPHoyELIc71Ge4ZUC5q/bq90uQ2xknrlmWYr6MnLofA22ni/WblvHoy577V3zh1+M5udoVWL9C66AzLLbWyBm8xKML9q8r1C7zKCN/voLX/51oaB8D3yU7dh+DnkEPHdKu8EjkkP/6Enj+n5dGaxWPjsxvzpWoxvkNS0gYwJsuZ5l+ML7fw7SwhkemjmHlprXoo8vzTwdBv4WivjmQsd3nBe8G+tdtw8sO6PPy7C3Neh752vdWusEVLl/10uDGgNVFmY3IpccREeVbWHf25dkr4WivY30ZXL6zYE7GHewvenroHWh59cG9e008cglQvvITfrlWut+imUdSPo8f+cE3LsbfXFtxPnL2EWkw9Y78LaP7mO9G77nP23Fe1nv69j3gUdyk7YmxHTyKYa3Y/QWONSus2vsY5+TkIX0FLm7MHzvaxaNLTc/ijz/BczXYH1S6eVS+6bhJACyx3vErB7qyL15uhjFzGmpkX/BIb0r+RHu4/U2M2CF4Z/3nivqX2H9y7pe7vahXVPxz2Vfon5pAYWN4/MqW80fhlB/XRqvhsUeifttf417YzB84CQ/LNLCf9MMaL5npb3g0IedMuz9MKj3UxIOefg8+/n2Pe40vOG/4AevgFt+u/Yz5Mhr66jf8LnpRT3EA8+KavO9S2Dxsf3QjtJvrrsmCgZmh0aIjPDrV7B2tD03NorWsoNtVA5UEaHI562X3Vx6pJqo1BYxizujMulU1+v85suphwBjyayH7Z8IPHmU1qTyPgifq/3Q4/sb5pShVhv7Be2WrXK4I8Ylb2O0+SZhPItPl3GbD59c3niyD/t90dNdN5JNMila0vxif/jz5veqgOJ/+ZXuoqUjwye3FSmUzOHmaUDwfji5tP6wyhU/x79mzf0vyacwxqU5Vik9HElhLfOHWeOP4c3Bas1GdvjSfrtqMxk+Q5VOsQuFjfVgZ6fo2CJY9OhB0E8pb2S/Snc6nbeUiNgVyfHpnvP6FqDyfBmMTVulD/UdOQlvgr2lGGQdhbXj6sX5o7yuS+luJT6qrdfN2K/Op49RTu0Jo4h/EbVXFfv5sqxmD2w+sctJX41PIjMObt8Ms3psDK2by6YPYozfF8MH4VM07GnzK5e78K67Jp08L21YtgJvL7VI3wNfLho1ToOWpv7ktMF9po/4rKKtfeHRIi08/JHRf0hw+HfqXbnQI3nu3QGmmNp8qpu686wx1fXM+CKD9U2+dKujYEy03rMenhx0HYlTm88mz6vl3U/iprdXRBx6dtZOXDsv2tjK+wyzLZxvOG/ApOfUP6z2U6Yu8qGrIJ5s/XrsdIV/7xsT98EVUpsNlOHLttG6PMZ8m7RCWlzPh0yv5Mwd94W8+XyoPig3lWr435VOJkuSF6WZ80lHfHrwUJrMn346G6l3l0q3Q3mfi2j5zPi3a92mioQWfxA/KnTwO99sXh2Ra8YnDiL79nfg01fziJXtr5GVPe8cdO5yPmQlLZRmfpN0FbY7wzMl1DWzovPBIa+wKPs3SmLB/gQPqsqBvcA8U4t/oXrSSTwqKISHznPk0vNcsxgz2hqpuYkBdyWwlp9V8yn4Uk9AAzfpbYwxckQerlc+cIDv23Z0d8P6hcZMOyNqVY928BnVYuUtbbx2ftF42uYdB5fyiH7+h5Z+9Ut89kOu/z89qePJJyi19pwc0VPVM4sPJQtEKnpv5ZLo68VUZvNDT7q7ghRwcVmvI9Mb7xxKmXoLNUhpnWD7oq7ml3X+38mlD+SGWvz+fHgsv9i6AZnPryp7D+RcVP+UH8inNkBKqgvjkq/1js902Pv1V32Fovp1PWzKWaNTuwLnohzWJ7kQ9/J1u+8KypNUpdqF86vyiLb8fXqgaqMiCzj+Nng3CYu2ZMt1hfHINPzsuHs6niAM1kdvhwymcKDYsjrNoL4fK138WX4riU/cr/T39cEk4L35dNJ/mGmk0bYVO0c4MNuRI96TrxvLpSrFE7kYYbXivczds80/M3bwXOXcv770JC00NO/phXMTpiJnxfPo+VG3jBOU8HsSFQaXXym9EEvhk/fNEhVIict3w6E4APPJnozkPyi170VcP07Jf5GxJ4pOX6pb0nmTUYbFcmsJBPq1dfn2JATzDEp18Hn7a+2ag/jDmgtyhDPUjyLGsxHGtFD6dd3CqPQvfzvRfexcmsfXqu9P49Pm5VJRkOp+GLkduOAzlZiWN18FsvxdDaUzkPnLlr05otjuQ95TFp4Ip767PZuPchj4PRcN3r+OYLVCvTFFbmI+8+ERMMYdTFp5bkgNLJ21SvQc9Gq7rd2Tyqbz5wMWPcN3RJ/d1svj0cTQ7fR3MKa7dXAh53+bn9h/HHDMtM3PK4ZNwdMvsQDh+wirT9CSfNCWfZr46hXxJWW6RzEW/eS3fZAu52zs+5EDJ9Q/P3D+Nfq4bjtYqwNxVH9O2htnF+fVp0Cz0wbo+uMl7X7X9WdRBIDIUUIj1LNASGod3Tx/3MC/i0zX1BYvD4Cr/t0nqxZhjbCenWyWor41P58RSPgUXTGYGwuS2mydWlKEffpZV1pXzabf7ZvltFahjsqNGxyU++RXcc6TLfApdtCwuG1q7BnwfvcKnHmamUXYVn7pq7vHfwov2W2+dq+ZT3j331MAanOe+weyea3h+LdtzRi3miZ6Cwi4ox3zWWwxXd9ru+HGdTy7/iQoe3eDTitp1x13q8XPp0IkFMGyecLV5A/o+aVfHYCOfZrwY+qJ5C+fEq0q3vIP5o8/wDmrmk8qrYrNhOGPn4OO2Fj5lBth8c72P/DKnXLwJt3BT5lS147kOtqd+wDXeFi8WP0D/LPMtZMMi1fxiqcd8uqWW3+8CLUX3ObXDwENXCp938qk+85xCZBfyPyl1ZPQJ5vX+iZM2daPP60vDTj3Desrf/338nE/phnGJa1/gXqi5kFQCT1i+v6LwCn1sbqu4DErGVGznwgF9d5FWKFqr5uTxmk/tn1M7M2FL8ETTDW9Q19Z7tbEwKVA1mgO3Z40fE/uAv38RqDcf1mjujlsNZYc7NgfB6hB5CQY8lHAt5jp81c5ieH3iU9WJ9Skjn1EXu9A25QHkM+mSrBOsqvtey4Muz67VXIFzO+x3uozwyWq2REgkXMS92GE8yief8kcRiTCyIoJfNY45Imm4X/oHnxaY7VkTC9+PrdWP/oWcbWHJiPxBbhYWqPwHE0+MtDjAudIriuJg8e+4Qy3wSlzk7FQhAbUu77ptKiwgE3FRQwcYc2hLSwC0C/xrZj9RQCs1drSriAroYu+IuLiEgC4LOFp6cMXB/NFCOFK1Rah5soAqNK/fuzAFz3ubeihdUkCZ3F/XjaQEZK4R+jsEHtZuu3xOTkAFEmNHP8IJRV6esvICEkjUxLnCZE1BoJoifn/bfpKwsoAcIjdVH4B9voaye2cIaJFapUwvHGSXF/eoCsgrYk+RmJqAUvgGTW5Q5WjZ7CHYcC1ghetMAbU0N9WnwdOatj9jNAS0vE2IPUdTQOtOjLzDuyiftyf/tpaAlHeL9TjMEZC3ymeFo9DC7zYrGz479XTrNG0BvQneeeysjoCWTK5ZEKkroLrhfuGl8wUkWvjuRrm+gMR79qpPMxTQwbmKil5GAirlbdRiwuj7d9Y0GwvokpXB0c+QZ15VOcsE+5FQX1ADQ49uYBebCqhbg2VZD5+NnOhfYSYgrSxhqcPQOylk4fKleP84eeTBSdrjWz+bC8hFZVvqPAv8XKVsijVMqf2wqQQufJbPukICGhZjZ1laC2iNq8lHPsy/x4iqhBXnPES32+G97Yv8G6CmztF/QcsExNb9rHwOLtJTX9EFZQcZu4xW4DyY156rOQhIyK3ooRW83xSjEAzrD29xyYAbCs6flnUWkEdL6R0tWDxx68tkuNvui/UFFwHddQhUmecqoKiuq9Y2sGYm42HgGgEtCPf4dRmOCLuNOa0V0EyOpetN6HC7c+4z+DJ+xhyhdQLyeT90dRFU273CfhccSrx89iysOeKoPdVTQNorJqhvgdJm5+bvh/lLE4cvbhLQH2HFOvHNAroQsPPBaji/67N/OrR8FqBXCblJ3b79sM92kWiUl4DCNrLXtHoLKOBvZOFkHwEx/NwWRkKf7eMvBLCxUGbxg60496VXpw3A42FclXf+qMPCjTFO23AuG4KWb4WtnbPNK+AO+VkfvuzA5w3uiSjvFFDuhFcfLWD7Yf76SzD+SeHm7aECSjsi3G0ZJqA7H2bMMQ/H/ppLl6+BV0rT3x2Fv2I8Y1mRArLpSbocF4X+s+7faxItoODm5pbVsKt519JsKKtT+noYupSumJobIyD/lcJHKRa5GnCRPgQHm3Tc1+0R0BOV/E8P9wpIddoG5cfxAlJKtqjKTkD9sg6H1cDfu7lpMxMFJBPg6roJ3q3KdL4M700v9hU9IKCsF4zq40kC8t0zWFMNf6UWD1UkC+jnhIjFn+DZIBctl4MCsg3YtSga/ouTOVYEi7yaT32C+weSSzanYK6wb+sJYIXA4OmhVMyd4O/VrHScg9DjHDemgMb+2k5ew0bfFv4IC4bXZs/cLspBbhZzt17kCohlHvKN+Ohb74D+NBhaddRvRoaAti7v9+nJFFD53a2P52YJyDozJacRxqvNvlt6DDmmwrjrxwW0be2Bl6wc9E9Oe0Q7rOIyMxxPYv9FLyxewYi308dn5goo4+CPDB849UyVeBKcNua3qRJG6Xa9egvl4o8oP8jHudxWu3rvtICaluwaWlogoBva51VDoc9wmNEHqOm1d/msswKSFL4fc6RQQI5JesariwQ0+/PA/DCY7eIhfQxOXSOSfQd+vGOTeKYY/fZoqlUPrDIscTQrQf0vuoechsX7ntx5Bgt/SE+1LsVzUv1OBsDYzHPPTkHboTDHN3DHr6FJWeUC2qL9sO4HbBCYyOhUCMj1UvuVRMg/wh65CFPl1yg+vox8vrsS9guaLa3LUK4W0ByDBUX2MOxxdV0qbLnaXdsFy+zXjH6FSpKy7Rq12P/qOl447JQrHamBF27kDcjcwLm2PjWcVo85tPrwmUA4P/1e+hG48rOdvPAtAZ2K/jq7GBqn3xj/DK9vmKDU1YR1uh66OrcZ94DWlpwmGH7vwvi5FgGZpsVtVL4noFfF+y+/gnLXl7YsakUfTPo24AeF23IflEDdrYnb5O4jn+s009fA/wF3ZHhP</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="34512">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwMl3dYiF8Ux9tDNKwmTUpLW5Kc73kTkkJFSikyUraQWUqJKBHtUGYaVhElFBWVopKIhqxsP3v8+uP+8z73vs99nnvO53y+q7Pq0LzRkvf/E2iKcg/Fb7mC2fvEBc+mcl6r40hL3/2D01hH8lO1Y5/xjlTY8hZibaVI1j7I4ydWUPSSHroRdAvNkg6C+DkdTtIJh2+aKXN1CoUGhDFPX8lJx4pwfLo/ppqJoLY7SchxVRWMf6RgvPlrWOwkx80V7tiPFvaQViOxxU38eWWKUHrZEuWnnqGzrYJ+qr8gh2sER6tUmmT2iocIUXxn81Sk229m0dMF5Hs2kJ8eXs13Hu0UurxTaX/3XM6T7GGF2wn8YFIsluos5rPPXyMmVI0CzI8hZIgGD51XhNeb1Cg0Q41aZBIx5GAlli0cJ2zdtxJPfr2gyrdncOtMKt02KkTBfTWsuNaImc+KEbb2Ko/1K6S7ot3YnwJEWD9E/duJNE3iPd509qImex+vv0msaOBEp95Nx6WLtsKJInl2PV6IuRa36MLCXr7gexoLnNSxIcgJwZPVMWPQSIQ82ccrfeUxIHcc77KyZqeIZah02wC/MXU427YKIc72wgqVsxTutJfdxZ7yvJXW8EuNwIij6thzqu8fV0/x2vDjUD8z0VH95y209T+M3xujuLP0Bd/X2I/AuUMwYoEOf9nfDy4z+gkW8ZHcG/ePJGgS/Quuhs1vHTYwfQu3tc1YPOg15VV+orUDNehV6G2SWn+b7kwpEHZ4NuJsjSPvODoEF39+hnLLWRpQ1w+Fu26j1z6dcqBBeuPScFR+JkfOmc/zI17TRsvBrLvzNZ2qmMbaV7ZxYfJrSvg6BP+O3ITy8BWYYjMbX3ak00ODTH67Wp1XVo/gr/GukEvQoLab/YRpIzdC+64Ntl1OJ2Pfang16rLgtxH6V05iputkch6bJcwpfcoHDar54SsN9Aa8oV8pTfCLqaIFzfqQWDON77/QFQ7tm8y7r9egaZqHINppJrz8LM++0RP4fcA2rD1syj92JvPr8LXUtd6YO3wkBGOZ86S9X5/HRjkid0oGrZ42DD9OOcJVvJc+PwyCVY6o8Lx2kmPJOWNYigXzmiUZZHZKlM/YzsNgmQHCwktbBbugXpqhHoeCnF6yqcigt6udBLmEhTzyj6Vg6k7sPnEiMHgzJsWfRey7YeT1sZcm7voMh1+jHXd8luLc2tcQ6S2DrtNS1lC8iO7Vi+Cf1gAT2UyaoJlJV40yaVT7MWgp9hf0pi2DjOo66gxOwuuZbynqkC18HqSgzjuWp43PpFiH4XRo7nDS8HWG2ehz4MwK1q5VxuAl6ygmXoHLjUSEvXu+obtZB7qnl+FyUialHxoO/cCXSLGZyvtzLlD4jlf4Kq4CiyYtdlrJXNq4io0U35F2Zw0tuDucWEWa9y0/hmVtw4RXLmMxvHINi3xzJtWacL609CcSujOp0U8FBReluCxABWKmd2iLeBbtN5+KuMblwjWhGQPHPENUgxPS7t8CD9MkZa0sGm+hCaP6d9QhMQkFe2RYonA9mcjd5vnJkbjroEkqP3JZZsgkrN++gTPU39PD0T4wnnybJUcMRNPURTg8RFqwOmImvA6PELZs0qTBUech+/kOdd39J0yIzUTPsMlsLhWPXaaj0fTusjBo8l6h6mIW6X+/jx2mr6H1Xxzaht9jmev9uHFZDCRPfSerwMs4GWov/PchmeuP2whXPmjiZdw2sPQHerfRhTLiP3FNyRSWMBBHbtRdGnGsA4dOb8O91eZCyOCDWKc8gv/zP80Kl1yQYnuY1ogM53XTIuHmF83laQOE6to07HafjAnZxXhQMUCYlDGcr4mFwzOhCIVeWlicsZ2L94YhfflhsvweBGcrVWGO/SmhvUoV+8Mj+WP2D4ruvxQS/+nhyB4nnDp0EL8SbrFQcBq5VxswV7kJPZZ1ExMfTcaTRi0apHqbLcf8pF/f53FBtbdjkaYibxoYjUXOP+mf03we8/0gukoPYO7IQCgHF9OpQx8hU79DaJ6nhsLjjIyNYXxaTRuKpz+Sc8FH2mJ5hNrrPtJeKVcU3/9Ja/rVUb7IZ0x7/pFmLjzA0ouj8epdF6816+G3M7UpUPkTzTurhpxl2jTUuY48Lqnh7RINQeZnOkbcdReiF9lDxTMK+3QecZW+gCOhe1FzNktwNxgJ+4hPtOLMEdpwToXPZVRCpCQeLqvKhfDi0yTTrE2rW4+Qg2Ml1z7RRl2nApRmuyPQWFXo2PwAO21O8WnZa0K+9SS2MN3Al0U+QVLlKHl5qUPdX1HQOmKLj3CD2mZ1rGt5jCCP/Xx5Vj3d9KqHcqMt52QP4uypOqSx2YEN7vqwjVDJ8yTm849lOkj6O5ovnE7E2OmmrNujIxx8VIVLj9I5yEhRqKo1EXr66ePA/qNk2vGZfA4fpUmf1kD2xFGyOHmUHra44fhofWQ928bZT+vpw7N6+nxuCJ/ZYMOfG8ajedtnfuU1l696XCaX8qM0v+4oLVGZjveDlnOF9B3+Mt1B+BR7H7oj71FF0Bjhe8gfvJLNxl75bJoy4iWf/5fGnwZn04ydSnxv5ijeVPSHWm0O8WvDUshYZ1MsZ9NolSecMWqWY8BmDeS1VmPeyXt03iWbHCTfInieOgcPU2WDiv/4QMR9wVVhmlCYPIirtuvSksD/qHvxf/Ql1gXnNBpo50ldcnIc4bjxJIR9BjPw+lw2KV/URWGRLqYrj8bIQ//R0Du6pP/IkX9KZ6BxxAihpOQ2X8lagK67c2HTP5xjZ+pzro8jeyh9pb1Dv1L2yY08WMKWr6wX43LnFXj9MoL9XOP58upEdtBX4WtRKzCwYwbtNtzNzSbSHL70FA+Mz0dEjyJ3rx3GnYa6nJ/8j7rGRuL+vq+k0xGPfqv0aMSaHJqmO5M6y45D68I6jJplxNFr17LSdi2+XSfPYfMb6fzeAMeTMOeS+YkoXt5I3yeVsuHOSDzYMJP6teRQsISRMP25GVtIj+Q3aR+hJ2+KsgDC/p4cEmMRpBXNJPf+x+jwr6XC4LeNVCQygH9t0xKy/f9g3nQ7fpc+Tnhnd4yOTxhBT6MWYsXXoyjnWyzy8AWOiujzkb3h9OhNAq8O/MGuL0bB4JgrEt3coarynbB8BE1UT+M6jx9ImnoF0mmf8d/+4ShfNJV3Ws/hl+5aAlstFzKcBvOaNHc8fp8A3WMjKFo5Ea5P5/KuhyKYc2oEhc8rQdP3E9D2KxYeSGxn5V8/uHvoBY4oHoHI+6tg/lMEdtbNsJSU5OjqYRz1shPTjVey9Y51/OpYLvJPObBGniwrJQPehaZcZuSBI88asEl4jFUWD0j+bRI3WTSy5lBrrnn9F/fNftDHs244cjEKiz+nw87Xg3ymiEInZDUPGyuD5P3fhfrrisKXNQ9o/8SRtCboB4Uu/0HNq8Jwx/U4JWno8ZuTHrRu9FfMkn3nGJN2l1dse4R7ZR60UjGBNednCHER8bz9bQqWif6Edr46f7vbwPPVf9IX659UuOaiUL8+Wvg0OYOvfFTBxiwRobx9JJV7DEbskO18o+s42cOTzJ9HQDNgBz4mO3J451JWXnEJci3GLHs8BJlGLpin4o11NnXsPceML8Xa89slE5leeHOc51Y2D1rJftnXEOy/nbueHuKWyeZ9305Q253vKO9tIo+mVThuK8ZrV5zgS6n7hZwfnuS5Tp/Gy6uyuHEz3f0zGLMmX+XjZs1UFNuAvYn9heeXGvve/gy2njxBBlt/UfVZfXxK7cGnKn2yuauPgiuLUPriBbJL39I0pa3cZQohwUIeqfNkWPrWLxr17QWkWvq86PdNeHlm80tlY46Zc41O5G/HcslUGmWrKzyfso/Dm3ZyxJgDGKVoAEOPWXzPTBvjZ9XzjNQH/HzaYjYdacQKVXF8W6GEg/vcZcz0qTijP5vmDGN+6XSKB/fo8XSvOJgXyvNVVRN02ooIjbs+ctCzWvxba0A71p0kiX2lmLFgNsr2GdCqxjI8mpWIFK0ubO2K4owHY1jS+D1v+DyOk2P1WCI/GsPyDLCqPpPPq62A3JkWJP53B2eniKP6bAuuKX8XPj8uQFaTAWqW/iG1jtmIDJYXTHJN8FB4BK2petxiUImlgxrhM/YsY+V70ljyEm0jR9GVCyH8XqsXwr8TsDXyoqfwF3zTG7kgIktQsxlFmja1fPzHOvZ4vwLBc2dgml4ht3QZCa6LRpH+ukKc3f6QsteNgkpbJFm6/KXZ20U5pjiIL3vXcVPuQ8ipzUeDiheX1SZzY/Rsfu1vDediL+oQccLVklOI6vQinR4v/JsvxeWvvEi7YzNLTbLjbG9Z7v7wkMoGSMBw4AiOX3wBrs//UtNrb2FNmB0OZoVxIX/i4y+HsH7hFaT/HUWKa/0RVDGAqw+P50e6p2nFzKdItwTjuSmLmJym4W6GCE6K5M5f1yGEb0NryS2k/zwBxTmG5KOzHepSN2j0nm2Q027CuYVbuPjWP5qlqMTNNccgOnwJex9SRsRpP3Y+Zkh8xpBKj2egftgjGnJtDG9bLMaqUV84x/ski189TW+9pnLrFHm+v+cBbzMfLIyvtOEg3aF849YUNv4gge11O1ls0CZBv1kXVtNE8GqtCa8ZkkvTpc25NDQVlVZx0D37VPCzyuPtFqksVGVywP1JGLvjDW/Z5sWjxisKqR4Dea77B/73+hGtePIDrgtz6VVGNy6auSGl5CyfzDuD+/fj+KpKB8pXvsIHt1+ojh/B1jFGdPyoEckdyyVRjzbask0P/4bGIjlAjS/4+NA235/s8zcVQwJ8aIjmIk6S/o6XVbmU0l2BrQV6OOc3lA+b2GH60BPQWePBRp25NOjxLAz2DsHJ57l0IOogMoMe8+kVczjzSwvb+QwR9BIOIvaZDw1P38PdWsbQenAKV81sMX+HG/8cOhepL9TYs7adLVfZsNX4uTg5NBrfc9IQ7BbBAae/oj7hDjIHThPKPRZy1yxRdpOawAfdI4XbSZN47JCHPO55K3scrqDGzOkQ+zUbe6rnksodZ7579zGVpJ6FzT1jcs4sxYuQiWwq243t2VPg1mxMtx8a04FLovCoKYXimWye1s+X3o29xcPWaAuPJfNoQGYOPiQUYIt0DXz/GwH3qU9o+JW+XtV+iQkf92PxC1G8OluLDeNNUPwhAkfExFAVmoBqEwvW9cujmgFOvOE4ceeGXexZV4CkzZWkpH2e0yq9WGGtCX5Ma4KL6B6Y7DHBG0MxLPobjebNZzlXI4tEFAfxy5yxnNIyhlUWebHnA1+qfeOLtAlZSC3M4cy4Rn4qLIRB2SG2iHISTogrcM+dPLLtNqGv2+VheHEKp18L4ZMTr8PR2I2NPcYIu1x+QXzuHhR5WPDe/UVItpsN96SlWLDNj17myrHVwGs4duoq7y+9xNmGppRmbkpSk/Jpr4EM+3x7DksZfey7LIaKEjFk9dfH3jwrQfJQDNXsdsImh63ccnEQCqZdQ7VPPrWcjUH1RlNa7+DAPtvy6bNGGrYWEmfb2vI10VCu+ycGKfN5sKiZijdH7DnQzUGQ3yUh+I/5gGcXTSlsvCkv0vVCuJ44Vj0xhYp4CnzmqwnHVTT5TPIOLL+mxN5yKXi67Sk52IvDdfQV5MCM8x7kwfPGCZYfo8E3xpsIL9vycCo6CpMUM6H1xBuFHXnILZtHp0xG0+IYGx6hPk5oEPvCHWMyMcv5O72u6nPJ9G24PGk0Iq3s+fOKnSSZl8n04QArBf/Bd6tEGJemomzedrxSVuaq9QWkkJOCVTXjcOBaA7alFdBM0cn4834YyxwtoNT8FISt8KcfB3ywIOMZDT7sT2NvVWLKs2aEd87Cn/DZ7Fnjg9xn4hj0qIDkgr5Auf0ZJp/wgGK6BM+yu8o3JcwQfGgOJr3zxyZZM7pRk4jYoQHISAxDjbYEkp+UIenQcu7WDcD5mDOYYvINJgN6oC4vizUSy3nhVDOSGeSJ2JpzEJ0dQC8do7AxdC58tj9gnQWFJNveN698grhZexNbLDTkj8ajcH6xBCo7NvDq5A48eScnjFzfxSr5Rhy4SgKzDfdjQ04hvdfag2X3Oki6/198uR8A/dJC+tvUQa/CvGHdYMniMQWYbXtOUE+SwLxtssh7UkhBtdasLjufDi63YZEB8+njUH3WW2+KUwPnQ/bVG/wMDYLtlRP8amU26gzP4Ou2NbAKnMgPw7X4poY5aRk9RlqOKyZPmsBGeuZ0gZSgkJiBE1azcKdTlhPGrYOd/Szk9MSSVL4inzjmiyitpcjouMfn66r5aMkNnN9oTjldkoJtuDlJmpvwePc0TNthTgkX12Gk2jpecMycTmU5sdK/8WwYLMfrzv8is/XqvPDSdcwSJHHt3R6MuHeWNEPC4WDswGvHdlHV0KGOjpK1mHYimwts/sD6QA1GiSpybq4bYuwykackKzTVTWQ790+oi5FkH8dOBA84RyaeuujRG8N/HnawxpxSHNd7g//GWMDPezZM+if2zQpDlORJoqBAEnVK6ZC8WQb77FooFkkI+/T7ZvtdB9bXn478jwWwkzBgihnD/XcVY5NaIdaJTMC/NAv0OM6D1QVR7qDvEMmzx0ep3bTBsh3Dre1YeBoMm4jJ3P/3dq5QkUKbqhQ29pzD8t5zZG/lhYUH3kH1eCA1iM9kJfuH8HESF4I3t6PoyTycnymF0aNzoC7jx6P6+NJ+VFV4dO4Gq/xwYLFhpfjhYEmGImH4uk4K36mUPAacw4zTQ9l682ShcOIC1tRP4BPrztO5FCns2nCejhxtxKzWMfzqqqyg7PccOq+8MLlCgp1PG/OcY1I4udMSF45YUssxS0xuTmavfFO23zCfiwosYX38LinZnsF/txbS3hp/yCxP5/73FlJvfBanBhjjXVMYwrosyUv8Al0UtyLzW0FsOsmVU2PrcVv2Mim5VCOhvxUN6ieNHXdTcHngTOgXjuBxelYkbmKF66ZWMB47E9MtrOhrUTl+IgDTX17iQYGeHDzeCm8nz8Sx0dIYZxODZXbSWLE6AP1WzMSmZbU0+qW2oB3RQ+vjN/KTomrcjA5Asp86D9llBdfFZzg2WBoF17U5M+I9LOVm8na1q6i2sWYn5ymscPIm9NfFICP9ILYo7cJu12jMWJqFiTcuEH4soquK5VhjMlSwfF5LSp0XKOnFBXo1sQYpQRYcdT4GWYbhKFbYyJ8Kt8MzBqi5Io3lbi+otE4as4ZepJPqe6GhZo1xzu6weXQeL570h4X2VI6dKoIuy2SWa5NG8kRr0v0mjUd3Dwhb8l6Q0gxrqi9YTK/DqlnZfy5/C7LGt48fkVPkjjf5Wjz9vDjrNRGHt88Hj7kszDe8hGVn7ZC59RKLNp1BV9tqPj9tAJTm3IZrmYxw7qY11C33QaN7F8xDBqC9b0U+kmQxRTXWjXHnwNH9+c7AGuiv3UNrnylx+K39sH9uDQOfDRwnWkQ/iiW44iTjWKKEozAxBpdn1aO/QhH5q9lg44UFyDUuot8b6ynItIgSA6S5qf4l7Wkp4pMPXtK3UzJsRgGoL5fBk1EnEHbzOpKkg+ih9S2+ZHaA3e5ch/zOcgqzikBbnQyCYorIoEcG5buKKJeCIPEhFHsrd/PCuw9R6ByEBaXH2SPZhnQu2CDyog35p2XiZnERNSYuF97d2wIZ4wX8ccsBTNUvgPUtG3o0ejQCu2xoqFEfH18U0dmXRVT/8ST/98aGpprL4ka+Pir/M+C1VrJ4+Eub/02QhWqgNFeufsghhjVcd/MXLhz2xOvgvaT7XZGNDYtJeuRrMiJ3XjfqNf00KkeoqQwrjwvnKrEKxMWnC74bj6FdygCpY19T5uxi0jy1l1I9LZgWLKWVCuksLjML+wv3km1uPY7onGK/KDl+1awkWMw0wBIvcb4ZtwcHfAY4arS8poNKY3lZqyxmtufjy+OlVDRnhtBsZIavd55jy/timjs7hN8ovaFJ7VH4Fd1A8r9loXNSiQ9uymDHYcEon5WCQ+JuXO4lhsPSfzDBYBH2T3lDbur98FH6PHJ789C+ejvSkzx5fuUu9h3Wgfp4fY6I+4vWkf2QNd0Wc7PNcGWuAr75HuInzx+hti0bg3r68S8hkU/42MJtgsB//S5Rvb8tTUp9Q5uEOlyoLUTjfDXuuh5M/l8OcIPuKNgrLOODjYd53dQW3NypAHYsxoj+esg8ZIugY7ZId7/OGUkCnzoWj3VnL9FTkV4ERG5nXcVHaIrth9bduzDW9wOflfjIrS8ycOuBO3c+GcBDOy7RnvG9uD7aHOdz+6F2agN+5/XDo5e2dPnSftTu2ciXJB7g/W4jHuwuYGZ1P1iaO8AitJdalTL7PPMZnm7qpbix1hyY3Us7re5gWeVhNpBPwI8IAQ1zUjFYRJ15YAINen6HB029TIntfWc7JVnaTBEmCy7TjZ8VqHsegrJ+Yiz2egcU34XQKhlX/rrrMt4enIrVe8dCujMWH/eu4Rmab2nYf3qY6nOfSraGcOMFBQ72TiCzlMv04/1dDJvkD/V/Z+E+axmJSy1gg3vThV1z31LZmUx0Op+GxtglyC8vhMGLy1ScogjXv1OxfPF2vqceK1RN7stTg0qop/ItSakmC+bf3LFxjAsua9mR94kD2G9jB8v6JcjDRDYLqBCqpokL651LaE//5UBrDJPZA+LldrQwaQN3dnTxLxtjPiZ5nh3EazDfZjdrhu5Fx1a7PndpwMEViXi28SQH5/Xj36tieJ3PUE4ZosWip+1w4Y8FYuJvAFFnYDpcmVNV+sO9cDmFDqqG9oV3tC8xi81LIxDHudCKH8ziLSW06tcc+H8tod6x/REw2hJqi4yQ+quEWiWO8MDc+3hrIM5RiSJ8YnZ//NecxclvglC5WkEo1b9CG/btw8hTPkKuUwUuGb+nJ1uSYLfQEuuGpoM852NKWgH8FkTycD0RvpCczYm+npDZ8gbTFr6nSZkyvO38TpRUrIVauY4QvPUKpRWcx6PMCngv/ca7huTgY9s+qJVYQj3aSJj5OIY9lz/A0MaReEYH+FX+FVrve4WXipTCcSzzBk1FHrMjnTtFP9CY6crCp47+GKyeSEHTK9ngyTjakTqK9R0NuUx3JcnF7McR+5W82n4gTk34QEZND+C9fzu2TRgI6RoRQV8xGA7zz9BGeysUGtrT4U9F2PFvP093s2HHsJW0g95gtMEApLzzZpsAK6hGrqSYxYk0boI9NkYr8mM5X54docueEQNx5XWEsD6umfxHVaFmtxXkpu1B6N6hXDlQUzB+cIa0xq3mRD7JDzZ/w9X9V+mkdD2uLz0OI3qFsyPn4uhWBe6VyHYMnDSMB/yxQt2yYG5sjYCx0zRO8p0Lgx0xguO/z1j3VJS7XtrTi1f2pPvGHmNHtZDE8LPY8DUCUsMWsNeYYYJvMwn78oM5RL8Le+oH4K5bJGLGOvdlhFvQ97DG8DDG59urSNHSgGerf4ZSdDkfdiil2rxp7Fl2jo8K42nI9XNQ9h9PrnrbcEh9KR96cxvrpBM4XHcprqw9ymfjIlESNYZve6xH4Ch5vN5bSqVBQ9g9cTyF6yRyccg/GH6K4cinjD8aCxGdOZ4kL5dSmII3W7jKY1iADN8oWY+aJdFYWHEYkw0+ouHDC5xZuBGOVePh1jGe5naPp0M753HxP2vYitmgw2O70ON3kP1aDPD03CEkPzJAvJcoKxnYYMvgMnJt3Y+KqYa8Wf4m9/cV51sGdlz38RN1dwxCpFkZZUxwwNnvvhjmWEZtTg7CxfAPuH5HCtWzHWjgQgf0C3FAaYM8oj3X0LImef7XE434bhneutMGqq7h6PwgD+3FRnxu9xqqWdGMwhJT3D5jA5GROZyq0Ur7f8pDPmUNxaauoexSB8z5o8bzy9dQ4bzByJNwwb7+k3nypFZaet6FpYuUWS6gjuvuOUDSXAEtb8vIoewYnnROEdxaGzGxuRkjv0YyVK/R0iIJnmx6lsX+PcIx5zTE5iRD9rElj/GNZw+JeVhsNAGF99uFyh2tLB0eA12505i3ai2R6zU68X4KPphH8sXFJ1C5NpVzZ12DhaOcULDQkx8ZXuCDOwpohEcYf0hX4tnthYiPnUAV5NLnhS3syTPZS06VV8knUVLeaCR88uB8lR3okDbhdbnXSPJdCIpLVmDT8ma8ujOBvLacxur7uRh2fzS2K4fiuLUoZ5kPwVTdObyq7QRudkxAonMllFwnYvbPMdhyIhEXTpTgyN9IjDptCFfPIbguchiyeQbsOicFQdK28F43DRmahBgVRShvqETlqhRM0dYXvumZoZ/BJZTpqPD5tTtwvnYvwswJ/Xen4OYkohsXQzH4Uij5uRJkc8ZzvXwwj0xOwc4joziqOpR6LXz5Xu11fL6Ygm6HICYVI3TP2cW/KkaxtW8cRq/NZdX2ShiLrqNjMUQaEZvQ39eN19/qxuanw7DqfA3HPU1BvydD+Iv1Vzpk95VW1BBVH3kBn7JC6j3URp93u3H8nxRkz8nC1YM7kdFEpPo7CZeX/eDwdzuw8ztBJnMcn28I4F7JaIwv1BPixK7T4op9nN3chnD3AIzSA/0deZ0sxU8hrWEdXhlep2u+HfgSmI95/gGAxkUMbFuHj40SPC6hCP1LXdFT8gfmxm2cu2gjV/ofJN2JUtybdA43/1xB2OA9+LYjFbafR/DEe/vhp30VdjpKuKI+gKckpEJZYTVOdz/B78j9wvAtO3haeTU+bTdh9ysTWaS8F4llgImwGqsbAD5zFnkX97H9391wfJTFfufWk8L7ahgs2MCfU47hYsd1Gt36gJ92FPGj0AGsvNSA3/3bhlVSN8ixPRFbYs9xZNwneIploaD/DUqX8eTFh85geWUrKzos5DCt77RNewOpTC+AmJwyNiunIe/EPswbcwOLS5WwLfQVhiib8oIJdph3Ug9Rhsp4Gv4K4/JiEWGXhgSHNBzcyrT5qRJuaa1BaKIJn4p5QlOkitjychTP13gPkRdK8Fuq2ceTA5giawKjqghcG/UXk14c4cK6Guwq9cVLqYGIumiHkbGH0LZ7DRrXHhVGhV3jc5Oe4suzGxgmkYLID2UwOKOM+fbHubnbDmMqLTBF7C3uPdNl87uf8XqlBgdeVWWzi8pQaUtDwZ9YgbbIC3v/FOFoZxp0pq7iNpcLEHO9gN2OZ/DWykB4IUSxlMZFznuzANN9BYKfgI8xA7HLbQKLRswCX1IWREiH46DDW+I02epXG761hdHrJ2G4qpJMsacE2nT6Jn3ybuZveQJ6pwXi83+HhSijE1hcfBNejy9Aa3oyNAwe4MBDgUK2J7CFdgO3PRPIvvMmNfxdi05XUX4jXkHT/QfzYzdtzg+KEKwLb2DroL4cM2wQ8npkOOXeeSgYOXJuxT48OpOOA2YVKDy7kWaLv+Zv44/jl2sFPavORdosR3q+cRy/XTWWzT67cekhVx6YcwD35zmi++1PMphaD1Xb71Dd6kjztS7Q4Rer4a/yi6JyQpHjO5qlVg3hRKsPuPIlHR8WD4JhmB6Ldf7pc2pH2neyguR+Cezx+yktz3Okts1RCP6pgj9t2qwdbo/uZ8+EY3N/0dChqtB8UEGnjthjdbMjfGasgdcODVbaFY/ErTf75mSGEFw6CPVFm3Cx3ztU1yXx/nGqeCkxER7tZ/v4nwiDZ2fh0vGQBxU8wQ2lieQtvQht3qooeW7CsRNH46h7DppKNgjJthPxeMZEdLtPRFZcPL8ddx0Jaoe4RDuHexub4GC9mXZvnojOOb9pRro579M6gJeb7lGW/EU6vHgUO87qREbJSf4c17fncgqpnZyI1GdeKNn3m+bl5XPwtRR6FKognPxtzGIXKmndxYkYsKMdZ55qClerNlPGoVIsHhGBUzqH2LNpES60LIJ+Twod2FoPiY5KUruqxEt9fYWdEyLgIvKHCjtc+GpfNR3Xy0SItBOZyF5B75Q8LOy/hzV0R3CJaxP8vn3BU98IfDs6GN3j/9AAy1sUFJOH20NE+IdJMdIO6bGRzQ08vTEY3stP4aqvE7K+rUdS3BAOGlyCU1l/qDxADX5qx9mheRjb/C0n2ZnGbDihDBbV6twRpAbZ3bcg7rIBLRld4AWLOCvQATMqDmGXUyfl3F2MWR1/aPw5J0gtEuO9S+fjySIR/trgRGVbz0N561ukSzVj9WFfnmvqjaVhlYiaUkQRT5wwaNhf8h/+lyR/OFHPZWMuWLkSFatWov3qGZgcMxV2hNuyrttWHJixFe46t8m9r/btG+ej5GYLJBsNWX5qPjqfO0BbrwkjH6xEUN5fGjvjNq18P5vfmpoj5qosd2vKcZrjMwT73qazSUOgq5tGIXKrEDt6Mte/20qqg7fRTPFy9u6axhYhAzg+3lLwuT4EoRFSHNgWzVtjF6D0nyI/qL9NLw2H8Bv3bbRur5ow+8NMBNlJcmn8AFhmTYDIf7ep7V0LK3wLg3dyHv7F/qN671Zuv3iCC6404Jf6ZMosfQp1zcm4sWs+f6n+jnCNoTjabCRIG0+GafMEOE+soqFOk2muSjeO2gzFojFDEWw5CyusZ+HQuIP4Zz5KWF7ng29/siClEI6o1ZPpunMg8rVU2cX9C6/eW4IZOZ+RUuTJvc56qN1WRaYRk0nCMBz7Q4fir640v57+DKKjw/F3nBbX3XHHyhNV1G4lgskHhuLM7cmwV53HM1re88WFKdCa8hqYJoKcsUP4etNk1LYE4kOlKG/+WEWLRm9C1YAgfr50A9dOT0fIYhFcMyvmZVlL8XVpOkkNtOCu98lsXGUBUd9rvLOCoJufCJvyRExcZiAMXP+Axmr15brzN7Egrs8FZjBXLpuCO11RuLP4M9Jv7BKW/nDglWbKgPkhbD8nyZstlSFSJ8KTE1cLU6XU2HA80HN1Cli7CM3Xq2l5YDBmfBkoTJ+tjPisl9AKBC7xZlQ3+AjlzbtwXCqCumJLoCPvTP2UnMlEdxHkH5Vhtn4P1dIxLuhu5abWQszTrsF/9s64f28zyqccxGvdC9wjtRFFXjnQNB7AZYE1VPW171qLauh8Ziqsnsjxz/5LeUp4LtxkqnF6VQ31mm+BQm/ffbWbOGNZBBW/UOSty0XxSHI/H1kpit+jGCvO19Di8kReXFJDVrK+/GzsI7jdicO1naLIeNVD92IjqMmNcaTdmaIzRLH8YjxObN4Nhbph6P4wg1N8LtCrP/HCY3MVnLwUQWe3WCFi6W94X2jmFSFqrHYtAl2Pt2CD8gGcMptK4v5V2Co3HF/ui/Iimzs067cT+4+dSi0mZ/Cp9z0674/nDw8jyPjLNShhKpnc0GC9gC68NxnIah8j4GowiYe7G2P9aXn2dNyKoKmZmND4D6tCtqLtQAmNkdtOq4bFIvbyR/izMotHpME6aSpW2pyD+vVGKBXeodiv35H67wV5V6ngyq4DsE0fLfy4coes12XiaMtUih2/HZdSvfi+mxHLbTuE3oI+R/6nAkfRbbDsFeEPYqoIzM+k1vw9SJgjhsPml6Dv3IFv+6rZSTYb4lqq2LEwH3KHE7Ds9DlEjkjBMWsXCM53yWW7N6w9XMg2W5OnsyqivV0g0T+B5T59xc7/MmmiXBbmqKzH4uPbKa3tE5KVNKG7Zyg3xtylhNi72JvtgtTjLnihXYEZ3jN5Rx8vNjWWcdPRcXC+LYYHD8XgdO8uBbeJIWnQVzS4aaLMpQLjgu9g7+/liBzkgyNPXPB4UgYvnXQbEZZFUDedLKz4th3/ylTx3EGarWc9R0m4KWd8MuS4hxLClVRHyBhPw5aCJGy1ixLag4ayve05VEyvpSmzbyLy4F58upBFv1fU0sHBaij6PURIkXVh+5u3UeYkjqSN03AvaTUrn7SB0cFaqs6XFHaNUUPTCSVsPzoNoQGRKMyppevzxRGSq4Sn12vxdctHZL0qB1fV0sawSN5a24Fx721wu7aWVj/4B/mVavjbW0sKCuDi5g3w+/cPPjEHuWxLPkYcjMSQb9No/FBJdpqihZSPesK56Bp+Kf4cEcPraP7qC1CsEMevRWl8sGshZ4ZoYeDOPyia9xUnqiKJq8WhXBOJEQF1tHZ+HdUY7ESd9wH+tFVJeNukydv2amH5clca0V6PE01qENtbR25e45EWX0cJb62EcyvnCWE+yvwg2ZVWDHkE24h2dF5X53Luxjav2fxwl6aQ0hiGWddd6ftYUXYbFUUv7X1x+FkdXV6wjvOcVfjeYVvhjVkUxTd9QrtMF2Z5HIOrYxTZS1/CIqONOP7tIL4M6MHfwmIuTPDGekU3OmVhzQam9ZQ85SIafYZyqL8EfvQxeonMYGHU51LSGuvGcXFaPNtJG8uj1DFC5DfMC9fzynv3cGVnGqS31VOo5y5W2B9FO7e9E6KKIjDkeD2N8zjDM+MHCjqufb1aUE/FP3W48NtPqM5eyFuL6jH7rhtJ19eTdqiE40u5nyxSLYFaqzy43v/ax9vBLF8XRUfDn7L7zD6HMpBg3zE1sBWJR024DOuK3SPSPI4fkt9wT0IDg75HkbXsMuSoavCqnxLY5D6U3eaE8QOD6WQllOOx4XT6mmQIf5Ed2Go6nXbMfA1R53tU5zydSEwHcuI6CLTTwLdPZbSksUUY/PIQ7iybTmlGkjiwM5dJ+yid8tzCdro66N5VDpVD7ZwxUgfiefvR5auB4K33qOreJFQ5SWLsUGs+nHocpfed+V6rr1DSsBjCl0lw2LSc4yrukcL+y7gwXxLBm67C4PQRllk9mrWtt/GmxO1w3LgDS9VNWa7rGs/aIomAI1cRrCfK+xwXQlLiACZ3Hkfcvh2YUqsBkaEN9NxtHGeoNJDoo/781M6B3zyYw0cvnsPfS/8wJU8Sb0PuoKS/GB9OCefgch0UF0piM2aQcrIiZ4anwXdSA6l4z4DW3BnQuX4Rf9Yvx8DENrgtmsGqVcNY/9lRBIy0F95MKIat+wmkDboHib+NuPxDTTD4rYMTexto6pGRrPW7H0cPTWbPpBnIy9iHh4Uz6MmSG5ypsgg9v3ZQV/gYvjMoEtLJpsKe0hkIP+jNOk2VbNvegEgJJb5o68TrfSX5UNcM2KhGk85gY/Q3fE8e5YPZunU22s9r8rn5rrzSvYj7K4RiU/IwhAdWY90mI06ZGA2x1B70M24k9/RFuCL5ELbRv3HfwRiBC1egyT8ST68Mg3/ZMExeYMU9LdJcNruR1pt5sZJ3I308N4B11kdDbug4hB65jBjn07xp+Emc+buIw1umoL67gYccnYmPghn/9mqHabgXtJ9NgcvfYSg9FE2r5HdDt7qRupSHo7XwPNuW9WWu3pnUmXeA7UJGC/N6rXjx8iGsPLoGxr9n0q4nUtCQOMuTkspQcaEbU4ViaKedxMr5n3G9SwrG3dFk8V80XA7Ws8GSH9BbMxwpd8Zh9drhWHU+h8fLS+NHbSJUFKVhbFyIKUH3qX/kGV7YZSx8GCKN0jXuuJOuzecmWMJ7xzRh2dnh8HeUZtn0Vvx2MRJqy9zR3ycG25+4058jt1C8/TzurR0qCAHSkISd0GV+B+tf6/GyOX7sW/4XrbKaMHw4j5eMm4rhn3IQnn2bv09y5TlDjuJ9uim36WkiJeFaX51o4sHhFL4edgrdYx5QpHCPw8x+IHaCJoJOSiPKV59di6PQ+PENtp9kBLlM6WNKFvZNfIQX6x7QcW9NrDo8FQ/a8vnAYHMOKu7HdyI8sFY7gjc5HyPNU6+RGuMByvTACAzj70c9KH3BCPw23c3vM1sQvqwCY/M9kFrgQUM/xtChag/yXy7LCq4bhRlfTuH+q1JuWBoH7UfeOP7Bg+JvZXP2mnj2yT5GE78/QMggT8Q3aIJ2x0P+xQJubBwlSPXzwRlFHc6oGNHnFWKc+1gTBk0iHG3sg6lLp/Cd6Q7sE+iCkl4djt2cCTmXJprrvwOiQZ4cEtJEGFqFJmsRVjc7hPq/ppC1XYPzrgewwrYKG5cE8lSDzVxyoYkOxu6kt7bHMWPmMD4et5Ok79ZjZGkTvUwswpbyJvqvoxE7juykL37ZsHnmScOeThcUm3yQGHIY5b6jsUSsmeBQBq/pEfw5UYTflMtgz24tLCtLEOxdavAs5TiNnD8NCb07Kd0pHa2PG6CTfg6KcVc4y8CU872bKX5dMx3ZMIvjPIJR7PkGp1rUhaqmkRA74wDxTi0M/66FX+9HwvG5FNsdegrL/YN4brQGnxsbjdq3V/BdJIoFBX08s5Pl3nGxKDR9iy0a2nh4NBf6axvR/n4WdYw04b0f9LlcsYVuhn6Gds8efDj4EBvdtRF2uQRhtSfhaNALpUhZaNFs9tJI4q0OT6CyOxpJ927wgi3nsXD3EcxZdwNvXjXhcfwRmM4ORTyfYI0T2lh77AT2qMbw/mRX3LkTDZNP0zitsIU218VifGIE67jug15xC1Xf1kfamU2YVTIbse3aON9ch23P+s53q8Dbew5vmb2eJ4yeL+Q/6+NJdwsp/Gih87+1YfVPG1tF7LhI7CQyJF144sQkHievAxllCT6gOoD7Z6jxJEMvFI4w78trOviiexTztYu43U6TS6z7wUxsJNss88JDz5PQ89DBw6shbLgxEPZVkvzT1wCu5QtY/NlI/hlDGN2zt89PD8Ku+DddmB8D2Vd7+zL8ZqQFxmBkthfRFS9y638Eyhv74fu1hyRy2w8qTctgPuYOwioeUvqZUkwvcuKqgzowi9hFtnt3wVR2Cwb8XIbuhBh8c7bnjwf7ITOsCyHndaD4yQvT752k1K5izNYTZ/+sLqQOakVHy0lKOtcPlV06+GrRSq++hnNC/nHWDsyE/JeTqBxUhkfjW+mH83SM0ziHlz6ttHPlEH6J2/T0wGmIDx7Fkze3Uq/vJNhp6uL7pxl8RVsXOyKzuSqpEyIhkSiwMWYp5VR0/t6FCfbZmCLmxPan59BVRTlsyG2l9GudmFDQSkXftmBJYSsNDhyFdap/8UDhO0aHN/CFB62kfAR4bywHL9sNiFV05mUxo9DuHiK8d96L7OHTeMaQRzQz/ThOz9kNmbDZgkifq4WPewQXqS9skZ0BN6e/XHZqK+4v9Kbxatfg5nwU0gtz+/pIDr/bdnCB6UcER3ujSjYKL5/+x/e2G/H9i4vQZDKWfQ54Y6ALI/FqD8wKd+KnWSumt5UiRy8K6dbDWOuaHCYUz4CTljMLP6Zz8v43uODlxD6vnbm2ZTda9RdD7kx/Nnoth1196+3zfBRoODDeynH2q3xcmLESOtI+NDm4H3fkj+J5ik3IlBzNsx4dxX/rT2Nj1g8Me6TBbRv0MGnmFdx5nQWzQbKcrB1HR58UIeFDGHrOGmL3lko+LvYFB5oGsNmTPIg0nKa/wYl9DPShlf7xcC9vo9CTtpx8Og3bP5wm+Rd6aBxXwC9e+lCD33hen6zJnm/bSDsyDlPf+5CXxFyaXGPBiztnIspoPi4216N5tyy3NCUjR3sEzM3m0mqZHVgrGKE+MxsfdN4Lhn/S8OreRozwfEyH53zFixkGvObrEFY6ZyeUzZsLP+cRcNv9FG9/C3B2uAfjDTfY7Gstj4g0wpSDuTTvyGO6GjYCL3efxLaWaJ6gcYzH3enExMhiHpQ/l47f+oyBZtdh9sSclykNwIglzpxhOoyDC0bg6dljmGUwAPGp0zi/+QDPV+/CBvsB6DfQFzOMd2HZihB8Tp7EIXWbsJv3kERmOhZq+mK9tS9uDjhD/yWN4RcBC3BY0gOb00NgHJoiTHtdw5V+vqT3toZOlClwaoosByz0RUVkDtvOfIdXEz3wOXcY/6czEqPzK9k0dgC+F45D7uA7pGk5VBCVMGfx36/Q7+gezJMeJBh6j0RLVF9W1TsLiWcuLNP0hLb7P8X03mdI+izGO+f1ZbJ1U5F85zd93DgS0RGePGabKDuWnaEINb++vD4ALhZSHB31F0de3sTjud+RnzESM69rCgOLRqLKuZ2uK+/FhU17uWF3Bh4VTcTL+yPxMqYdP3b74VtuExeWKrCP4RzufBEBkYt+/FfmBBZd8oPXZT869a4DwTr6WOG/l9wm38WSx35YODuPnD5O50XP/Mirww/C83badvshis97wmjLLDYf0oCB603wc4s83B56ojIxkG/qP6WSAb/g4PscU+zOwSv0BDQ3OqFg2l8K/eOJ2PW1vDx3L3I852HrPn3IV5tgvtQgYWToU8pKfEp7uvPItkAfZ5LmoXLZePQcqWHp1Kek2JedpS7Po7ZbF3FMzBQ0JYC/PPbgzZ/kMcUsBMfjp/JFqXgMHjMNIut12OPma3DnPOpNEePHj8o48GAJnB37GCRuAIzPh4+kAVbL+FNo7X6UH5DitYb/KKyfASpHTcIuPX/MUonDJhsFjPgWyr2lHQjVTsU5C3+i8fGg2b+h76aAug3b8GqGP+X8bMbfez8RLPzAk5owITmoAihZxgrT4tAQrAC/gnz6XNzHY+0H3O+8KYaqvKVMoRBt6w1YLFIB1wLP93mgCx/+9g91HQJL3PQn98QlfHHMU3zVvIn73+3505mTvGT4CWTY9WNEFOKweABVSHfgQqUCOhZp8paR4Xix9BLCdAayQ/NoVhAJYpm5kViXZcUiz+Ip2SIAOS0f8Iz6+DYmADJPBnFi1SG+1BQHT9FRuPddAWOF9bj9bBnaX8bh5Ylo1p03GnIm0cLVgj84EzgaOYMT0KabgMcZHdAemUARv7p4jIEiJud00EONJpi7jUJyeQe1q+7BYZGxSPuyQxhTFUDTHJrwCoq4eFiOJ8+SEgadaMMVL0Wo+CTQoSWKKD7shXkZx1irPRKh3r4sPvcJNg3spIfmnfTYopPMT+/EwT053BStiI+f9Tjx2igcSlWE3/VTKJBvwPzn4Zgib4bfeoWYZa3N++XmID21AmV2xpzjp8cRq7RwO7qTWtM7KaT1KnqqE3Aw5S5uWM3BrFOduJ15GDyjFZWWHdhT1UnSy49w951OGlc/H5sVevD1dSdJWBgi85cixNVlOWG/EydPjUB24jFIXDHg4d4X8VisFvYG+5D7/DHybRaQkkQTJI2UYBZsiJw5Lpw4fh+uhRtibqQhlruWALyPvI5EQSfWEEvH/cXNku2ss+sebQ9fAH19bT7ssw9i72ey3zczpPxqxrTUSn519yJax4hz9GpLXvgkCgcLD7CPynFsk/2E7jw7vLhbzYu01nF1yhOs9z+Ip39ceNU3Q0SE7YXPOSVcWnMQhX5yXKAYiJUDjHAw34D7Dekm7aGB9Enbnyerd5Psij08MFSOD0ap8UNxJc6tV8LYcYGQaNhHMkV7MbJLCS7e3WT18BF+zQ2kip59CM06S+oh6rzdLxdKAUaQ9h7N60QGIlfVB3apS9jTQgwfBw3E2jRRQfXhWdjrJyJ5vxG0HHxweMM4PIh7hVm765C3oh3XDj3nZaaJdO1VN4liICeaboJK+Q2eO7qdr09MRObnbrrlNBBiM4Lx6ZIRgr53U4idOL+uMYL7u828b6cPljtnsmpQP/bxS8Rti4UYMsOQ/U/7YP3qRGhLTeAZE+PhP34hLp35jKroRFzyeU5/FvlywCIL8IUqJMmewSR1Y4z1bUSsvD3CsxLJRMsY/3W8QcNZMU5KssCWMllh5/Wd3Hp6IV5ce069M43x13gJG2TGoyb+E+28uxDu3sZY4jEXwYGCcD36Bcr0OvqcCKz76TlFv0qkpjUXEPF9IEQ3P8CwjXNRFmeM9ssTuN+1Yrgp99AGlR76PO8Xj779D/K5Gqw5WJk9nmXhX64xhtkvoo098dA12E/nvmSh7asCtybksqifN28wsUSu4iX8wCC82LqI7LtcsMN1DU53uyC/wxjVWT10XsIXK6WewM97EHoCi/mffgLuGSTAV6sJdxZHItguAX8GmcA3W57Dahah/e4iMjQ2gZapCX4du83q/1dwnvFcv20YtjfZo5KsNCgrqch9XrTLqjTQIJRoSRvJ3nuFSInMlJUZGir920qTBqKoRIN4fs+L8939+e77vI7jzXe8kHgCBenPUh30Xr3KauesosmcXrpfokXXlmuSnZUOYs7LUETWV2SVWlB80FrorhQmwy8GWOaVRX8PKtOGakds2XcE+7e54UO6DkLaHZE1kI4FYuVskVYWHmTpQN/fjcXOU6f5FcWQbYmFZnUxPozJQMSf19xpTjm7VacD9Uc6OPvyCAbIELcUruFwrBr94AmlgHc6mKclC5WvOuDP5ab0FSG48FbNfH7ZUzx3fIuGZAuoCcXhu2MI9KLq6JLULua8ogx71XrZvjm9bNmzp+DR3cVeB26ldv1etjbHmB7O38Vi/sjRXptz6HnXBS3nBtyuMERD217kOfQyRTMX6k/gJdED2ea9ZxKZe7os0vvuQNIpDqvOJuKHm4m5WE4is+etQP2qI1TReQ3Rl+7h36eLFDK6kIynf0FihRh1T32OuKgcevlfIuuOySCLLlnIi+xmt50ew4zfnHqGE5n/pvkImrUb+lvmI6VrLrrr4tAnOJvMBEMxU383q0x4h9vVL3HokRSlfknDA5vdrD3sLprXzaIONTnc/RqIR1XbkNA5jTYPqpHItK2kMXce9ozFocYkCTN7l+LtRBwc7N/CSKqW1G1zUGI1D4bLDcm0VJYe+s1DTWcNBmxMycdiO0QDc9C8dBnygnLQouIOXbN72P1SEwGpSWxtmhxSVYywImseNqXLQUjbndX2/Ibm91z4VczDq8pS9C40Qp3MOYQpR9DPXS8Qad2HUVd3FqZ8H1Pf8NJCmzbSa01iLzhx8eqDRmwf1sb1sQdn72GL+HEKEtqIUxf7mGe/IZ0XuoyJK/H49yAKLmvSYCZ/Hhuigml/Xi3xHpwBJtwBS82nCH5vDZ7YcwggXZjuVKPwqf2s42YtZ68EQXHiFIZO76bxkSDSvnMdAn+CcCXjBK6bL6LYuqt4+5ObKqYn4JlfHGTvbaeHHCdRDe1nq13CMPlkMkp85BEhm08H/ORx5cUOVDeexeAxYeoRfoG9oi+o2noBaszjiNsMlMTthCXt/Uzk+R4m/EqdXsh2UtZSU/If08W0HSdxVEIP7XJfmBl/K3a1JzON4y8peaoHk36ZjBoFPTyqqWJhR95g7IgsCQ8mw9/sC/Ne7Ey3uFNwskSVNj79D3OVpClkpweW3a3DEr8vbF3JHgqdK20e6lKGbHNx0jmkh+tH9fD3yyZ8OKmHr9EC5icUuhGyXIFezalmy3pX06/TKrRxWj229gWj6+sX5lNRQCd/ejDlO3pYtIuLhuc5cxz3HarSfuO2kTMypeRoqFsPB/jzYXZvJbm4HEedfzVejpdBNIaLihedxfQnF7CFTx+8RzyZWLUC4p6I0+bQhVTXwkdTfl3H0jYFuBjoI7K1gBzOerJtjxSwISgRv/xs6d3lcDR1p7AEtVuQfV+P3F36CB1NYe83mJBZjyez3KuPLyn5CItfhy3SqWy9YgMUU3hoptheqjrBS3u194LmKOLIUCf4PLbAx24h/p3MxbjOInr1UB9J61PZxnWnqO7QAPOoH8GLEQFaEb+XFQ3qI7qal0au8VKzgAF+ChogKKMFgbV7WXrdXpi0C9H8jr3wf7WGPLUMcKlIESN5mfAV6YSegAJdHsnFl8jFRBCjfy2pTE/vFXuz+BEQsx6KaoNsTdx60tDch+ANj/BgnR05HjDAHwpAcrgcZSvVQHvZPvZv+T4oL/AmvX/C9M5Dkxp/V+LalLt0MnyQuVcn4aP9C1zPnEJLq9tww5SRTJUYhdnr0VOjNFbm+x6DsaFY+8yFw9JKkFE2Jts2QTLOWoSV6sGk98sAXedegHehKZXJfGNxkoY4KWuIaI1SfDf8xtKnR5KVRjKemBmiz+4buxuVBhuz2fhxN4LkftawC4f3s3szJcxvOhrC/Vg3lk7rgEHAflzyMoTunKX4W2VHCtn7cfuoIXSiH0Py2n7wVboiOFCTqlbexK+/9/BrtjK1JBrC5mwfnTBRpO73pmQwtRr3/6WxytxkkNgBpEtNRuEVDivN+s6cZx9gdp2G+DznO+tRcQOv0BOMzP3ObihZ0rU1ByDuq0i+wv5oNj3D6dw8HJ94S6nOPahxdcPFP8mYHv+dbU/1p4ifUvSZrwkzyr/TlNGHVLvuJfg0mrDBeT74gyfj9PAB1vvrO/vy+wBso+VILPwjvHzn46jlLVzkOYhpifOh1RRDb07PwZL3YXBuOgMuk4OwHN9F9uwgvlpHwcPiB5tuvguOHWfYIX4R0toZhZMfzc1DQ01wM+45tn2cD96QKxTJNwXtQdfpwEFRc4M7B9nC9jq807Unu3PG5KKajtl66aCrUVCyKybugR9MvTwfneJerPxOFIoOvsKg0GlMOBth6LwwCdnPIO75XjjAJ0QOZqYItBcxn7bUFKcq2mlPRDr69jbj25Ehdlg4gBaV6dKDs1OQsdydXK8YIfxIPTP8N4JRqWCaqitEWyqGmLPZJdRXpqOtxovp1Hmh954ILgT8RdIDI+S8laNpr4fY9bci1NvSDE3baGwZ88KMf16syC8VptwLsHsoHMLyC9BkI0yLwi7BXP0QDnwwxUWVUDpVkAqptBr8m3YFq2a3IHjVAnw9pkkbXX+yVoUGlrxgKtb1cNM1FxH6q/0Ab3IPsUcLKmnxWh1MMc+hKzYZbKtzBtpWCVCPpiedbeKlvN0NTOPdTybde4htWzCEvONTUZklQt87o+FRXoU7flIkbnaORuYVYN/BuWQtP8zen89gfWZKBKNhNnPhMJZYD7PW/xrwYMoevCtXo367NOyUM4a5vDGSu7Wo8UkGu37UG9KZ1eScMszifYwoYtYF2u+SiMsDM+nRv6kQ9d2DWRMZbLxumC3iUsZA3140WxlDJ20PHjkZQzaDh5pcjNFwQ4PuesbA7vwepL0fZhMj3mzNf7oU0NiP1umP4ad6CXUc74gwVUbskkwcy9qBbGQieGwPxnummvfZZbLKCi96vfowptiPMDbVA3d2HMbc9xvIwfUwW213H3M1PGB1egQtSzxof5e4eWGxCIVEHGbbcg+zlPhLOJGkjOTirbS4o5GdsQ2BeWom0tcWItmxBaX5tXS/SIqeDJlhNzOmw1ke+G73ns3V4aVusXJ8HRxhiq1NmEkL0Sl6hCWEcJPXzOtoWruQFNxuIi7zO3XMeYfuQwtx9aQZqXN7gl71oMOBISPWkTaoeOK0bxKK7Z9g0aZY+KQH0fK35VSrWoDSydMgH/qLtcb8wuM/YrDSnoY+7bPsqM5ZdrvZBqfEc8jZm4+2/bEgoZpfbMbpWFz8dAbzAz3R6zqbkrsXYvD3NXjfWUtuonm4MLiGVk0cwaxbnqjnmUCjTDpeTV6E0VeWFGNyFLFzF6GW3ULvf/b0lGcveLSb2A5JefL59x8aLJrY9TP69CuuCI43p+GZ0yJcfF6PjODfrNMpHUlZv1lh9lHm+VeXSp6W0Mv6o+x1/zRMPZqOrpbfzOHjHMp58x0WI8+xkjeLnSqqwXPNCNr+f2b9cpRZtyzCLsk1tOTSXqRPzWIkdoy1iv9hZnzitHHsFuzMVZDZ6kQWs7tgPTmEwi9uJBPD5fRSbjEGtmaxOzNqcfXDSjqu2MzO6QjS+tF0jBUdY6JOCRRzfC19CFGBZWgWu191DNdSs9iO07cRu+Yfsjg8KXzmNip+HmMnI/ZB92EcXufsQxZ3HPW7SWB30m5S19SD6HRe2rMtA40dWSzybhAOu8+i2sxm5v9GBdGCr8A3kIVv1mW4s7ARRRXNTDVlHhVUN4M3TgIb9/9lheL81DKlBpv4s9nvD2L0d3gDXTb0J/nkv2xM2ZB61FbQoG8CHco6zhbrZDP7qxmYV3ucyZxbSov5zRHXJUujk02wOFuDJJrPQ/yUCJ312I9NL7bT1hoeKshVoKue2Sww/xtaLhbBZl0Ls99iAk2LezQWlA3pkGzYWJzAzkATcDmOsoH1l2hHuAnSht5DgucAwi6WwPyvMPUOpeDBwXROZ5jjdNAo618UA7GSd7DfI0dfom+idXMm/GZeoru3T7Da1lHm8DYbq9pOsPKuUebWbwJ9ncUU9NUckZ9H2TuBG+wSfwJKb4mT82YVemQnQu5HJSl7ey0+9W6haA6/hOQL0cTcyfTV1gKXFotR1noLrN50jq3yd0OKuym4PUyx8OJJNk6NCN2nim0GJuY6p1UxnGaKlqMJ+PVgjH3XKaSUn89xUOYs2g4V073vY2x14TrqLzyHid89LEjKh5W0h9Ni2xNkM97DNFys4GRsQ9VNqlii54OZkjswNjcWQQ5c9E5XEsND9Xg2ZooxGx92w1uQbkukIZt7CVI2/WMVB/6xYS8fZjegin7vf+xIgg9zsjE1b0+/i/F5l/Homz/drvZhIZNz6PYvT7ojfw2tP2VJdmMVrdJVg++Pf6xtyAdaTA2O6yIQHbIUg6SGxdMfIuxeHe6MJmGb139I3ZTDVivL0ZLdasjkxMuds2Z1IuLS0mBYugTBjhw2bG5AtEMQCR7wZesOjzPjhBzm87IBk4/7gt8+jh6b3sPYuyXIF5pHomfGmbdNLsUVqnG84Bb7/oKH3maPM9/6HNyp8eW4/y3W4ChP+WmJ0Gj0ZYJNvozrpS9reznODr6wxoEZZtB0qsfzLl/2Yso7GGio0roCJwTz+rHSyX4QUfHDLDU/xtQn2H2TCewKyUKH0RncMerF+4NmKNjuh8cahaS49jdaXP1Q7TsBnSXn2W333xgJnGAeSe9gU2OGSBNniOf6QX2DOmRvvcP1h2YYUPLGWuNDNJgbh/48jst2+rEPXX74OUuA4HOeqSTb0rLeCSb92Y8tmPDDPJ5TLOZuHKJKzyCY/xSbJiNJs0dnkj6HUVbIcGHrhzL4i/3Bek1JeqfKBQqugIF2NjZqcMGyXh07u53x6Iag+W9Ff2p9PAyR+0U0cUqAEjZm48yBy1B4mU2b/q2nLdm3mf6GU9jdHYAAey6YnsjGm64KXDaOx+an56jS5RRzc+VCSN1yxE+9gHVRo3imdoFxlTI4b92JPZcZBCzjId2ZhP2+V/AxkAsrB+bSs+x+uCy6wObskKbXbxnd51uBxdt4KO/DdfzIOYWc/7LR+mC6+cFRBptJTeCtCyTl0HSMHNVA5jENfP2ZjdC7tTiSLw2+55nUts8IT82ARVYvMcEJ3wsuqLw8hbbCCzjdeQpHlAaww9oDoaZlkK/UoHs3LrDwA02ImlCjicPJ4HFUoGAuf/x9UgxXIX+WxuHLGTw61PxDA3skwpGi6M8ElPzZrL3nMLMaaJ3BjYM9K3C4txWr64CHM/2RYMhNJ/RSaObrJLKam4tppW2oaz2Ch6fUaLfyV7bBzh8zLXLZwEZ/VPAR3kV8RqhZFa5t8WfhLv7M6KogzfD2Z18Pc9Oe/24izfwoZgRmwOr4VzYQyo2hQE3cWuWKKZbrodYqRdVjdbifIkN94CfbEk2sK+DGpCm3oK59C2e5PsB3fTTkHn/FgQtHUSE2jFC3FEhVuyLaNRqHm46S9Juj8P6cyzosc3DpyBCeby7HrA5C6ehRfOnxZ2WxKTjNNQNVfdxY30XIkOamnoXSNCy1i4Ik0yi47gX61h5D3zpN6i1RpN32x9CsxIND9x9AP9WWEmRVSO9hNCQUfUiKmeNZ7gC+G/Hgdc1e6P6Nou0cNviQsAqqSXdRmfkHJ8acabvRBeJbfZq1hwrjSORFFAaaY/7m07gpP4fm2J/GtWP/ULSLB3N3n0bS+RmYzCVJA1/V6RBvFjmGRaBfO49cT5zGnyZzuDxdSB/uXWRVtZkYD5pF+x+Zo7rcgy5/96FW9blk/+Ei49JejZo/5phqn0jbzt3GtqKPmDdDml4JauFd1F/o1/DgdgsPkrQt8DFWm1TqGiCvqoWIyPMofM5DT5ZZ4NvL05B/kkIrK8/jU+E4NmYK0JGG1bhj+AgDArywuZpF62TnUOrGs5h03gL9CgHIvL6WLPV4qH0KL6zVedGdmMemntlCc3Ga2pMeId+Kh4wXBTCTxQHM73IeMlYGsPjvFpC6r0WqmwJY0SZefN8cwKSrz5KUPS+EirhoQ18eC/kqTY39eXju2YaeDQtpolaOjtftBq5EkFZwAHu36wLuhATgpG4IWr3TUNnASC0+gDWcvIC/KbyonpHPLrosxak0XlwzOYnf6bxYnceL93YnYdKoRksLeLGxIoDVzswCV/JSCBRomz8ersSm2wFM0jkf+ncCoO+Sj53j52iY45W2hYWUfmMpDg7mk49+Fez2r6KsJ2OwfLsUboHudPjLSSw5OxNjnNzWt6Skc/kw/hPALubks01/A1AwJZp6BPiwS5nj+Nb7qH8rF6lL8eHH9GXQ3JeMn8qadP+VFF28l88qpgeyI1fnUwFvBvW1GdL4PD7o1MpStqsPflsvQ0L7atJ+koUrjwfwzzsK/O0q9FvgEjTdaqHQKUtDr+6jyDMX2psC2bljAaT+9QS5D99nsenL0DVvFv78XouAfXy4G5sLn9zF4JXfjA4xS6xPzMWKI3zQLl8GtcXT6Py6S0xmwyz4jRzERIQ+BS6uxFxlX/BN88WGzYI0ReMVIlMCmYeZLPFKKaBhkRzdKJ9EXaO3ICi+HC7/bSAfB1+srwxkPPWBTLiJD4urB9Et7IFKYwVseMKH15xuLw8cYgbHHqKldhYGng9i3XM+VFdb4sfG5Wh8eAkD3Xyo7eHDw4e+8OiahdOeyyEk/Q15/ssx62QKXvdZYvKIL8cF+ak+8ilMpPxQnqdGQ2NDkIlXwInRXtwrqSDX4lIkaQbheC2n49uW47GXAeVVZ9JCu2ZYf1wOzc4ACq4ZxfPVQfC34UeBLT8iBYVJd30Qp3MewHlDEFsUwkvtO/jxVciEtu6fjSeJPbjXKUqv9vCjQm0FuH0LcH1mK0oO8uNt4Gzs9w6CpX8Qu+3Pj5Yboub1AfzYFM6P1MICtrrYnVZ/fok3vy+isq4ABoJ5KG8oYJEHVsCgZwq9ipKh8ZwgZrFdnvqLg2D4pIB5/EmHeoknuKLOwbI8CLvPrsCB+crme/+FEZfWQ3apZxpZpO8k0xf8tMEuD/MmPKHbGcRcPy6n0a9BrFFtDga7V+B6TysufudHbUUYKsdW4GrfObRLrYRlnBg1iAvgdVweYuKJHkv8gNGclShWDmYbt8/BFQ5bNaoIwJva4fyfIl2tykOpTjCcP9sjKrSQNS4RwM75I9hgFcyCjOXpa/hKTHcMZsqCadArj8HMJf0IvLAS2rkrYc2Za7u9g/GsYiWyYxKgIjyOW2HBLDhdAC4ZwfiXKYBftfdxhesuZlQ6wHKbEYVUBmO+zF34Xwum6DccfnLPR9ftYDwuesQOGvtDrkqIBC3K6cInAYRN/g9BO4rYcLUTlTRVQLMvGF9GBLB4yAbbN/mjrDIfE8FFrG5GItKW8dJKUVs0RdxFTUQRs5T6hg8ymnQp+y5sPTl+wPcU/ykIQuHCKqx+OZnG6RvWlBUx1y9KmP41De84qR4Jh9+NIubcmImLxmfpDW8EdMPLKFDhEqa+LGLTtS7BMb6AKuw20GM7QWztmEQuOrNJSysC2ksuwcn2BRpeTMDkMi/xyxbj/qEQ7NMsZuf9taj1TyP2BoSwlMAQNj8oBIOxIYzniz9ehr9AoYkOhJMEIZMRAu+1xVjzQZ0yxmxhOMZNB8+HMPeCEBYWfA/L2nqwZl4q2ambk17ZLJqidZr8w4vx9lEIftSuxprhzbQ+UwcCZ4uZeaoYHe8KAW+vICj5LMTezKYfWnvo7q1iRHGtgalIKJN+XswyxYVw55kojUsI4enLYvBKCsFXLpQti+Ci/FltCN9/GhzgYWHXpc2rZyvRAfkpqJtIoGrvuzR6XZIS1xfgk3QTlq4KZRE8T1nC4X2UpW9GERUd+M9SCIEJbxB8sACHHITg09UBAYcPWMbp7KTqb5g9+AWjWT8w4FyCkRNCKL6zBlNCQtkN6ZcwSnsIjfJokg+Zi4Lih6AUIUikCsH1YATNWzWJ5PKEcCsvlC3JF8KDkdNQOPyZ01OhuMcXgE1VQnj9qQAR1aFs5XABhsuJdsRl4X4LsP5mCR7eD2U/Fq6FT3sJbNh9FC71wrXnQlD7PBcnPgjBcdZHHJpXCIOhUJbzUoR271uLk1xhbJhLGB77wqnakJ+4+YRhIVuKF6LC+P1qOi1KW4u4U1xUoVkKJiMM7tK18P5zG1ntRvRPVZjy1cMgMlcYNu+9UNy+HYkczigW9qKAUEazd8yD7Pu1uPJzLba82Ek9fbngreLsDRthhHHSvEUYKxzCsCmoFMbpzXiZG4DJafMguVKVJG/34efxMJZzVoCSpW9TdlAYmzF/MS25+g0Gg4X4u5HDJI6WKBggHPVVpYldlvi9YgxjnQEoe1eKxHxh/OkuZZoNmRRdGIalM9tZ4tUwVip1mo7mLKB7D97BrcgSaY92wGX6Zcazp505Br6j9eNTqfqFJTAmSH/0eWlFbxgL9ChC4M8wxA2HMYmwAuhbeKPuXhSy7RSpyWI7KV6xg8OjXFqxLBAJolaQ23sZzcpWUCNllJ8pQrucCPR+LiZNtymk+7oR+42tMEs7nPX/aYexYTiTyL+Mw93xFG8ejmtW56CQnkdx1iIoOGaFgRArvDd5DpVt4cxpvyrlR+2ixUZ5iIgtoqC9JpR4Ipx9rLFCoGcDLJ9046GnJnVGhGPrSina9kufdqSF4+8ZzrHSw1nHbGdM0vmAY78fYGuBCDo4e2lVUTjr1C9jr83KGG+iBAm+PIdaCz143/mB0a6NkLkjQnHcQei9F463rj1Y2xHOcveUMRLMwVM7a3TmjuO2zBB25xSjdygc9bmrqMhgI+lemEclM8woRCCCtX6QoKkVZSyrQg9SO4fgV62H8+esMaYWwYorrJGkEcFe37aG/n1rzmy2xpaH1jAyiYDEO2t0mUWwf9/KoPTpIeIqX7ChP9ZYGPwW8bai0NgcwZZtE8V40j8crpuGNikbFErbYOF9ZbpfkIPYwhw4nsyHqs9M6hh9gUDTKzAef4FPCbuoY8YIUqJEYWB7Banr9LF/0zpyzYjAqcQSetinTr1XROHg/QxnU3UpKMUGrrWiWF1YArnBIKy6FYFV+6rxrTWCOWt9gODdCPa51AZSa6bSl4cRbDh5I92qiYHmTRuYdIhitOw3Ip/b4GqTPo69siGt3gi2ayiC8Y2JkBR3MRqW3YLxc31sy08md14xGpguRJJCj2FVYkojHztgl2NGn2XF0L3rFMb0HsNTVoIK1SJZTt1kerNjCEWXsrB2tS2uFOymtiViiI05BanF/9CaqEm/14rhpqUYWlcaQMFGDHftItmOg//gIeGKfa6RCAkpRRu3MhkevwofPwMYeTuS2OqP8Kt7jFzfSPbgpi02PubCl1/noWHYAp+nl5CXIkZ+e+pxfEUL3D/bwtTBky6O20Ku3gCV6vchLvwEDWdd0VFfSS03OjHtViRyZ69DvrEmlQvrksMzMZT5/4S9Qgl2iLyB4G41OnP2NG0tPkBdYiF4PRgJ3yX22DEUycSnGGLBTzGU/oxkvr7rkMIVxcTylallbjlbaFzOnt5fSVoqUSwk2B7jK/hpIuA1qcwUR6tOFJa7GiLvynNMqBK5LxJH9WJxCkzuwlLBKyR3oQs/wsrZqghDxK4Rh/RacSRy8kRgGm3cLI4kxXRsQSsEssuZ6rpJdPicIfYc+oUroqq4orwe0ov+w591a0l8TQrsj4mDp+Mylm6TJ1r/GGb9lxEaE8UKykax8scVGuz6jspWPnq6bjo5zHMhw+fc8M6NYkpJcQi1zoXTpPloagvB132dMG+KYmfrSmiWxnwIfm3GrrtRTHTXTOJFBbiGBUnpXRRTCeyF38P1uLm/EKXdUbD6EsUStv3Gtw+xNL13PVQa3+Pt69dM2QL0ejwKi6LKEFSVC+9TFThUnYuCXzJ0UzUUl2gVZU+OZjWJFaxDVQIpBhtQOUMC1t2qdNIkFIPqbyCVX4GPehLIrq5gf6Yo0BtjCRgvi8b9ZRLoaKtgylbRbGh5PC6IaFHGiA4pdlbA/wgv1TtKYOoMddrr0k1CP2rxaXUGGfAb4ULJBiSWbcAXzhw1KHrD2o4cgMjpaNxSNIL2TCMce74BOz0y0GdcyRJfvGGvQxVIuUCETlhWItXKCDeNr8O8PhQPSqNZ9CQ7nAi8CO1aCfiPuFBcvQRMDlXCUfoSWZ5XpXNt0WyPCWeN4yrO+5HAzY5oNv/cbDpcOZ0qN9vBLM0IlZ/FKeW2Chn2i9PevmjYjURjOk8Y1FKJtnt8xIFiRuCPYae/ZmDg9hV8Eo9ht58Y4YtGGLqid1GTSgyrVYths9VjmHz2R7jNmYSj8yah5Y4d4hvfQtAgBpt4FmBM7CqWL5mEO0ticEdbmRZPrmInB17i1sxiBCsvgL5VDDytJ+GlXQxbrVOFzHkLIG1SjDeTPiEWVcxDdSO2mVdB1ysMX71ikG6wESXHYzhdOAnr42Iw6cRVdHKyZsUoitNicHvzMG44jiLuwiR82jmMHV5O5J1SxYoyq9jNqI04mLyS6PxVTKmNYS2caJ3biEUskV61TMK9qwsIDyZh7l1V6rqfhphbV6FRvxEvmz4h6nUaDrybBIv3AtTYOQl1HZ8g+rkKzQOTcKu/GJ3d79D1PQaHRibBczSGxY1VMdfxMNiKG5PmpAbOfBShfnEF2pgaSedmrKPFatXsyhRJzNOvZo1akug2MEbsLEl6b7aZBqw24euqFTRsFMtWLTfGpkXS1GkSDhuKhaMJF8XYMw4DNKNifze6tzXji+drXLOVhN3hNlSe3g7b9ZL4lDiGLfGb4Fo0BmE/Y+zZG8t2u4tQo6c47UuzoNhqdxIv2gSlOy4055Qknrduh2DLJlwMimXbg2OZ2Wt3Eisth8rwX3RKxNFwO2ftixe4/HkTThWeRWurMeIzJeF1XhLX8yWx/pIkaps16WWhFM0tjGVJhZJwuyKJh1WxbFzdhdLlN5PlQDVr+F6OJ9fFyHe8Gmc2f8f9R7FMvj2W9bdLIk72GodJrjGfKZy9tLED1u/EKHLXZqxy34zMH7Es8noDhaf14Id0Oh7+CsdhkTi8kohjBpJSONvag8fjp6ClIoWQy5shoiqFmBlSMJ0TxwbmxMFNO46905ZCrE4cG9GRwmDcNabjPoOufN4M6xVSyBR1oy8Dm9Hp/v9/bOqgq2IhLIefgDt+FvV+TSOD7XHoUd9KxW5SuOopRYn0HpPmbYGGdxzLvKdPP07GodytF7oHI7CzWhNPQmWo7ts1duxIL6xj4tDp7I89m7egIi4OPvZbcFogimyz4li4+V2sTe9FyOtxTBT24oleAin+9wOBlVK4deU9U6mXojsLFyFLqADzUYMX0yawbmUNK74Xx4zbpHCfE+/ouxh7+x4OnTLU3+WEZzaVKOvkXM+nOOjtrYHV6y0IO1AD1YUXcW5lEFn6L8KnfROo55HGYrUPbLqAPU7wSUNRwxkKotLQqbmOAG8d+igdz0zrryN6kRJNVpOGwcx4GHLm0xELe3q5djItWW6P4L/L6LNuPLbOfoDYV4vwxN4ePxxfQTnmIqYui4fZqngEmJXS7zXxzMlSGpybx6sgTjZLY7JpBB2eVMs6eapQsjse/xmZUefZKZRiLUwTN+3R0/eB/Zq3kATC41n4tQz8GHdG9oQzvr16hYwz0nQjKx7HfP8CXA6o5nNAhnge9nrWsiGB11i2bzHJHKllV89Ews+qDHcCapli3GIMHu4D91ZdmvZfPLNd4gCLZ/FY7rkTgZu0KW7VLKpv+Qk5h1hSuReJnP0OSBZVIHml1aSWxkVd89rA9bqW/Q51IBJLYM85qctwgEbdaURNT8AFTh/MvuqAY2oJ7BB3FDb/rILMcBV6npfh7t8qKD3jodtmB2mfcQLEjaVJyG0y7TfjHGfAAfdXJWCtkQkeN2nRHzUXrPnKRT0Cjpgp5Eg778+gp04JOOicwLR/F+KllxzF7pIh/l1LSN42Cj++zKAWHxlcCJCB4cVmehtlArHYOvZUyoayEupglS4Dj6NR6HQNp18ur9B9Igp0PoFZBTuio6IOjdKrKSHREeJ1CYhId8SpehlcbUhgZtuKsPGmDKRuJSCp1BHvtz1CX9hzLH5lguK+Ota71Z94O6uh1pPAwnpksLshCoG9Cez2B2PqljDFhUmmHP80haxUPdszIYOJ36+gezkER1Z3syK/L/izsxfGyonsWeoX5GrLUqfFVmyZm8jkttQz/x31zMlCFl4rZMn+IS/JnjSF9sGt8LJJxB4tW9wL3Ipms1/Q4nj5veR6KGXVM/szW5Ei0cbhxUS059czSS9ZiMwXo7cD3SzdWxYLy7bi0JFEFtiyFeKBsrjk5oVLz7fCWckN0+IS4aX9GSdTE1lb91bMLklGjtR5PO6pZ/v1eiC+LxqW52TR7vIVO4oS2YUT0WAr3JAXGo3a2kQ0BhcjLTwawUnReOw+k4aUl2DLTG56womW/jZcfJaIg+2JuPjmO0rNt+FfuCgdTxQjmYpi6GMJzDZvQ9SWbbCwbYDKkCxOeW7DLJVDVDAsixNccjB7rkO2bg242O6GA4cbIGg1lRzTz0N2bjm8I/lo5S83KLkupAXhHRht3oYqfTlwFzcgPbQG/YvkwAc5XKQkZpPETYYLdkHjegNTb15CfdZyZHU7iMp+H6cAjwd48uQQPJ2TMOLUy3HIGhwfbmCxx3vZ5MgUmuA1w4hPEtuF7bikYIYN0UmY6BzA0Uw30k6Ww480OXj18lBtThL2/1bGn3w5OIoN4uHlJA77JLGRV71Qv5qEDZVysI6WIt/E7fh96i2crBvZldzteH5jHn2/KYejo7uQf8QbbsP6VNdWgg6rQXT5NbIL/o1syWkzTO9KYs92DqJnET/JFcVg5Ze5JPctiU0ZKIHr7Hz6PpKEOWNycBndDuSZ4fiTYcw61A9fQXlUvIsjh0uDOJu5gf4oyOPW1FLwmjpT+LIz2K6azDLaG9lnTXk465TC2241yemW4o7sITp4Phs2RvI0bYE80pHMfjrtQNSTWniYJ7OaZ7Vos5JHsrgk6fzVpE8bk1mBYzLMtsrDQ9STZiTykq5AHY55yOP+B2F89Exm4vuS2bviHbh/RB55hrHg4nTPzfFiMvWXx59geUxz3kR9mxlKY5JxsJKHDBdK0HhOMgQ2uEP05i18tpSg5IjrrG53LLKNrKjpWjJT9XVHOe9hkptViZ1qTlC9lYyZosHY4BlNcQ/kqTS7D2H/FXJcLBla650wU5yPNr9gcP8hT03jyVjOlYJI3hTMPXQP6/hTWHuYE4KEgS+RlRgZWkLLc53wYXIKU56ewtx2xdNEvRMypM3o2Y7L2K2rgD89QbTn6ipqY00oXpLCeC1SUGHZD/dvTkhTfQwRlXoYja8lEz5npGxKYfv4naEv4AwdQWdcW1APQa8mds6rCZ4bxrDyOB89OH8Z2+c64+0hBSrxT2HJ+nGoWO8M7/wmdsj/MZakpLDMjBQmn6mAKH11SvH8gBNZClTu40xdBQo0/1Ew7hSmsO6z9fCtTmGyKxxo5vnDFPW9iUm0KcCfMzpcx5ugzt3MlN32k9InZ4ioE+b0OKNDo5n5jKSwsTEF1IwrIJA/lc0S4CdxEUXa5WxBBsNd6JHdiTLpVPjIKOKifCobaq2Cs2cEru9qZn/dm1mNXgPcPZphFV/G+ZZ24orWEB5EETJTm9l3pf3UlN/M1gbuxNnwnXjvoIgMx1Q4CMSjOaAB5fJfceDYHJr2tAzaO/npk5cieKfFQ33uV5ZzTJGGdb8y2yBFXN33FmtCFVHLybEhwtU552GcxLnGrp0YvWxFYemp4BdqYYmc1P38iKq2BkhZvsBgqSLmlCmi9L0weU51weU55lC7qUg3eX/ip7E5PtxJZT4e8Si9m8pYyVe0XF9EAQYuqDh7kjbJlmDhchdM/ZTKou7w0+xp1sTv4IKYXkW0OLogYECR02GprMvTBXbDipAqNyIV/xaYcivh/fwllKFuQpJJ5siz/4GMqWmYpqwEpyIXlOgOYGFpC15rKSFQaCXdMN+LfQ/OQ9dACc8DGlFvnMautcdj7nMXzK2WJHGkYa/vPgpYrgS9I9p0w1YJOnZK5FTViKXblSguSpu+1DRind8cyq1vxFrBG2ylO+dcGq7ILxxAhJYrwksG2PqdoWg5oISy3fm48aYRrwKVMINPigxvaJNgzQlIczzswC5XiB5wRfKk6zgq04mFDjfQ6nyD/dt5g1lXpLHu2ddxamMC9I7eYB0pRhTndwMid9NwA9cx80Ea++HKmfkWg6zK6yqOPlfCg5dpOCjZj21nLJD8VgnqT13xJM8CvO0cfym8wZTFt2B4RSgp97tidaUFbldZ4G3PMOaOcJ5NtQCN1Fng3m8lRI644sPdG9DiO8P26b3EQP8zDAi7YWiaGzTkzrCywRs4FlqKz0378HdBJG0cssAk7qXYX/UAqld5iWudG7Q39eD45h5YmpyB1IrJsFk1GbqrJ+OjwVI64N+DeQPX8T5mBIrbJ6PR6Qy7tmwpCndO5jjuGabrfgah2W74H9I+/NY=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="67" id="sample=1 period=1 cycle=3 experiment=2" defaultArrayLength="361">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="666.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.011561868436" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="39949.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.124983333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="2"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="412.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="12.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="12.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="412.5" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="21.808494567871" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="3552">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNz3k4lPsbBnAhkUSiUzknW9s5IdvhF8WdRCUkW5HMQgwzZt53DPOOClkqSRQVldEqbZR2lUGSSpu1nDKFor1Idcrx+/71uZ7nuu/rep5bI1t1y0b7oPZYSOT4DB/sNh9rI1vojxd724aomgC4yj75La4NgGeixlif0YHIMDvisTw9ENN3Hxq/sXoV3u/yOtvwZyga5c1P3V1D8VwafleZHIr4tXb/TqoOBZtSv1ykHoY+PUVozMIwKMv1dqq7hWGl7+YB24y1aI4znmhavxbXr9Ry9BCOj5mVGavNWXhrIC3Vns7CilHjSrvcWFDmO9RqhLOgPtSzLZTY2xqYXrWRhdvr7kiailnYPjmrxFzOAvOyYdemahaST29OulzMxt/yC+mhcjYsZ693X17CRgPfwo5WsLHXx3pVWxcbUREt4aqqHPiGfjHdYMzB3A9VoTZmHOiXb7N6F8YBHqpa53LJftrKNVMjOJi+S1rZn8ZBVKuzapucg35xpKC2hIPZ88wqA5UcDCsuOgaocDF6wb17XcZczGYSna1NuHAv8tB468LFsKGT6+ViLnwM5aqOdVw0W5aqy5VcvPlfZrq4m4ur5S/E7SoRqPByiPAYFQGdiIYJAtMIGLWV1tQjAv0VlQv3sSNwcn7JjzOpEUgymxIZWxwBK5fmk51mkeD2a407Jo+Eo7r52w3VkVi/u1W+qSsSQS0DBV3dkcCyH65rRyJxSjEu5bHxOkwczjVUS12HZSz1w0nEH65BOneIK3rqDJK61kH6piDnqHIdjGg7JujFOqxe/610lEoUovXPdkw1icKnTG3dWtMoSIu8hbqsKPxs/G4uIi4da6WhyY7Chtr6pqDiKIyjEvdeIl6oSzhxpysK+eqhxR3KKFjzP2hcG4nCNM0q72zjaMx62zEqlxWNawmwWp4SjcjggoY2eTS8LucyDw5H48g9fbVX1dEos9t23LcuGh2bCrM8wUOH7py4x8TQrFMdWQt5MLv+It/AjQeW4rapcRgP1msOmCQRByxubnbcwIP40LJmn3QeUvbLtEQlPGh7PavmH+FhGn3eRvmchwNxQV6OSh6uBNnc7/uPh8XDJvJGlRjYW9lPfm4Wg4azPghnxYDqdz3oJ49BouTyPieTWBhaKHnt7rGYmuVsFsyJxc0CiW19aizetTGO3AOxuFJTWNf1PBY8NYmJkwkfObmvxvBd+RD59LPbiIsaN0i7F/FRK2nb8lcYHwfqlbo2bD5ujIykHuXwsYp/IMYxnY8Fzw/6zizmo/7PHu5jJR9B/4xKbFIX4JGLNdvWRIDe/XfvyUwFUNwomGq8WICwvj8K89YK0ODWVHqeJUDmKbXPVSkCVJ8IL0lOFeDT1zSvJ6UCbCvgvwutEcClzdjVUj0OR7Zv3cdMi8Mgo/NFY3oczDSdLO03xUHrrNb1z2lxuK9bq/u6OA7Si2nrvhyKQ1npQucZR+LQzFuVlnozDlZ9mxs16+Owu9vAuPdlHO6M6k98MkqIke5QbqmxEAVn8pfvNheidXd2uyaEWJG1RMALF2Lgj00X+lKESD457snpVCGSvn/t0zwoRPov9ZGNCiFqnPQnDxE/L3k7p6hGiIUF7o/blUJcUvl5rqhbiH1e1dcUKiLYaOwRjVcVoaI0RpZGbDLyNp2vJ0KlVnC0rYkIP5ix9FXi8puPM4tMRXDd+blriNh9Y2HwCjMR0vwv7dAzFyHB1if5sbUIEUobn3s2Ipw65aV+0EcEhd6i6haiVUq/eP1KEe7IM8uuEKMz92q6c0SY6btgSxGxIfdTkaVQBImH/SOVnSJ8EuYXXTgkQtVqkUtfuQiTeT9yys6KYCQwvfuceG4Ry3OaQoSe1PQaPjGiPcfe4KMIvB+F/hXEvaa9Q/NUKTh5n/xqpUchJeqOeZY+BSnelq8yofDzgbF7G/HVMZPSS7YU9kVcHJhmR0G06u6q88SCDrfIIDcKp1culVYT03PPF48XUrDT9ZHn5VEI/lzg2iun0OtmeGxKCclbymeGEj2nje7JK6dQlW0YeJ8Ynj8joOwshR+xr7XHnqMwI44bc7KawvrsJXMO11DYE5t1UruWgtfonszYBxRSXR7SFg8pnF18RW0/8V3Gcm+XRxT8g3a2SYgHdzhIfJQU5hqfaD/9gcKBitjRg8TW62uqzD9S2HRPEbSRWD34MaebeNFx6phZXyiMq3s197//KLxs8zuxYYRCc+vOSReIM2gvo3+IE4ydih10aby/sbcom2ipHXRIW48GP6/lKvRpXBLd9Csk7n6dZB9mRoOtaqpQEAvDg5bVW9Ho7nwqzbGlMYnlfbyWeFh8ar4xaOyYM/9MGHHVKbb81UIaQ7yAvCNuNEIUSZHb/WisnvS5YQ+LRsmtWUbqbBpHdebo/I84d+utwA9CGovqh0tviGisNRxTPZqi8ea9WvZSYourjs9IMo2RyOBZL1NobFFPv2CXSmPrcMjdJbk0Pg8aHqqooMHdM3GkgzhPqNPicJaG0CSTSiQKrrbqFz6kkcn5O6WLeMO6qnO4i4bh1z+2hCtp6ExxCAv5QOOVMIqTTXzZ88zb+iONF/rbnZgBGlNuXhbf1hXj9znxbb9MxXgwe8jHxUyMiU/dP3faiLHf/4nzElsxmr06w03dxHBLKHoZzxLjZ36G1lFiEzXb4CGHzGyLmjKRGH+febagiRZDNqPRxGOXGFuEmfd/HRRj0F+tZvChGBzFWNpLNx7lk8/Laokv3K5fExnH43ZA7awqlgQNmyr9deQSvP8pG4ivlsDr25P+LIUE55Ycc9N6IIGq9umWdUQ3Q6PnfY8k0E5benGgS4LJufrfO0ck0DoSvUOgkoAlOYFPBVQCrpiPrysj7qt8019RkoBplS0VZ8oTEHt/Ys7JcwnYkXF0w0f9RMRbBmb3dCXCYmOPfqSBFF0R8pEJ5lKc8E/QaCdWhli0Wk2XondF540xdlL8q9qef4YoCPANiTksRcyAgefcSilCYn+7IlVj4G6btaNFl4HRygnDEn0GPfe+SaZOZJDcss9bw4ABt3ZLYZ8Zg0dNC/Z42jEolQSvPk5cnKQRlWXPYPZpp6JBovOe72LfRQye/xK55BClg/On9BGTTnILnd1J71Gd+hniXjfNl7dXMmi8KFG38Wfwm4emZwrR4ts5t9fE/q3ur2cGMPD9x7iujs2gbN/33k0cBiuucSxvEYu/hv204JJe0fvj6cTgoo8Ol4kuef8+mylmMGDOkSiJDh0ui39PY1DtfCRXQMwrKix9sINB0I+UpTNzGXwpvhVVQbRv95j9Qc4gROXqZEEJgwU9Q5tbzpH/F7+d7VfJYP+Eec2XiGv++jc4o5bckRs25zHR+nh+J7uOgcczqxLPmwwSS1NsdZsZGGytTqOJfuXXVZ+8ZPC14nun60QZfrd4P3EPsXMLen4R3QNOz5Wby9D0/Zf4t+ky7JzTYvvIVoYZfo3Z3XYyJMZneUTay6CR7GIds0iGGm+VDn13GaRDB5YlEWMtPvhVEDUNnNjXVsqQN8Y3Y7+/DFXR2VoNgTL8H8NqGfQ=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1804">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwQk0FHgcB/DkrFRE5CpmUJtQGseE/L5/wkRKkxAK6SZ0PWEdG1F4olo8SUyh0koWHQrpkCPDhiiPpCRbqWykYj+fmUnhlH5sI+Ya3rVJ3fWAGjecJk3FMQr57kD8rgv0IEgeCpuLbGsCNTCrqRkbq48Acs4IWT5k02a5hoVxg+lLrgo+ntvBuJ8PEVfbHdH9OsxBmk+xOWM2dSlhZBp4m8p1LLHuUwvkR6KpcyIVU5nXsf7VNMSePWyrePk+GRlsR/jAHMb9FMh0FtjR/toHFMjXZJfSJCnZxNKO9zyE7VofT04iD3bhTjz1ysiCHydLdZ0f0DPcSBGPrzBBwRReP5SDVn0zqefOgNg5G9l5LRRs0UZ6bkVsUNeMvS2SZsNVdexFpQmg9RT6ybFsNEcB9h+fk4t1BcLKu8lTnAaJajMoDLygieEXeOa4k1W16GHLDiV4GfOx2HIr0oxXMeWad3CT6COLxZbIqHtFoTlV2KhiDU9XVcQUZtBoaQa9NFKjPyJt4BpdTcY8NVwctMHU2rfEBtXQoNGAg67qdNBHnbzLypmkYjb1BWpQlcEQ5fokwjBVEyp5M1jnVAyOCZIQ4PiJKnov4x9BCFyXCjAecwApMl/JPmEt3BU5MBppQG7mQQTt4UDOaJS4z50gbBXhodlFMo3TRWmCLtwWu2Bq5SVy7F9i2+8zTi2Ot5EpoY8RR336yklH8JLZ7O+QdNRltrLNmZFoy1JiZT716Ly7BJH5v6h4qxANi6LQeX6SBGa94OdvguaeK+S5vx3r1kUwvxWNEN4ZxveHV8nysQEVdUyDn9Yyatctpp+HirHJRwLm2yQgri8m950eEPWOI0yYj/9CPZAWl4Gj/RJoVJuOSq3pGOmyhbfbApZZ4Qk5w7/oVvhexuVsQYCSJOy9vWDXJwl/jeX01KAVtsu9MffuDaa/WYpFuhZAWkEaJY0rKKgtG1JZ8TAM6WIpYmkE1d8g51BNpDabUJJaGV3TKKN702RhpNnB0n/yIPrFo6ZJHlnlGzNxXj+JJK5gssQfa3NNqbeoHGevmuLFvu3g6c9h28Lk0BkuB98JU0ysMaPf/JrxVuYHjD/IYcHSq5AakUPvBTMUTfBsY427EJEbAOe8AJyU2AGOmTkKLczx88AMtK4xR/zZSsRlVJLLs0pK/HCCzrx5igrtk1hqaIEh3k1KsVmPbv+ZSMmeiVN211DadpOSNflUoc3HpA4fV09FQTJbDEHxn1AQD+L6PT5W+64ilWBVpr99Fe0OuE1fz4vwfkSVDYTJw0pnLwbTLWn89B3ymVfI0jP2ws2iigy86mG283dmWjQb9y/PZhEdm1BgGsRk3pciUWxNTsqrqXrhauK8KUCHVDU1vbOhFV6fMdGqAL/ttfRG6ICcw44UZ9zEjjWpIF34hBa5CdDuK6CMPAGCeWtJ3ryBqpdl0XlDNTxqVsPZmuPMeWsM9DZoQPZnDiUkC0m1WYh5asuYb89CfJmdi4b5m8jpXjx4pdq4fc6dLF8fh1OPO0z63NETqMz25pRAtqMEy8susUfBHigJ9SCHcWVmFcfBjvh84McZNCZwYFDOwfRMWVY4+pxu3eTgyJgHiVZ4op3nSVHv8mnM3pwNvOcgaTifIj/IMqXoLtKu8UREbRdxv3URj2WxwggRnuwWMlXrLbQrqZtS0kvhP8xFkLouTtQmgmnpspT2brJX9sK/870o6v43DHBfkkvGCbwszmNDu73ZzH3edC9KD75HZWxFLivZgpZZtg2pYYip0MPO0Zd01PokPpr0kKxVD/0P7bVdpA==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="68" id="sample=1 period=1 cycle=3 experiment=3" defaultArrayLength="251">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="252.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.079547431863" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="22042.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.126666666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="3"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="437.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="437.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="23.321104049683" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2520">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzHk4lIsCx3FCaLFEKsfJDF3RRCNlqdTP+tySotxyLWPM0MwY8b7zTpRxruWUTqkkOm7XklHRDXW551RSmeFQbmUr2mQZ5CQt9iXVff/6PL/n+T6/TOM0vrnbXnybE31/RstIq3m3XRkAxqxNWGFNIIZaZUs2KgLhNC70PqkZBNVTTtmGbcFQO2tQRtSEouRxJCu8NhS2nzK3so9xkG/x9cXf0jhQXL0WmlfPgZB//3ATk4sL+zsavC25uK/TNHjXnYtVAwMhExwuAmW/hFuHcdG3w/JH3YtcGM2JrysKwuFG+Hx+oc6DWq9dst08HqoaHixV5/CwWueWbQiPh3q2x81MPg/pE2+cXSN4cPzFK+t0Pr2Znf++RUt9PNRyspsH/607WUE9PGSYBnYGqvFREq/evInBR/m9LS1XevjwKTt4aoJWsOlX2aRaBLjuWvKilAgc8zyhvVEegbdGXsXM3gj47Fm/5VVIJC56VseZcSNBOfCuxdEyTJhWtRcjIf3OCPujLxI7io0772kcwKIR3yk57wAmWZYjK1IOIMmpJGo37Ur9X4253QfQcky1xsNcgBLVN2+2hQAp3dK8Hg8B2iutHdMKBOActrHq7RIgQOO+Z2m3AImFpUHnVQK42DgvZ60U4qN9lc/tcCG2Br+5sihZiBV5zss2XhIi5MWmiRyFEHnpuYNf1UQQCr/oMUNFaJ3/l9f+4SIEMj/ZPU8WIYZzYKnfURGcQtU6qwtEyHLM26BSinBJXzK9pVYEVb/ctLxLhGsmfa6aHlHwDN91o+nnKAiWD7q5XoyCdNWjbZ/kUdDT8V3cpoyCY3rrmKw7CsnydVONvXTHT/+Q5ynG7hSGndRLDAXb0ooTIYZEFnlHI1WM38aHZm7ViXGhLd7GtVcMnU8DVZ3q0UiLmD/rMS8a9n/dbFu6LRoVPw2t/btHNGYniavy8GisGpK//ldSNIqtMvKCNQ9CYTS5bbjuIK5zfJfnacYg/fGV3YErY/C/Ob8Zw8gYLH/NXL0jNQZS7Wt9ybRTQlbN0oIYFLSQzU7bYiHatfneVHIsbA1q2T9cjMViyV3x+e+xMOv1Hs1VI6BhytZ+Ykhg0Hd69ZIlBMpV2cPN5gQm7BY8ymcQcD3ru2qY1tKl+PQwk0BG2bOv2y0IRPv9LsxlE3CuGbohAoE4vYaTD2mDdnJ3tu4iMP+MzV7pHgKaN94yw3gEbrp80e2LITAbv4TSJQncqNEN10shUO3mnrg4k0BXcFDTHO1Qjk4p7xyBErHpmz/lBELCBh3MiwhoFSR6tlUQyFOtnZ2lbVCeCnSoJNAyyvC3VhB4xzp/gaKd7Zw+YtRMIGadk7+Q1jVYasVoIVB4BJIFbQRejp9g/0a79z+lU9o9BPg2WgbWvQQUl8uTPL4T0M1+8fyyHomxKsf844Yk3h9sp7YySLyqHzXJpk0gE17UMEnoOLRv3s4m4TWzZdzegcSH2DNrf6I92pHTsM+dBOfhhH0ObUNR/3TaHhKtofMWOXJJfG3ukvgQJIZ1/9xuQJL42Wxsmikhkd5t67UimcQpY4VHXibdr/ky3kZblTTFp66T6IoUFJbfIBHLPlNnUUni3fWq9vdKEv0za+231pKQX51jl34m4T99mZ0+QqJG7ng0y1CC0eqdto1LJLhgmLNLy0iCRkH90KCFBHEV2WEF6yVo7WvTb3KToEkmndBKkeAHd3txllKCLOZGrYlWCZzEuqrkMQmYmx6Ne+lTWPZs71VzCwrrrE+s49MOrzYLyvCj0NFxPKOOdszPL5XjT4ERePtwOZfC6cUmng9jKPQIzAekBAXFLbngfBKFLhNBbl8qBfEpVezysxSCbQSOPuco+L56EHma1vroG29KTkH7eqzeM9r16cXC2QoK4fWZxesVFAbu2jh7tFDYSJQp82lfl08WebdSUPto2VNCS+Z9XtPWQ8EoMpdzRUXh7RHtL5ojFJ66ELeujlIw16+vCDWQonJh3zL+OinEvmZWRv5SDJa+Gfq0R4oIlvSPb4QUGtWORcOkFMzSlA9NKVIsO99dLMuQotBhsr+WdowRYrrnv1LY7H4QkEv7xJ9x6F6dFA9mtV2+9EjR2nHPyE4lxeYPT6LVR+nfY/ldQbQzGqzsKloWu4y53+8QiBVazt7cQ3BqZ0cZ2MehzzHgnDftxGe22M0vHprH76SRtMfEES7KinjcPpfqolEZj/1zRVrlynhs+f6yeaj/CFiDhUpWVgIsQ6/ZB1xKQPXkOTOTvgQYkw//OTqWAP3w1Msl4wnw5lhWndCQob2gef8A7clB43/cNpJBckH1qNFYBtMIU+qlhQzihd8YNy1lyHH2XtSyXob3oriRMAcZOkTh3fW0j2eaAmrcZYh3mmusq5Rhu92lBQlPZciWzWgO9sng2XtIwu2Xwermu82XaEMbjz4Sj8ng3MteqD4uwz7R74OhtIv3WQVOqCciVBU9IpyXiHTlj4Y7NBLxbkNVSgXt4bSx57FGiWhIGpq+Q/t/eTGUeg==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1292">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwNwwtQE3QcB/B4LI/EA+IRIkI8bnJOxuJxGI/2+/6BBgJTpi7pJc+UQEaGhQkpAiOZIcxxPE5AHgqoINmEtJQColMgZWhxh24gA0nkIQ8PTsn63H2ieIHUzw+k7ZGnSfG1lBTDZ6l7fFh4y8mEZUW3Urn7lFCfGRrE9Zih664yKJSJaPu3B5z4rcgzfBcGslBkn1oWvrb4Fnu8cA1j3xVDKnZBodqQBu3yWMDPhpDIc6g9yRV1qbk0+soqSCwRobr+PMYn15CNrpdSw6NZ+nQd/nKSM9XcXYobP0mC/YM0kzRI2w47Yn/ZRaZUSGET5o37ynwsTA3Rb4sFzGSyHg0bWuBlYokirhXa9ukoM1lHqxk66lWXkPfVHFjtjkNpojGraSql2nN68pwU4mThYXjNryfxiwlERVTQ9FU7qnlzkmweabHka09ey/aknklGQVEYC0r8AY2vO5BsnQOF98zQA0E1jiocUaWZpU/n5uiU1oLl7nSinl1OCOQ4020zZ8g/c0aY3SLl+LjS+h1cSjNuoOXwTdRSuJH9mBKIiNhGCmt2o50Vr+hK0BSKknmIaKpB3gcGmD5jgMuaLTh734Cthp5gouQhfLS7FmPvj4GTl894ve5k2N8MR1s+ZLwWxBzj00onn7R2RvB/+iFEGR5Y1R1jsmojvDHgQX88NGI2lSYsl9tKqk0C+nVXLsoPttL3HQJaKTLGoecfw+WOANUaAQ5pjJHj8A64kRwUmHrSi/F01IaK2Yk7HJib7sV5y1vgVTWg9KiO+rO5rHdUh4wDXpSi9sIEJx/Ra70RZ67Goz3e5CfPh89oLDaIfHB5JR9PWqqQYB2P9Es+JClvo57KNvqWfEnuIca8qJ22lfmiY9oEB7y30i/WCuKpr0O1T4Nnl/zZJEvGrDIAnqoA6v8qEP4tyzA7coPKfr8B27U3KcXyPfA/uUl9flL81HyT6h2MWNy527gIMyx1p6JYIqSSUiGqtLPQjMgQ/URIHk876At+I2r4RTBX7UGSqg8LncZsKcgC26M6ST93ENa2pmzMSI5/1qRD+00XqoPbMe8aTNfsLWEgtWR/vgymbskAWxcZgiviEErbEULFISXoihKhbTgL+of/33iGqhzsUfdcC332BVi9LcHK3mE6PlGA0hEuIpQDSHvQgKxBHQktYvDYtAKBvqdZU/xLLCljIG3KZCv3RhDx9wg9G4qhPptY3N18AT1OhRgNL4RbSzxldW2G95eF8EsTsc/vuTAtV09qtwQK26KnWfcEOi7h4YhpJf4DSlCtlA==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="69" id="sample=1 period=1 cycle=3 experiment=4" defaultArrayLength="166">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="500.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="274.021054740076" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="23877.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.12835" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="4"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="462.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="462.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="24.884387969971" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1700">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNy2dQkwcABmBN6slSGVJRGkYsVlsICCKjjlfEARZl9eAAIQvCDPkyaMBQEkDwFC1DcaAhJCIyasCB84BgFSoC4sBiyx5apVTBcrLOfr+eX4+1w5F1FjsDkfjLg8qrumCsCvp4Zdf2cHSKVvzYinC00gZKXA9HwtzFUKl6EAlFddWL/WuZqL1sk3rGi4lCV7xxiWKiZYl5yOkGJtIO+YzVKlnQFlTtL+pjgT3u6LqCwsZ8FGUvg87GG9nr6WIOG8eLGxrPZ7GRo22ecFWy0VWs0lxVsbFxJ+dA8AAbRlkclpMNB6KlZUMHSzkIMvYraR3gIH/lREfPIi6u3H1nq7Phwr227oyaxYW1TNfbruDCxO3WsyU7o0GcaMyoyoxGV2XfnuTGaEw6r54b7Y9GhFa/rW04Gsv4RxUdVjHIGzU99o4Zg0+Tm9+aKWJwz1ewXEtakt8u0O+PwULN7/tSSF2oFXN/LuJBxQ/UbVvMA5XzWneYyYNa3qS8oeThtz1xmfN9PDBrYdjWz8NZxr2yjqhYuN/OoU1nxCLOk3Y8SBkL1xE6s1cdC0/LSY1aE4vqGWpnBzMOT4YDqnxYcagc0zoYceJwsNic4ZAdB69TM9m5pNFbnOxlpfFgdlt4K20T8E/YD/MF3glgli9sWLkrAY9yPuU/USQg6ciymuJtiZjT5frXRSTCQ237H+XnRDyjNMR7eifhWr1o16uMJFxK/NbET56E9YF94a9IiRTlzWZVEs5mzyXZ9SfB4/O1DjcqH1yH5aWbrPhY2qpNfRzFxwFq6MgbLh/txJje9kw+9EPPVI4o+Uiw91ZTH/DhSgQPTsuTYRk4nny9KRkviny2meuSQXe8tcA0FiBh1vHCfWsBdugoe47ZCKBnt0lTSTok+2ljKykj7ajZO9KN9DU+DLoAobe669qcBPCaOZqrggBTedYR2WwBaPXyIYtC8k+UuKxpEkD6eHw4slMA4/DLevR/BThW8ZToIjXYndKywZhA8UOpM4e0RrSOG2BD4JHGb/KTLQF3n0svfZ0IGJTHt+SRqtPc/mC4EJjliSciQOCvg/OHTnoRiAr1VaxmEkg/LR4PIzV7Xma6VU7g9Su0lxYQEH4VUx/QRaDO37G/Z4iA/FSEzfsJAiHJ3aGmnwnc+WLUP5vU4/rix4Okqu3jvd0rhGBkaKs3mwiRvrw6ZQddiLcROd8MMYXY8uXCSnuWEHkcWXYv6VjWkH2xQIgbDZGaVXIhHM9n/LpUIYTaKyzr+wIhqsrlnk06IZxOXLrt1ixErqHvSecBIWh7kXmRIoL/iDgu20QEroJfrUcXYfey0c2xpB7NU3nBTBEu2CnXjpLe11YauHeJwE/TOHw9KALTwefzdx9EMAmxNa2YFOFmzPVrdovFWNKyPrKCIkbFxS2FRKMY+osM95c1idHTQHG6NyDGvun4ngXSDcPBfpHvxdBYWZR99JLAql75yMpfAmdxhGg2QILQGSNH/SAJ/jaU2tawJEixrmF1N0sQ4lpEff9UgnYv+YnJQQm2NoozBXVSJFi2Po3VSdE2us5MR1pJk/VLu6Qo8L2bxfsgRbmv9UPT/FT4N5w911aaigLGlTSoUjE8q1hTXpuKpKkVqwLWyuCdHmnQ6SwDR2RhVPRchsCY0PnTwzLY37l/NWpKhlxaGG2c1LLlZXAhNR3dBeJzc6T/A3uPVu4=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="876">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwN0f0vFHAcB/BE7pLHiOSh6Dz2QOfZ7vi8v6eMPLSYlSwPJ5wS1VKGhMvaii6JkodjHvqB1FouhjQSFrVq4zxUNl3ZZJoSYur1L7zmvJ/7qkt6fVMc1tCiG0sWy5+YbpQLBh8raCjOE3YabeieNUPS/AviHX5JloHlTEdUC+GhNRQ55lP9dXVED97Ad515pgytQn3hIMXOcDA5k8Qu93DJpXozXXV6BrvR9zQZW0juJ4LYcrEuLvnz2TdJAbTd9Ilrmy9SVunDacAAmrtz0O66leRZPFSIDWFjZwT+vBEZnPlMcUW/8OaBAHlkgvMhZVSaIIVppIrGiu/TvnumlLCiovW/KkoOsGB1/ZZ0IEKNHXGuJsepncTbaE1jc4GoU9SSW6wry71dT7yoJZI0iVEzvUTGFbaQbWikmJ8rpLtxlXL17Om3bBU1nGzQdgd8Xc9jjn17EN4WgdKBvZgPrMV4ZhmWQmqRoMxFnXUzeTk0U4B0DkeP5yHNKhLylIOsOFwDH2QaEGgxFn36CQXc2oS6bXxSBaX7hZ7jozo5mu3q5KPPpACRWQZseIcLve0roDQfC/iIOJA81RdZZXLh3sVF3CwXJV3BrH3anSXK49HioaBGHwWtl3hg4Z0nhiq1kCzXwtSIFoK32LMr5SnsbI8XaYolUCq8UZmhjWvpYWh11kED7yNsUnUg7BWC91qIpDkzZu5BuCntJusUY7bS+hATo0THTvbSotgPYdOmrLnTEJZli5ju76NXfneJM85lakb+yBHFQGAWgDunBsjk/80fYb4oWE+TVX6Ro8HQCsMhIzRhF8bMF7pgKL0I87xIlDyKR86PeMQ1yXAhNZtpLCaiI6MD0iYBEzvuxz/6hQtz</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="70" id="sample=1 period=1 cycle=3 experiment=5" defaultArrayLength="218">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="304.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="274.021054740076" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="22500.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.130033333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="5"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="487.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="487.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="26.447591781616" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2204">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzGlUUwcCBWB25YgsiluqlFWcMiKjOAhFuSytCCoR0Y5CJAQSEpbkJS8kQA0hBIqCIxAVdFqlLFoRKyDT4hzWJAodggxbETdAoAhWC0URFaPzfn3n3nPPtXE8EWvqF4n3KmmILSLxocD6OtHKwBld38imnGPoTP2PzuebY/jX7k3rYtqPYbS6jZFrGg1cFt4cRDR0Z3/eF+nExN034Xl9AUwMtg8VrYlmolGeH33nUgwqZVlPlhqx4BWxl6lhsPBmMjrg81gW/OrGr+sojRqPaKtKWdDPcNRRoywoP6wJizOIxX5lJdvMPhbNpzqW39fE4gE9r/HCaCzoC/SbIwZxiFgce1SriINOW1U9S5lla6WwLYvDwKa0W+mUj3WfWQQw2ciF5tYKORt/Wk/nkKVsGPb27uqmPNHi0pQ3woaq78FO3Tgbp1iv7GuNOXgy9/Y5zYSDQF7KgobJQdfhOBfEcHDWEPqVCg7+ahxGO1TGwQe96zL5CAd0hQWre5SD+qSS6MRP49Fl+mz96Uvx+LjHv9M5k4uC0mvn5su5CHtfkH+vggty7nS3exsX/7W4or2s4cIryCHWS8uF2F9zw5rBg7yhSrPA5KFj39SyozE80PifHAzK5uGpQ40op5KHHQ+GTz4e5kFfsXoFQ5kAKXf+Q3BpAi6mbjjp8X0CLHK0b/RlCahJdOF9bZwILzf7kt+CErFxoHtXNysR0pWkR0NmIh5el1zzykrEvRGG+gVlbqdaH+uXhJA5a8vmwCQsyQ2TCORJ6FjYUi0bScJ7XvnaEJNk5Jzfof46KBkl1o8OD1ByNzZXGzOTMUweV5opkhH4Dxu3GBM+HNnuLZF2fLRy7IpDs/hwMXHw0lPGOEoi12bzwRrzYppV8rGV1XVwvYaPzrexjS9u8/F4SLeIcT6iXBceupkKsDxA4/QjZfHoxmK/TwXYRAt4ZmQvwOEtZd450QKoC20s5zMFOK9foOUpBMgJbP41pU2AA12+1pvVAvyx8JO5/20Bxjs8fT+ZEGB4lcNEuyGBzCJp7FV7Al8G2Sp9PAgku4bOZlKK/+3ZnEMnIJV7+aSFEyg5AY6ERWCzgarRVECg9OdOi6lsAkpPeuTrIgIXfUWhnioC9W3Wdua1BE7fLol2aiNQZur5Qzkl2SFeGthD9YfoRq29BJY4f7To6CMQ8WZ3kvsogamJ1+v4hkJMDQl4262FeG0cEnnQXojca3dVEg8hOl5NuuzcJsQpSfhcPoS4ulNT/EMAlS0/Lu4JpHby3xV+RUKERxzJUFEWvh05n10jRGWX5bYzrULINnKeyv8nRL/jSW/diBCK/pQgwkoEVoB62psuwsvi9uXTchGKfyrc9VumCA1BF4d8FSI8eni1xbFIBD//vJDUchGmO19eOlInwtrV7JbvRkRIp/OeH/9DBAepQ1rYjAiLpgYee1+K4OQhg4rSoflCvbkNidzPpVF6OxLsrzY8XeVIoqjsXPshyqRlk8JCyluNXy0ImCQCm79tukHZ5O/GKyRIMBvfxefJScxP7ZKRShK6A0ezCBUJ2uHsv18pI+E8Hhh9to5EfQ3qBT0kYizXq0N7Sdz2P6Bb+ieJNu7jNn8rMeJ/7xk8SXmF9n0L10aMzfeX5BrQxfC2G5h5QYgxYK89erlAjOByq1/HisRosdL6b9eKMTm8AG2PGCfCb6yq7qN+NkuDZyh16VF9XaNilG/5cnL1mBi0vLrpd5QXVh0P7pkV41zPw7208BSUun5kDpSlgKHwrg2pSEHfL2ah7ZoUmCTqGHu1KSDGNCSxVQLWM5/mtgMSjNYP7qsUSRB8xufeMpUEE/brehtqJEjd4dwsvymB48Wm2XZKdc2TMZFGgqwG2wRyToJ9uWZRfdZSiOeUoTsdpcg0cmG8/ZsU8uTER5FbpWi6M/XNHOX6PXrna/5SOFYfZ/yFLoU6zXT1fspJ1zFaOuWaheeu2Soppp+7V41T6n8U5teWSzH7RdOwpk6K9uQW+vZ+KWa4bgVGo1L4HpU5RVD+c7Bond44Fdr46318ZiqU5XN2WapUrKgMNmKtTEP+x/05d9TpYFf9kjVQL4PVYknpTa0MkwzL9Lv9MkiWHClQDshwyW7xHX9chtZ5zQanVzIk3B8yX5udAfP8Ce2DigxEuPu+ZNdngLNo4tBKabhtd2qMNgMdFY32rygZ/UWf+Qxk4P9YjCjF</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1120">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwXtQ0wUAB3CYJcTQjVE3N1iT14SwmnihsJDv97cZDCjSEPgj9JAj9aQiyS5fgbZmXa3c0cJLI3kpYMg4rgjSAbHJ6xhy6xDNzgeXJBTLVerFpD4f94U6Tg41wx81ly6RyvTavhgWb+1EsqocYtFd7AlXUHf1HwxNFXDHXCW/CvxayLk3gDNdIoxIq9mS54Kv4hvh+OYM+HMf5f0jQUy9/Dp3NVQKj4lDoAgNoS+sjbEd4zj55ydYnm9BQZ8FVf0WxCUnsfAph1AWJEGiZRKfbrpJVfIxzPc+og/c+BxrV7Zx0W3lhE3GFs3jMG25hfMvybFnkxzbmuW4dXQarR1y7JtJ57BVAXG1goaIETqKvoS/+QWh714kxVF2oSGzkHULdn7c/AdWiAShLMuLB7+oWe/xon3SC2ge8sqKv/jtD9EMG4vhaeFFFs42cnvxfUjWN8GpO8GGD/bDvV0mGEd7hIVqPz4rjWfThWbslCYgtfEh0i++wl8lf3NwuAWjY5+zQ/kfrjta4VQkwvceeMOViPHBRCivBVCrWU3//tXsnQrkzegBdnummBL1DNtPiXit6hzKF5cJv617FqJXf+ZQ7RJKIrUsHgjRWyvsUEsrWDNmh8ijJT0mmgc7wNQA/dA7AYZ3G8RCzGgSIe1EcJ6ZB55cixumIDqMo3w556JQt7SECW8H0/pTCaVLSqk+tJ7mMDFF+np6Qlz0/ZhCmyIVM/6dnDXq0H4ulI4aHQ6d1aG+P5RHN5yHtnE3I9YphPkROxNsz2Px1DAXXGkcD3egKn6Sy8s3ILbbgVJBwn0HJcy8nY63ZnuhLjlGyxP9yJb3846aiO4O49W9M2w6MIAss57x5U6k2Q1M63aisseJSysbBHN/OA1LN7I8w4XTkgwcPDIE/UeZ9CmNKFIZWRSZjTfPZiODOXhwQkFZfhUnasOFNWIl86Fkiuwwg40R/PD4Yb72fQQLvrhDf2Mu3LdzsW3VJfTEDdAa+x0NcV2s8Z+kao2KrbVdLDG9T9e/ZdxxZjN3GTwwXclDZ+cWjPxu5uX0VdTYxjieNAe3TcvkvXNY5tQK03d3M1XzBjVxNmaJJjh9fR5tkV48XbCWqq1e/A8vLWt2</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="71" id="sample=1 period=1 cycle=3 experiment=6" defaultArrayLength="185">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="322.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="19885.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.131716666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="6"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="512.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="512.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="28.010726928711" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1888">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzWs0lAkAxnHXLtqOYkuxREU3QlMdyuUZVLRtRw1tNWHMBTPMzPsOMmPVDLpMW+5UQ5lpSdtFUrqqMSpWJZeyW5RQSpIolRzRvp9+5/nwP0/LBM87yuogvC+/9NnNOBh7LswmHb2Z+HhWuMENTDD69C20WiZaVvkV59JD0BjtnkLbG4qgqZd6kmpCsYPvVOE9jwVS2H6E5cvCbnbZ7MFQFqSskstPC8NxLGl8u6EBGx6ftubzQ9kIu9pGWLPZuPhv4M19HDZqV8q/jKnZOF6alPhEw8bniBNxGzvZMNlwqdpZj4PUiermEsqX/sdHabYcnJhnPyoM46A3Oz+zsJODFZM7c630uVh+bhFzMpsLqwK/vLZkLq4THi3aFC5cb39PPdrFRcNgKfm3moeA8OQbJhoekkoMw6VVPPjo+HlNr3hwVY++bjeMQLZtSeN3RQTu+TSsjumIgILr+zCYHglm/vLmk4WRKG6w2DZC2bqaf4qhjkTRy9CVlzoicb83YwlPEQXz4pOVjKIojBnPyK6n87H3MlPtHsKHaWL0FdtwPvZlcUa89vDRY3PMxayYj5/sopdntfOB3UZdV1/wsbgssnVGBx++yojUO5Qzvhxonq8vgLiOHiAwEgBnHi+smSvA8LhFv4lagO2NpwXefwmgs7hZ2O0XjQsZ+dcq2NFgTEikjSZT23VbP4kYDFa+NtT6xuBu98rvCX5CPK0bOaVcI8TIImGupUaIW2PjnDlGIuDPvvA7NiIwVUdqf/MSQe3XluHOE2HZcP28wBQRen7fevZRoQihlVPp72pEeJkUeG6Tvhgn6qxHbIzF0FvcUtqqEENl1CYr1Yjhv7/yw3udGAs6pm+p0SNAu37KMdCcwFNF4rMSWwKsK0erMZfANE4srYJS9aLX4bwLgW67M1eiNhPIG9Q9LKAsOtBUIWdTncfzSlsJAdHOFXLjbAKP1XTHynICwcYfLjvrCEQfCJi1iVJVO2X//NuUh7b1iroIDBVZZs8cIPC2++tskT6JJXQaV2tG4v3GPNf1tiRoi7nwdCaR62ZfLXQh8W39lukBNBLKKUMMFWV+D2NfiC+Jt0070meySBwOyV3IVZDIqjK7kks5sHbI534mibI3ni2Hs0gIy3zD+ig/RNt78TQkppH0pDRKtvJ7cnU59Xe3d83lRhLa+l+mjlNWO3tlnesgYT8m/cYdIOF9/GvYq3ESD3KC/Ff+oPoAg/lqygWhQj/CVILRd8L2/WYSEHM/W+fQJRCU6Xk4BEpwcDhzcJAlQaNl0HA6W4JpTn/UHbkgQcGCfrHRgARkRl9KPqWDgdLRc0gCpxOOzDLTWHgHPzg2bheL/WkdvAJWLMyTFesWSeLwxGqV9tWFOIwGRcidquJgkPbDf19HHGp0t4jqzjgE8jY7eb+Mw4//nCW1m+Oxbon2cZcwHv8MBIzPIOLR3JSv+qSNx5f2KYaRVfEo0lm0TdTFI+2ei63e43iEfbGSh0h2QuTetoF9cScS8NG8hLK0MC1co5+AQ1U/Ky1NE/DQ76DdLLME0BzpqklzEqA7X38j3U6KZ0sb11x1lcK4xoB2iiHFOruZvWOUwW/euvuwpHB7YBK0i7J/y6QiNSVty3vNKFuKV7tMmfeypdgq8sj4VSNFd1vZJ1m5FGuu7q6to7R+W/8oqlqKKY/erBLcliJx8R3x2S4p0o9ud1DOkWH68yh7vRUypDY8kWklMjQpD0Q+yZDhxVIbS7dMGRzdh5rMy2WIXRpY4aNOREZ/qcsSg10wZvS86IzdjXeHrO8a7pHD0HLjNQalV69q0mlKqU1OCnLlEMtL6CSld++yVv9iOdo+cnMmVshxemtTTPwyBUyGjqliVilgbrN2gudmBf4Hq/+m/A==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="960">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwQtMDHAAB2AVV3d6UlvnRmG62vKKhDK/3/+i8zoib2Ju5kbklVdskTuPKcl55DHl0vNW0mOo5JW888ijpqZIie64ZLY0vm+U5iTis6txytvKaY/8meypxceWAvgNDlRV9ybR+WIrXzTG8bxYx5ifUznTd6bQZ9mzsNie8WN2C2uyA6wnEtEmElQLImtY3NIXfzUhXBsowZLGJyhafFgkp0vR6z6Xta5HkTa7Pw5l1CHibhJu2LfR+4Ra2B17C/c+RrHhsQfj7oRQPbkJN81+9AwwIsbmya6Fa6j+08KYX7t43CBHdKoc12++pnbFOQyUKngttR2bje3IcVMweZuCC/cp0HbvKyrVg1Hfc5UVo32YY7iErGYf7nS8jNbnLvQfoeGhzkx0fBtBLwclh81RwpSpxBnP+czWtzGy0J+NgwLwoDIX3pOjaBMb+Co2H3ma00yJM0NisqMpVCvmZzyjtnk/Y+UH6JR+gOEZ9ix4mESljwN1+woxb4ibkK2/Qu9FB9ma9oHd61ayw0VPQ00RrEOD2Hu2QWV2MjC0vZKS/A42yw2YtFjC7+mrmaNyFGeXj8ePghJGFB8UVSUliKxyZPe/8XBeEoyIn6UotwWjSzaHvhYnTgqQcvqnMpQtEGKKTso+26Xc5idjxd6JtFyQ0dEko/sfHTuHZzIorRzj8kNZHxKGgNQwTgjpRFdKHjfKw/ly2kBau8N5q+c+at+cFtkDIvjR7MXUEi/mzopniiaeKtdHaFo7A/3wFCPLxvGubBCf1jyHS6uOtz1q8WyXgllTLQx0qUN2sJXDTVE89j4KatMlGhuimPW5DhZXrTCW6mlnPS4s0UqR5yYR11t82SB7Bz/3YXy45T3C9tRj0++laJS5ia7EZaiPbYIYq+O3LxvpkVhK86pT4og+mC+LSkVguA0nE2xortgKXXQc7iSkMVezA/8Bc1w5+Q==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="72" id="sample=1 period=1 cycle=3 experiment=7" defaultArrayLength="220">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="259.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="274.016408683336" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="24361.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.1334" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="7"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="537.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="537.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="29.573804855347" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2232">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzns01AkDxvHRrNzK3alUGpJt16ZBeQvxuEQn1sotm3WZGTOMmPnNjFymVTOKZW25nVr3y9goKUvK2mKMWKndXLLa3tSQFFE6pPCy3t9fnz+ec57z5V2k3wtRBEBynvVkq2ogFqaDPlk7h0DX/3S/tTwEf3I+uDjFhWHK69Jmj7QwnOp8tiROD8OLENoAtysMQ5rWms7hEVBbq+p9mbTTf9apI5yBFe2A+61lDMRzmyWUNUwYcLNC/jJlopRhO3DUjAmZLyW4J5SJqeZUtmcYExH/aY6hMpm4ltbyeSPpdH7C2ussJnqpgXcazjChqJQ/HShnwtCm6k7ICBP06TaTJVJzv3JdDwoL7Jvnv6XSWKDFux11I1V5zBRphrOw/peaTcZ3WVCYE3o5IywcuCDbrqREwtZPaV8qjYT9Od3ZUdKMc10q1mWROHh9MMZiOxufFwdQBsfYKJmVOhVSOdBTGnobfMaB9NfueXVzDkKM5qm6Ug7KUmoaLSo5cFpoaeMoOaBP2O0xHuVgKEraZ7AtCl4HxDuWTaNQNLQvy4QZBZ0s0ZvSsii0ei8Pr5Duyt2isv5ZFDo9uanLz6NQl7nwbDwsGpPRTx6nV0Wjz2rR0WsNF2FBVHqxCxeF+hr9+a5cDB80rm96zsUe/SNcdSUXmndcMi+tcDHmnWm+QRYDvZpVTsHzGNzRaGprdj8OT3XHCh/mcSh06xzHR44jcXXZWOQWi/NxRqF3WbHQU7uYTumIRfmDrJXV4Vh4T31tIXePw2oQEW3IjAOjJq9A0hGH6wWTBVepPMhsbbMOmPBQSV1g0C14mNDW2OuWwsP+K/SS0FQevpEG7tY6y8ObiX9ajqnwwf5fufJeOB+FaRm7bkr4+I21M9RIyoc8Vae/tZ2PgcahHS/H+OC8Ln07to1AzAbdvnoagUP+8h9K6AR+tHM3XSYd36JV3QsCS7UzmVM+BHJLbr+1+IYAe7GaIvQjEOiwNPqQQeBoTzg1k0nAs0/WMMUjMFnTWPQml4C/loqhRx6Bv7JGUEyaueV+6HwlgRcnPzY4yAjYhsp3P7pO4N+SxssDDQQ2efwwFNRIwFF1zaRmO4G6VyHWfqSdaUdUXXsJrIbecKKOEBCFdRKsUQK+2t+fcZsh8Oip6T6XDwRu+xisN6QIMG5JzQ9QESBhd4/foLYAE0k/q/vRBJgfnvh9klS36v5cOF2AdXpa6iWkr6ppNc02ArSvsglLWwFc9Fu/jSSdP8ihZUCAbMOJK4SrADYbV8e03ATYvvPjMwbpSvBjiV2EAJfrvzrlKhHgRmuA+ynSsz/dGxok/SVR4vh3DvkbNPJ8b64A0ZQrlHLSTd66Dy3yBHjt9J2SUyHAz2lHhxsqBYjdrLG2p14AHTa76J2C7Mr++oHxKtlTGRN4lfRwf9s+ob4QGu+sXLzMhPhybfWFQlLlS5Wti1ZCVM3HiDNshBiONrWo9hVCc7lldvG0ECmZnje1pULUP7nleTpHiKTXmksauUJs/22JvlAuxIhTmiCxQYjNrtbH8xVCnOg8edV4RgjVVWdJOqklc3Ave04Ihx3/7dioJ8Llwbl+AwMRjKcNH2mYiWDX1l1kZyPCl9GlPhdJu/evi3eMIHdZk8oZ0rwz1+r1GSIIInd+4S0RQWdecSwqT4Ta0bNhVaSFsmEPUaUInrwKh/dyEV74rb/k0ieCyY4WpYz0d3f1PrN+ETaMqvnGzIqQvV9UqCDtf9x7hEmJx1SG/GmGTjwszLtvB/vE45jzrZ4f+fGg1/4pycmOR4Vb4rxb7wncGtqsa5+agAfBiu9z6xPwqcI/9VZjAk6bmV9qf5iAf0+xikx2J8L5rL8ag5S/+JH/mU0iJs/tpw/6JaKl0bI4uyoR7Pd10pyGRFTOvGCXaydB7hDrei0iCXGxBg1bWUkIDiyUpzUk4Vfb7qY50qJ5n4+27Ung104Xn1Ak4Qanx/UUIxn1X7k5/sNPRmJ6I40nSEbHDetDZjnJ6HLLf/m6PBk3F4wOpL9Phr3hHOs8TYzq5Lg8kakYhZuMUjSsxOgZszfU2CPG1Y2H9ctcxbCcPvzuLWmwVUEXjS/Gw2sX7tdLxLhy17c4oVwM2baePxYqxRh7Z951RCZG33SFUNoohtqS19/fdYhRl/KqVklKXGwb7hoQg9fU/mHXmBiYwbo+m5P4VOc4+KZIghV5iviQTIK+8cgK41oJ9sq31JeZSfF/fOogTw==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1144">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwX1Q03UcB/Axxk0E+4FBPGhOyfGgxdoASQT8vL8/iJOYx6GkdMggyZumd56bjR54ZqdwcJpTsyEPWTLgJ4hCJ0exLcKDvGrDQx52k8ejSxPjD0ooe3i9LqtNGPEzkHjbP3Au7IesOQBnFpV8jeIpfTskZj9OHsCD7g/ItLmExpd2Q3Ikln/zZw/EOT2Qp34FMavfU57faVh8X4QkPIil2AcpODsVa4xb+Ye6KkqdrYJsZYh6V4eoh36gsUopzcxFoSU9h/nX3cCvPjXEvb+WzgkNcB1qY2FSDp1rOJyJHKdpcSx/3NOfDt77lAYd/rBcXI9Humpc15ooLGGKWo41IF2jIdVSAG0vfgm9K3NUeCoYv6tCmNW5QKm+9aSfn0Lo0Q3IaEmBj6SR1gd2o9TYROeWm+m9IB2ajoeRcCAD/7X+QVn6CcTX7YV22oH7HhF0/d0LsBdYaCgrEjO/3Ga5p5Iw3R9Fels7ErPKUPCdnN0dLcNV+at4uvE1Gm+vZWY5j8+LOujmjjoMNE7ShyYxPt4ejfziaOwuj8bjx1fQuWRjyyUKKi9TUO+IAgVTnrgR2EWTHW8z2SYJkvdL2NIxOdvTaoZIcwhTMiUMWiXMFUoczPRCWraR7lYb8e8XXikTTi/wf21hhf0qnBi+TfZ7Kny20g/yi0FLn4jtfLmbnm3qJleQASG8FLPv9KAtt4dmD0exviopru15izm+jqWx5DkSvOKwIVPMREIcZqKqEWkQ4JMaD+WlO9R/+Q4ZHsTj7KI3qPQNLJgzWfGsH7PbdtKYSovgdQnQFiagWOqLwFu+cFzZhVVhF0aSE8lc2QXT325W1bYO7vlEWLNegKIkm3kOJ1F7vpW+XMthY5+VBHCwdnE4umCjk4schEc2qq2xk6qW6MlPhC3LrTibMoDSeh0yrl5AQHoDCz0SArUoFM8Oq9Exp6ZJk4M8LzlIP1iOophMahJV4quJEdqm20cXXaOk44y4f17K7+hoRpzwDVxp0eyj13MwcSIHTfocNLoCmajiNNuaV8G8c93k1ORSyENvJut0U8lvbjp/Sw5HYjie68JRf20ABe5wNH+Shz85C/aKNbSPj8BzfQTmazRYHc1Hz8kVGrYU0c22PnqSloT/AR8hbqI=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="73" id="sample=1 period=1 cycle=3 experiment=8" defaultArrayLength="145">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="108.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.006388337832" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="15100.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.135083333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="8"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="562.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="562.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="31.136831283569" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1516">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwN0n841AcAx3GeTE0Umlpa4tolFSdJKvIhKpulxCMZznE5rrv7fr937NxxHf16WtfaCY1yx1Uq+RHybKxyeAzNj06K5ckxV09pnopZrVb2/ev1PO+/394Rk1f8A/fBrNg7zeOTKLA0r/psAmLRkG21eeexeCwt/IXrv5INm3Pvhqfj2bCs+/IvZgIbilue+8c0bEy8K/Hq1iRiC3lq9qU5BysyGw0fXDh4EGOUMuM5WKSoNZxO4uCE7Zqhbi0Hk7Wrtu3UcxCzVh0UO8oBoU/fmG6WhEyjR4ibcxLumPHa55sno9NL4Xs/Jxkn/XpZy3XJ4KwIe+20koui0PyYJi0X+rtzh1ilXPyUPzXTNM5FHkOQFmDiYvDnAiuv7INw+ONS/HvlQWwfsGau06bgUdLfdwdGUhDQVrqMoeThjLaiYEbHg3jqh14PPQ++N2qao9t4sKuIWXjNORVu6y/NhsalQuYzVex/NBUpPqOH/hlJxTZNmFv3aCr8XSzmhivToC4iIhm6NPS51GMkmI+GbhHnRggfHzty26kcPmwTjB5PdHwUVCiImtt8HP+8UcMc44PxSM7NtRCg/NAau2+UAiz/4t7WRCchXL2ttyoYQoTP2W96lizEWd1Mv2O7EFbNTUd8zEXAlCH7nVKEtLWBkWtzRZi6f3nIokyE6uDd1jq9CJ1XFLcdW0Tor3vINI2LMHFt+PBxcwJxOcP9l50JpJCPLphoW1qeyxguBKI9mIP1IHDaM/F+FIeAY5NxwQMhAZW3xNWkJlB6mF/CyiMQLNhUZyojMDayrdlGT+DDyVaE0hoOcR/fMBAws6jSH3AmMXd2hCinNVhmTARuILGxcESbBBLnO/1sxEEkJDtlewqVJExx8zSyMyT04V3XtWoSqovW+ie0at/K+MYyEu+fvllys5qEgzJxXkENCbvQqCMnm0l0xx25ymolYcXy64rtI+HV4lAuuEfCeZ//b01GEhlOAaHF9hTU+Yt2vKUdVn14I2BQcHQ+s5mRSOGtKmNit5JCVfunHc9p7TXV0yE5FIibk+Xr1BQW1D2oD9RRmLHruRNcS6Hjx6u8wVEKp1MafrV+TaFu/qUBcprC4n/tHeYwxNh1Xe65i/bF9s/Wj+4RQ96jl1axxfh6MLzS0yDGqSrfYoJ23neNKqsxMdyDxOERtCIG73uVuQSiu76rwvZK4FnCutknlGD1jv9YF0gJ3r6atC/NkdA/yLLIegmyawsenmumu2B76wvakIRZy2V/SjD/9rnAaFrLOh9v91cSuB9V8HZMSdBTQjyN2psOJxuLmoUR6ehd+vjj78J0GM0jO+I3ZCDar2udjC3FLVWLYjZPCv+cNrKiRAr3hqIwZo0Uyq8uPsmulYIrL9VG9koRsCDYb0iUiUqL1TpfTSYWLznxzKDNRLayL2jcVobDAcPfsrUyHBg39kSVybHpaEf7Up0c9swBq55pOWxfbnE4OycLsa795+sXZoHdVipPXZmFVmpv58P8LPwPgoUOKg==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="764">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwXssFHAAB/BEY3TzOGGe15z3Y1x5nNV8vz9bRyFNxZalzFaz3ZqZdo1Um0mPSSplu4i7TQ33B93ZmC3czJL1IENMXjXKtJ1XMvp8FsN6Er2dN5GzOsS2teeiLm0MBYbrGLFWMqtqK9Hy+xZ1ad3io2hira6DsYfMLC6UM9hqANFTDkkrszbw/6vitdBAYXKwp1Jjj7LAh+hfEtzTjULzvlCkNVbBvtoJXVon8SLYFaZVVzbNuwmvjTnkvnaHpN0diF2E7OQPGBK2eV7ixV4XL46veDNlJ4o5IXIRpPCD5/cGlJ5JZsvYH3quy8RwjJz9NQFwTm3Gzawg0n0HOo8QJmh3sdw2Ixx9wjCwv5bSxw9o+rqP2oBwNt5oxZYsgs0Td2ictGLnhwhE3o6EoS+S4+V6nqrQ02XammN2WaK+aoqpw1FYNg4KvY+Wx4YUuOzYgQOzubxy4SgOltlyTvJIXPWtZ6bZlic27uKwXiJe1hsR2mrE0yI7rq8Zkd5eCfNeCe+PtDC/tpMxX+LRq81g0M4uxVQb5f1Klnt0oddNR5uMbmRWFtCS7Ssa1BKamC50muOoi1OzbK5ExP9K5KtY4F8ccG/kHQZ7nJkxI5ASXUNLfBICvKX8qf/E6UtmyJumqVpb4lmLlG+2n9A/1MBiRxXUz1TQZHtQOTHK3GQZFQvn6BY1hr7TBaJGUcFx9QTeHplEY2apKJQGEKOB9NPm0a8hD+Er8yiKyOfniwvYNCyg+ls4/wNPc/SO</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="74" id="sample=1 period=1 cycle=3 experiment=9" defaultArrayLength="232">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="346.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.079547431863" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="24500.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.136766666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="9"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="587.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="587.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="32.699813842773" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="2340">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzHs4lIkCx3GiJEdm01lly12l7YSUCNsvKTZFuR3ZjDEYxpjLO+9MmJHLbOksCW25LOs2LtXWRuhgK7fU6kblsqdWxlBKuZREIef96/PH93m+zDInjXaN/dBsYCr3NPvA6vrM2NlGf3j6dFnWqwdgf/nuv/bu/AFvfe9E5e4KhEDt47tvTtAxWhJXMneLjqfLHhpcaKPjUNDg7yULQZBrfxHrmjJgfFlnNsOZAavuSyde0xn4tiAlqK0gGJt8qx9pLmIiJa4oa4UJE7+vkT+porwgdGe0BDKRn5qbo0dn4vN/p//oDWbi+XipXXEIExE5dr7GoUycepleo/yRCdvusqaBX5mwaDIrLy9hoiutc5lZExO/DgRU+yiYeHX3fbhEJQTfddbH6xmFYOpIvgqP0v+l33qnohDE6xxnTaqEQtlZl3A1KRSjZh7mgyZheGzr3fi/wTDkOfgbegyFgRWLw1+rs5AZm11rkcQCp0D/dTPlmltmGirFLAR4RNfWNVFa8B6F97PwvV+0+ZxxOPQHP9etloXD/EV/UnpBOG77rvN6R7n0Q3fQt4kRcC1LrpgviQDd8HVbvDwC6/bzKwt2sbFxPtlDJZANDtuq6mfK88XWRp7BbKhbl1cNydiQ6y4rDjrOhqe5cryN8rd/llbNF1D2q6latbAx48SeVO9n48M5Zq+U0kV10M5tgI3w/OixXwoj0c/90mNbEom8u9cvlLpwcPPpFSGLyUG108U/7GUcbNe6eOp8MwcTAXyzEQUHPV3OazWVHEj3VpdLd0ZB3OMjGN8dhTUG4uqGkCioal0Od02IwnzV9JFAdS68le3zHBcuEo/q/qi9h4vTrp1c0yIuTL5Ejrqr85BqtGHKy4AH16jWDSPOPKQPuW3qDuXBa+jg0DcyHrC7t/7VcR7iPt/vOryYjwTOwyd0Qz4c+jZ09FGm3pN9mUzk4yd+WfmbIj4epM7UbGviQyHrdx6mdLga72ik4GPrUlpniZEAJznZC8OU8+PZeV8bC2B2+v7BSBMBJpk2JcutBdgvNxfmeQhwedud/D8pSV6NHpcpQLfB4+v3eAJoB0rJsSoB9vxLRWdTkwB/mpd8H9EsgJ/fjLltpwA6ajr7PCkLu+eP9vUL8Nu8fsIqhQA9dpUFoaoEPuWlhC2nEXhqYb/GkfLOoO/R/3xFIGrE29HLiIBFXJojy5KAbf3psL1WBEw6rM4/2EKga5+e0NmGgOutlaSE8mzYxUN0EHDgn/KJdCbQFzgnPUup4Uh6h+8m8DH7rpqTJ4H7czknixkERg2mxgoTCZQ1uH11KYNAaeSZwiHK2kzd+MRMAse31b68RpmkFfLsWhGBIfcKyV/FBA6c2TwUf4XA2GzTOjml1G/arrmSQOV22dv2ZgILKS23z7cQ6De9Z7ZygUDATlp3wwoh7NfnLzRAiDZXnkbOLiEWJ9d4vWYIoSs/vXpEIIRSbpr0KkEIhVpNj2+iEJbhTNslSUL0PYvoWZUpxIi6jcu5KiGygzl9MR1C5Dyo89s6LsTsWu8tfpNCNEavfuOgQ6L03/Z5ZiYkTLc8Gb19kMSnLKe00CASLwZVJBIGiT0T7hXXKd0q5miyBBJj99ppPTISjOxjEpszJNyJsymXKfVuuG2ebSSh3/Ti+Q+dJOwqF1kYPCKRuynrdYGCxOyS/MVTlE9LNXTcBkgkp7zQFypJTBdWmdVT3qqTJ09OkAg75hQT+o7EwMhWLcZ7Emn2ZG4zpULVbkf8IhFibJ+95+qIILB+cyCVJsIS20MvGyxFGL5kc6TCSwReU+/SRYQIl9sO+f3UKIJDpnNOfKsID2stdX7uEOFJerTb+GMR1NpL0+sVIvTR/FdoDoiwPfDx4QeUS/R7b5gqRejamHopnLKooTDlOeV6xWA63ovwrGCV3loVMbQnrVfKlotxI23F4DDEyL3W+PdNLzH2belpUGeKIcw2yTpWKMboR+ohF0NayjBPuyrGAe6ug0urxVg9nBEQQjn96JLlzkYxih7p9QVRuphsOdncSfW3ocZ/PxfDhtY77Ngvhpbn59J0hRhPjXgZXVeO4smJSivHq0fxiT4QeZ+S35a+65xhNO6678jppdTLsI2jKaKhbPJ7YTwRjSztVWtal8dgkcZiPWOdGARbTlr0ZsaAdWB9hkdVDGoGx8W/UA4lO97ZkBGLtdly2c3CWPwj4dSCZ1EsKj60fKeyWYLWYW3Fc2cJJtJcufaJEnj6K09sK5RAfb6ltYhyJX1rkm6RBFPBvoYb1aSwG0qs2U6T4txH78hMyoUZFik1kmJHh7/7ss1xmNWsuTY6Fgeu4aqE41vj8X9YkFrK</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="1200">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwN0Y1T03UcB/CBPOTx4GIgjNU5nDCzgR3w40GNfd5fuLEOx0BSQylpjTszkMcFl9B1DCgRjhBigiyRrJSHyYb5dCEj2TE7POR4Kk895BLB0IiSW6hH/guvV6f2tFytElB68aR8buEM/bclm03PhJGfsiW+V++G/Eo3/HD3H7l9voiSftNRjGlZvvFvOT58eoVtyCpE8agTBZ5xprWqcSQekKAxexy/Xy0ny6IOR77UU9oJPb3Dq6CCKyfjDx2bo9bkSzid6kpCT3fwOuLYFH+ELgfXUMQRPQtY2k1N82KcazGyw35lWHSup8aDr+KzT5VsyXicUm420LmQRpI/qEauewUmkg2kSTFQXngz7lcKcXBeDqFNhiyHkCTPZqF6MUu8acLwxUB0eonY7bwwcL4iGtM1oPV5D2r3OLExZS4m70UgpEUM679iZPr/hGVfKZMGFlJVdjtNBBRRK7cJeZPXIXvp4zLjoPTKFVpKksJmTEXz1+FMw6lYdPkujNjfwF/+q+QQrlKouZblNPJY5sU9qPhWwQpEMloQd6NgYyj0klDKstTgeUkoYuqdMV3vzDq+CEPZLybivalATYIivr24h3S2tyB1ZKDP30ypB97Hu0NmOimw0Ik7RegThaNkrTHeI7MVEU2PcH59FY3nt6Jn2EJHk9zg7fMnZgN7qWJvFdJeHk7Z3WBJcEdtuTu29EvY66M+zPbNJL7jcTAnarBjJ0f25SQ4n9UgqIOjRfYKmmeiKFIRDaetMZQRcZk+KpOy0qBYeE12Y4PAA5q2FOx7dgsvtNuQtt0TpkKw61ZPnOJ+pqDDXthc8jZu9PeRtWwCXrE50LBf4Z1zjVYuxUF1NQ4icx3SF+oQ8KgfhkgrbYoi3Igmcom9gPmoszBq+OC0fOyvtlLwx3zw2/nwc+VYv2iADOYBuvMeA7Yex4pCwPT5g3SqY5Duzz3Faxky9vmOZSq3CjA00ADTGhspBwWITraRrs5Gez/whbpfQT/6JOJBeiK+L7bTrWo7PR5Rwmhcj+ExO03NnUeXTIN2FwNG15Ri1bUUO7f7Y11XL7TeD7FPe5MoWU2H1GpaDelkTo93Ue5MDrS6MWpOEIM62xDe1Ya7276Cw72J6bolqG/MwCfmYAxdqIbJ1YOxiRC2u/AeWdZN0/7IzbiW9AR+RzMhua0F98dDWniyQP8D/syAJg==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="75" id="sample=1 period=1 cycle=3 experiment=10" defaultArrayLength="145">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="214.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.082648552041" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="15416.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.13845" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="10"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="612.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="612.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="34.262756347656" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1512">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXs0VAkAB2BCpSWtWr22GI/WKY+iFu1p+2VFKcmjEhnjYjyGca97DaMUjdKprTyWKMwcGi3ZvMqRlZqJTrY6O+VRwpqw7WJ2T0tKTbL3++fTfldU89HdH0xBALMgyx9xZTqDXEUgPF1bN6caHEDntYWu4dtDkJ/vuWiwLQSjAfVeLqe4yG5XD+R3cKEojLEONAjDIducoLVWPNgZvrGpYK9VaeVX3Xn4+vkSeo7Lw7K29PeFZeFobHZ7N61L4HBz4/3geQT4gnMOmlACyzfE5pZHEEhTbb31uJTASJu2q0NK4BKj8glUEyjacnyd5SsCwb7XZ+S6Efho07PmgEUELn3+/GObTiReJnS1bteNxFjlzmGZNAqyqz7VypEohAT9cG7XaBR+twtYpK/PR7N5b/oX6XzwpvofL8vkwyrW7Iqtgo+0IzcdTgzxIdOsZtI9oiEsXsX5lohG6nXXnrdl0YgsNY7mD0fDseF2sX5GDLzkp6/NlsdAp+Kst2tWLDgRKYtm/4iFY41ukIQbB4tfw7iQxGEyxLIsWBqHxsSTk7XbBTgXejbrqYcAZ2JD3NsjBahuGn9xrFQAe61m3KRCAMVscH/LHQHiRUqbKrUARAw1KR5mz/W1z7CMh8lKB9LFIx7/Lg3e1t0eD0l56uGqoXioojTzTuonwHDH8iE/jwQUjon9xJkJEK23ebFGkYBVTT4jtzlCuFzsP54qESJnzLl1Y5kQnY23mkbbhei2MLW+2SFEgV+4i5FBIryZh2JjCxKSVcY/p7D/cqzE+oETie9Hg6UEQWLrSr5nOfsN/xdRKiGJ4kG3l9kXSLhdMJmwziNx2uh9Zl8tiZ82TR+0qyMhS7Pm99STkH/YeF/nHomFEyWzoexPhK7NLioSBYZejz4OkThvXuVnryYxcKph2/Qcid+WftiyfgkFT8V9sa8FhQznyO6djhRWOJhM79lIgStfUOvpTIHzmjPhCwo75YXZ63gUvL9xZ5wzKMRUXK2l2WXc0AqvHApZTmt31bDfyRPl5OdSyM42uNnH3j5yaM8mNYXw3UFK7WcK1X16DWdMktAiTTaatzQJWmXL/P+QhIxes/K6uiTwJMJet6kkvDG4PBvN3seZyn1uSqNpQHB9oSWN+P6RKgf22cubu0330fh0sGowjUdjIv1unG84jZm/Zdq9J2jUfNg9JmPPvBJh5ptHw0Uj26VW0ajsKeQceUrDbCqvtUVNg7NPs7w4jMHZDd377WQMIg0zxvfeZaB49cm+gL2mS5NM3GNAvOPo17PHFlcG1j1joHzXYZ4/xEDSO+fYqmbQSQoSaItk+CTfOX/bPxkS838o28ZkXJQailZsEqEI1bl6O0SYqd72cGi/CPM7HVcfeyaCg9XjykHLFCgD3ybqO6Wgy95gvCEvBfvwpby4PhUleovf/+UoxlyM8LWTTIyizKcXgqRpED149GeY3lEEmc5U3pg6iifKpjPauaNgdJRf5eWfQOhi5y1v/E7if76BF9I=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="768">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwXlIk3EcB+DKzaXl8IwJM7eGosZMJ7wglPt+fq+mmXNGUyQ3GUmEZqUh/hOTZh4M1zYwJpYnSK4ks8LmBY0wRUsQry1EKAnTlByKBUXR8yjT5DgkbyGd+YD6XFkUyMexYe0zquAFPBe3q66SVpFQs0LBP2ros+9AveTz0uCuGqlfX7O33e2Q5CswdymWzeS+p0RbABXbM3jj4BSd2BBgS7OFBqsBlXYDdjwPyLWgZHW9YqhnVbDZQ1HT4cBKeRjJvz2C4lgrXY9Zo43UUfh+R9Kubp2W89tIWbIG6zzgskjJ9lOKxx2TsMhi6WjQOfbU2k18rp+C063YtvXQl30ZRddWo/6lHCYdh1KzAn5PHj4V1FJKczpCnHHEcuKhL+ynrbIEan3uotqmLlT2/yXvdCL+eN5B6DuM5Hol6YYkbMk8SP6wAGxXvKD2rvtwnJzCsnSI8s7oIe01MUvnHpIeClBXakDQogCygkbo7UI4FFF84xsV+cZfUeEHFTbEaXiSlItoXoSYTBGizSJoJV1IbhLB3tyMa1kcxaxzOMW5yZPtpvCUEbIYx8gkuwxBWwVuZ0/Q6vANnL8VgtOhYpRxN7FeJMYFRzxm+FkYRjJQvqmmsU0vqpmf3E5GHd5wDBgyKWFxAB+vTlLKxQgUjU7SwEgEJiYicK8zEt81URhfyKH6aS+b4/7R/JHjrGFfQ7/0Wlro0WI1NInddVrZZkkxZGevUHJgCysJtmJop4x6jHuooztQuXn8B6CK7BM=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="76" id="sample=1 period=1 cycle=3 experiment=11" defaultArrayLength="141">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="174.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="122.082648552041" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="15542.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.140133333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="11"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="637.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="637.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="35.825664520264" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1480">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx3041AcAB/AjKeWdespTXu6ovAylCaFveCpCtGKk6xwnl5z73Zu7816WZlkcPWgNWevppjmkZNHJ+0vlNZWRI2OpKS+rHjS7vz7Pp3PQsuNHtVA4GPTec9x3AlV/lH5ZengCazutDWfkJ/G0nTJ76DsqanzGFsUXqLAaySmMbaGCNC++u0SlYSJbtihtCIedPqVwWYWOvS92rdah0kHLn/r4cwQdqg9CmqTFdFCmzjuzSuhAibr2Nwo66jP37XAjRWCnlsfAHtMIkCixmsOkSORZ2UQeV4nEdf1PJvJiBmR+lk4LcgY0VJcCz44yYBw+W93wmoFNB+5s/2dVFPJvFPeap0Uh18vWoUwp9a+nzgWjUejp7w4zU0TBQ9R00iLtNEYNnpWqFZ8GRRBaRDaJRmGtifrGU9GwpGS8utwQjTq+U6bXSSa0PhuHGKUywapnXmCmM2ElO/1ywygT2tWGTumlZ7A+4N91NV4x8A4YU+SlxYCU1DvSWHQW3ef4ErFXLMynI0L302Ix8l4waJkWi5WekN57aixMKBw7zT1ZCLC3/TQYyQL9zJaGj80sZLGxcfWw8u2yaMPVcXi8he6jkxYHdeqc2n1TNrpsLY087dnwY7t8tU7ChlBW/cJF6QJh0a1ZykZZsN21xko23j00DtzRwMZmhWCp7T0bMT+5YrMuAb15/QQ/UwLnNLPqx80ILI4VNcfZEfitQhoi3UWAdsP62JRSJ7mNU4ADgf52w0O7PQj4Ju/YJFPqmXlPJ4BG4NcnlYNxqQQs3AX+BTkEXCYrXK6UE2h9/HJybSMB1fXqwf1jBAbw+Ob2FQKuL72TZbs4YGzV+0/kwYGJc2RWXQoHZSE999VTOeiqrL375gMHxzPO+VrNcqApMez7Xuk21Ys2bvMckGx0tU7pcNFVaNa3XY8LnzCVV+5kLmpev6oz9+Di9uHksDY5F/77VFcMGrhgLPjHKLq5qJ5b00Pu5eKXqQWpmSoPcgfph3ylGi5ZVcH+PMybhhkdvcODqDRZ61kfD7WZT2JvK3jgPdiWbj3HQ/qUGSn0KB97OnKzxyV8HOssik8u5+PruLyb4XI+JgqNLw718dH9Z1WrzSgfak0aV7sCBcieimu5IRFg6Eq0NKhKgLdEWGWm0iBBG2ePTjwqbjmO9evH41HO+fEycjxaC18c/cyNR9oP5MPVknhosRkBFdpCMPeymn1pQtxJLKtzkwhhVD9+dkLppuCm3UmVQky3zw+ffyTE02uuPkGzQpQImi7Ts0V4HfqMnFksgpnj2y/lSjMuLeepl4hwsENCs5KJ0DGtb3Fdqe1Kifm7JyI8bFk+srZPhKAii/pZXTFym2dp/npi/L7Bn5xiK4bJgrf9c3sxts4YD7jvFIN78Mhzx2IxVlZdtU8wSUDgJPeApUcCVukOLXNHE2GQuMV2eiYRtMhLbbrsJNya+VattzsFlDd/r8kuSMX/Nqb9Ug==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="760">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwWtIE2AYBlCnloqZkVjO9WOiA1NmTmpz1Nr7fKvU0Egzh3OWkpnhpdSwombQ0mitUNcUYc1qrqazixpkNjMpm4GoMbcsqAYWeUmi6G5I5+z5HEM3B67DZ3cnVf9cjS1vhpluQwX5Hw9HrjASc3o+7sy5mcLqSzWGeNaRPUynG/zI6Vxk7zOdVGiZgrWsE08q4jAkEiGc3CQQJ+ETr4Gl6z1U8moH616Yoo6aEdhHG+nE3bfkFEnRbfDSoKaZMmqnaYjrwp8vXFQ9cuHolRk682+eJDkcpvG2kaHtO3nn2sFz/6IEo5XWnv9LS7pFcq20wdGuwWXlehRXH4a8hM/Emhb0H7tNUWYtFsxaGnqeh4kENUIqE2EazsdSWBJEfUZF8eQyJi4wIXokiQ6+6KGzVSaMZtUjK3s5G7/fS6mVhQjO1THPjwAU2TdhZ38gZHFB4M9IMCFJxmSpFCnlUnr6YAVe9+nhvLGZBFEuPIwNAU/uIIOkFdmJMsTdC4Xnai+apuVknx0kpYeocYqQ4a7Ct5htpL0YBtXiM3JlbMfEqhRKkI2QYCAViuA0yhx3wNecRheaa8Exc2EPioR44yX4HOAgsJzDItTjVGRch5z6aKaMPQdjQB10PXuJZxGyllm54mN8JNPuUlJtKYclf32MMrsFtq5ovDylosx3Frq1tR3zoXnk5qpZumoMEZUC2K+paeyklWxH9sG/zkuOLj3MDiH8PhxCZ2ITCvLFWLP/N/0H6HPuyA==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="77" id="sample=1 period=1 cycle=3 experiment=12" defaultArrayLength="178">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="444.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="24807.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.141816666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="12"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="662.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="662.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="37.388542175293" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1808">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyH040wkAB3BD71kv0suVkUrpIluv1HP7MjlP20pyCbVmMztN2377Db9NyVvFyUsop8vL6KmjvJ1QHY+XUsRFyHVdZzonTpfIpete6n5/fZ7ns9ZD5ivkBmJGq4A/syEQk0szStadEoEp7c0IOi1ClJJ73rVFBKtg/5a1PDHu57yreiESo05t7zOWFwSHe5aWfzMk0JSZDGSbStCyIfCOp0iC6pnKAI5EAnUZ62K8VIJ747EMnwEJDi6Zs/mAiRSP64uGp9tKUTTvCWsLLcHmPZHSxgal1M0ukMIu3CPzH5NglB6x8JUzghGlFq4ZtJOhrK+qqTFWhuAkFqMiX4YZcwOm2gdl2LYo75ZFbAh6DK+myYwhmEwjIzEQgq6NOUcUNnIYpJ5l9/PkyG/9b8y66EtkWi/rTHILRW5kwqjv4VAEHdjJ4CeEYkQh/2Nt4VFs+O7k8t1cBaIWrjWp91Dg3+TO4/slChi+nzZ0s1CBirq+5N56BabqL5d1NStQePPnsbPcMAiOHh9q5IXBZt471ru7YdBWF4cv+CUM75vMZOc8joHHMfWpDFZCbJsynSlTYlBg3bk5Tokt1593DdIW6mqiqbtKBH1xjtFtrkJ6R9TyM9NU8Lg1dng4RoUP1GC3Q6wKrVej6z9pUoFlYuW6306NponFIoWPGnmeRfoAiRrbr43stMqg/9vs9FkVapBjttFLGtXgKrzMXnaqMcCp3e3UpcaFE0bmqFEN0dKQOaEDahzEXWb1azXC7IQqHoNA3AQ/i29LYLVtW7LQmYC0rPv0Cdrq8Et/tnAI+Dz2ShFsInDa/YZmAwgIDeZ6Be2qzuGToe4EShzNqitoU+X79zvyCFxKfqWKoV3PLR5bLSawy3PPU/8YAtpcW4vD6QSYJeb2lbTckdqH47Rdj87HxJ8jULRgT2UHbWr+m6TNBQRGl2QN5dDaeNtU1BgIGKqtxEbahmvt8gdlBDCLn1JbQWCWB5U5QWtkfxaj6SIgUSa6tBsJZLex45sXaqCf2tEnstOgsp6yYW7UwOVDN6o4GmzZ2/lXAjRwM/t0pXOsBiniB1FtFRpwL6dKXw5o4LSj1CzhjQZzqa9y40xJ3HAW/WhvR4J/zPzBXg6Jlpx15QoxiSe3n1UXnySxlS8dEWSQ0MX1MTtohfd+2KUwkAiOSLsvLyTRuozVKGgg8eZKxhVOI4nKwOa3nz0iQe3o7J/zmsRPDo632sZJbLGeF7JjgkRNqzd/7h4t6vI43yhUWggS/JKHM7RwnZrISWnQIlA4kxXbrcWZ2+mrZvyqhSnn6ko/73C0jcptnNkR6HuQ2DyFCFw9uviIxC0C1F63Htt9EUjOsjJ1D4rAi4/MJr+xCBzbKQoLzYhEh/fskV5jJNLELrIFA5HQ9UtcAmitqCTp0MdI2KfYVt1gUnByEF15Sxu5rU2ZxaJQstoa/ZsoJDp7bd3kS+HdaAE7XUWBU/shuC6eQqnlptuhqRSie7WjX2dQeL5dVu5eQKHHv2Yfr5JCltEv9xTtjOLf9OO04Srn4YQmCoNckUUPbfDTI+FB83RQtjtayhbpMD+v4HqmjQ7vf9/2sMhHhzrGyN3xfB1KWbf7Pe/ocJad3j/iqAeDH8fe6qSH8+dNAWyeHmrDxXL5Hj2uTeOW8PL1aDy7JryRdmHyit4h2hePxx0iC/RYd2iSJMr1cG0U+/Ea9Bi6o2JU0j4r9P14YX4U1LweMZsXBa/EQ5PK/Cj4rxfU53GPYyFzd6Jw7ATOhJrXdtEuSotOMBhjUJq94nHScAzSHI5L7JfG4n/cUnyq</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="924">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwQksFXAcB3CWMzc9dDlXmNzUM5bf9/+Upo1CQryWhpUpeTk6NvRqc7Qk55pHjnm015pbzuWaWM8VVmF6ZljyXhNtkfp8uJM1bI2zRFWRXF6n04ZPVgoHeTHtJO7LweZ6OnW0V7OrfGU8DbTGb50BMo/bx2xMdni+G7PYqq4l94BxJP3xQ7yWOt1bqcRomAatRgsxz9chG1ExigUWLKuigJ10Ost0P+bTRJEhnJdzwA00wS53Ds/9YzEeMQ/dWl/ovd0gHqcJDU/M0Rw2h/EZBVWJLKAYWsCnQn+8z7SGf/0Whc4qsSndOnLUt2Wh1Q4st2CX7v4qgKtnCH6+2SPH4AyIDtmz1mkl/LNzwAN7R/hlOMKyXIhWcSrb67LktfU7o0HyEj8zBFidUsHITRf8DVGFPH+T962zEVM6amgfdqWxcjE7JCmDRM8Nx1fFEBz4joRQNZSbu0HR5EbZ0itMJGmmikfqEEsNWXKcHQu6UY/HPepwoWgED6ijS82DPp/zwLugFpIFt5DulgdF8VrJzDQGhUWncHAxG/s3sqHvGYss41z0D2sh7oIX2rq1sbztBfkLb2TKukgU/Az5UacRvl8Pso4ekiv7wOaMHjTTbqOopJdi5XnoLk2E4JYVq7yujyXWR6dkjCxzeegy3mHhOUboUR4k2w9pWDmsYLYpqiw5yxSpbo0oTIyBwR0pCQMu0nZNECIn9dlYnRDSvUF4vV7Eoq0KU4yYIdU4BJyaENI+PI0EwSWK97SAgZ8FNOXTaFtSZZxjfexViTbzSp+Be2YoNMYvU/nyLHVwwqiz2QrCL0eY/0QEzEalWC+KxNqPSNI5Ok+m9014Rkl8ep/Eh+zuAt1s4kOJa4MTv/nww3lWZXqNnAqjse6eB62v35EqUWFDZaUsXckbvYYP8R+U4Sv6</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="78" id="sample=1 period=1 cycle=3 experiment=13" defaultArrayLength="132">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="264.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="15084.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.1435" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="13"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="687.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="687.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="38.951393127441" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1372">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyn0wmwcAx3E09dIhor0ybzPsqLrWy/pGVz/DrGon1XSs2QUhiVAkT0JovLW0IzNl6q2bReSMYZOi006RKn3bdV5qTstJ2FzUhnrpaqrdnr8+9737FqitWh4fY6KK/xWY/kyMeYaGWoCJ+Jw+vbgcJrzXiJGBXib09crf6upjoqSCdfXURRaCw4yCJ1kxcGAqx+XfxaKycn56lbStokKhU8eiVPmast2ADeuW5OY9Tmy851DVyyJ9aN+5bsdiw8O+ZLo4jg3R2IOMN6QnuRuhdC0bu0edLy2TWvbVr0brxSHCzMRmr2Mc+LQ/lVmaOAzHB1ZQ9eMxa7iUpyDt8ztuverEwYMDa5utcg4sIhrFnDoO3H9qGR/4g4MjTs+2irZxYf1Rh+si6RXTsKi957mwpMYsxGu4KHsRGWkn50E1pdj54zQPB0T3LPcpE2DkxXlaHcCHWd7QXd00HzaaR70dM3x4d8rDm+WJ6De3MU2qT8RfNIfiL6YTMcCWHRsOSsLGS4Ep1/8sjFN9mnWkP3eNenZQktFqtWmkCErG05DMfMPzyXge9fvEI9LFufWVyfgUBIS9rf5nIAUenWc9n1NSUW8S6a9Vp2Lpqn7MkKMAxga0G5IIAS6L4x6fZgswNGnYoUsRwOzyaj+FEMAj2ivtZZkAUkrmBfevyZZ+84G5SoDPfJ1t/dUCXLk5cSKqn/y3UUPDhwUQChhVO7QC0E0b3ZikSbZ/T4U5CuEWluvr5SPEVrBLsT+EmAnXaA8GCqFv+UP+vVwhXOdnGsR5QozVuPn1lwohHqzNHC0TouhCXUh2mxDS2bt1CU4EasoY0lpvAsruUr88fwLMwwnfqqIJfLjZfmQ9hkBwU9ueS7kEdrJdH/5LmpPD33idR6CMTxl3LSfgc1JnQb1GYN/Yr9WG7QRas3hpXssEuLsWjuavEfg4glE8QxXhtCTwyymaCDf7pLw2SxHOyArCjZxEyCsaz8wnlXU31bp4i/D5p1OGrFwReNpfSi4oRBjTpdp3z4ogvl5/47dVEU7UNKkKqGK49yx33HpXjK2B/uNUQoxoixU9Tp8Yh452rclJs79PN1kYFeNMofl/t5bE0KlN1Xb0NLAHl2ziSade3V+pJpV3cp/QY9KQtB/zPSNpaBgVB8m0aRBVsyu2e6Vjx4TtWGFAOuh014Dg2+modVHMqd6RIOLgi1SKtwTpzHLDJxoJig/ff+OglcCTcX1eRjriSdtlHJuB8fZ51St5Brh31I3CaxkIZ0wOjpJaaQxOLdZnoteX1skIPAelx6FSZ/k5FOqZRLJJzW5n7NaQyvTfn6EqpKDJPkl+RjrXw1vO1kixUalr2NifheGQO2z+Ujb+B/Dg3qk=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="716">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwVtIk3EYB+CYOs3DynRmFxtErpPQhFHRnHzv7z9Niiz9LlYOKxuIYSc1rbww7ITaPAx1WSu1xI0WFUWrhhRkui23ZLK5AjVwikg4l2QHA6mep2t2iKaP/0B6fJCrjZ/mWpJnOJ5/RB/umNkNwR5MLb5Gw8I/zlRRRz3cTzbgc6Pa/p7ky4PksQvQtH6IQpub1VeeOOk878LYISkTzkZTzaVMtBXGUI5cjq8XVrHywWY6OW5gi8JWOtD0iU5bNjCDO5GZVMeg/JZMsk1ZSP9YgmHvAC6K71LHfgle8hKMR0ih6F/GC+ESzUf1kr3gFz3PWwtPhwzSThl+p6wQpVrps8uK3EAd7So7Am/6DhZaUjBFlRb1DVpE1crJ0B2ByrQ5zBekqs8cjUSsMwPVvkgM+q/TglWq9j2NYzaRAm0aIbIO26j8VQg9V+tRORUE/ycaTuNu5BdXsEZpLL677TRx7yaqHKW4ZRpFpzgONe29KNYpSVqqRHZaH1oeZ6JrewJuMxVWj/qxZTiDCQRmNAZV2OYQ4ZqAQ6LcQHP6d/CmgMrOAiNhRvq97RQ/X4QRfRK4cBIc2UYazjHCFeMi3WQ/1hTvI/+5ZwiKPaQ74SG3OQ9vDnrJd99LK308rXsYwXb+lWDj5BipwwESKTVky9Tgba6WLoeLaKsmhJIxCz0IWPDFpKPCbh3lm2ZIldAKzcQp+g+EReKn</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="79" id="sample=1 period=1 cycle=3 experiment=14" defaultArrayLength="138">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="179.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="13445.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.145183333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="14"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="712.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="712.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="40.514221191406" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1440">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxX041AcAB/DOy9OtmnG06dFuXBOVotRKezz3bay3EwuRvMTd/RzhXn/nvIRDNKUpYmrE0caRl1vpmp7Mu5O2vFSrR83LtV6k60mYx5T9Pv989k7NL/+YHYwl09s8z1LfszhN25kVhpIdUk5YVxh6LD+xf009XLPo9uhSBBb2N028p3HRkBzReoPHxUGvDQ/vlHEh2sTmeY9y8WB4mrF8jIvEMdXU0SU81LLVgQPUuxzfFjJseRhmPV4aSE1/znT8nMZH5uuOOE87Pibr5X4fWARa+frJ3jIChI1z8KMnBAqKJsNu6wm4NRXqpo0jcUs1eKVHGYnBeKnSNz0SK8/LzRqox+1FZWdGIrFv3wvBWq4AhUZ+sV2XBLj9Mm8DoYzCPQcv7/sVUbg8r0qlh0bjwejeCNqJaKQ2nTUPo27P1+/opVatDqj7ruIYiIKweo1nDBxXFByiEzFwq5jfNOgRC/8jXcIakzhkDf3Dj/SMQ0NwwtRLYyHOFxd7TJoI8e21C4J7fCFm/zCPiCSEcNO5c91MRbhVUj8/qhSheml+HjddhKHm8hWD5SL8eKfrGL1NBOFHP5S/PypGUfXhjhiuGPPZgkajfDGcG3WhMyoxQqrUe2Y1YrSqzwY5tYrx56rwlZwhMeLWDdQWvxFj+18xa4JpEty0jDIJtZVg6MDfjmrq864XZra5SOClMu3KoJ5x933VtEWC0kwjcf43Eqxt9Gfu8ZDAoJ2xTz0nwUnz2Ac66vC+won7DRIoTR/1FrdJ4MJJMlS2S9BTzzFdtSjB+rRTn11mSLFrMjfl+BYpdsQ4ZvaGS7E68xf//jQpRAS7ZneFFJy0xxMOGim2dvqLFg1S9FmwFXgjBVdwoMXmrRQ0WoHP/ndSPHOmZegYMribOWidWTJczA7p7g6Xga7gfTiYL8NPxpwBsl8Gh7o5V/MBGb7c2lnnTa0NVXaox2UYC32SVTwlQ3Y+s83ynQzVLlOVNUYkoiz6vqpjkGjmVvOtWCSu5hT2uXuTuM6qeDYhIbGQwv764u8kajd3vnrVTsKW3rmsaIREk34z32mchEPy4LnD1Is+i0Eb9SSsrMdcn7LlYNbeXZnnKwcjJ+TFF5VyfFoq2Hq9XQ4NXbuia1COphs3TyyrjIcm/Yjm1K/xULec+j6uUYGnNgEclUaBqN7A4bkRBRgbI8TkqAJ2NvorNWYJ0HXP3p2jPmRtiCY0CSjKPa3XUue0PX84oEzEzme8KkNeIqxCyjJayhLRXHot9kxDIp7Ipk3KbZPgw+rxsrNLgl9xyRrtxiRcf0r89p5azxzetKosCf3/bsmVU5sGx7f7NSQhZd36GxpaMtL0FQFq82RcHnfi/cc8jt0/r1kI90lBSfRdwk+ZArFucVZuSIEw6HZzD/Xjk1UH80aUuGmR6XWV2pfMddlunY7/AX9/AkI=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="732">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwQ0sFGAABmC0KFlcolhm03HqrOOayoT3/TA/rbUIZ7spwizq6OI2c6NwaSOXWjJXbU1uYzNk62SVSn4q1s2qraVVTNREMze5tJ6n1iUbUSPB7KibEEHSRdwSxxnw+ymWSwrE+aFc7kyLZ+CbkNjsgXp2vr5NxXQNVG3t9FpL4EDGJr6VjUMbkcLSbavMUigZ6FwvYl4p2djqwYmfKkwM93E5oJIL4hDTZdupnfGGYeUbepLyeflPPqbURgavzyLMXshBhb/QNNxFoOQecg5ImfZDiionM45tlEEqecxkn7/w1s6z3EfOBV85wos7UTQiR692H41LGl49+5IWq4IRQaFoO1FDy7tQJgxN8XBHO5e8ukXGGSVr3QzwKDpJnbeB83My4XApiam9fQjQrXLP6hGao+uo7wqnY2suq3fkCa/vD5FpcuXBon6UNW1hj72AypuRuNA8gAqLG7f+UwlLeAMnHe7TOBzFQtdGpn/RMGb2A+cW3amLHsS1Ag/2ZNfw6651OgWR7sXE81hB/1+Cukm5GD8XxwhbHKzPPFme7Cj2usTT+GgYo5IE6OtGYfYdQ8UTOzf4HUXY6XGYJq14kOPHFnM1p80pUGtT0dV8h86OJYyOTOeLxN202jJReXGFZfqP6Ou/wtIsNaquq9FxQw1PzWdIcvPEfmcZWzafgi2knjbTDHR583ivamLiTDfHPhVSZjAxs2QNkZ4V+A812eTa</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="80" id="sample=1 period=1 cycle=3 experiment=15" defaultArrayLength="133">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="527.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="15924.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.146866666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="15"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="737.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="737.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="42.077026367188" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1392">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzGtUUwUAB3CJGUomHJQoTLiM1MSDw+IYvthfFBU9iDAOFpM5LhswB9u9e2/ycLDMkFT0+IgjsyRRSpCFYgRsMFA03xpKS0C2+TgJZKiJPLL76fftd4gfpPvLtBEZDXNYsthUJHziMi3k8hH1gVEw90sBRnPl3cILAgT8eCKeHypEVuX6PmuMENP8XXOCtgqxqu3nWTXmdIz7/bn7iQcJ0869V7gCEuLSzgJfkoR3o33/kQwSXoPfd3iJGPfN9hk2kuBJ2A3dxSQsVy7Xum0kpltXGJIekOgYdDwUTMpAbD8RcZRxJEP9aC6RgSXXFFc5HiIcJJTbTIxxBm172TExNgXurTnvEuMx13hiiluMWfzuqzONmThdNbo+ty8Tnm5HMz84CzcCrDmz2FmQpx4UNZuz8O+2zPaIymxcsgbfVa+UIMiLxYpPkyDRmE5sM0mwbsyZzemX4LyDQzatlmL24ftRx0VSJFsLTMePS/F+pYBobZHi8CkzbwaRgxUn/uiuXpUD2R2ry8DKxeLJcY25q3PBvxoa4GD0tnR9uJQlw4YZb9gTQhnc9yvefi2SIcf2WB88WY7583a/PGuVI7IixH3Rg8LnvC3vPAqioLVVN2QnUVgiH93UzHhEZe5ZS1LoO8npHC6j0JHyEzt0PwW7KdVr7AyFmZrfJ+bXUfgi8lXIoIVC8H7e1B4bhXHey6/CWimYXxZxyu0UUh1vejxvUhDlf+Nr9KCRGMwxDPjQYF/oSYwnaDzlK4hkDo1zCURn0qc0SufNKeWCxmtRxVBJDI2TrCO854yOuvDXqlU0QqUbaiuTaLjzwqSWMhp+gXPHPOw0Pn6lXdNVqMAWmVmz7G8FfhloXFbwXIFBo21tmZ8SnskL97wIUSIhQuIZy1ZiHy+K3ixU4sW3v01z25RYvjNCK76pBKXa1Rh5S4kDR3s7tU4lclxOVy1jUFmcOPAfJQjLjWYZY3nP5aqut1QYYBOnvBepoN/l/K4mQYXSelv1HpsKTU99f5C0q1AkNx84d1sFc/i9xF9j1BAPnGX7bVIjZ3ykaCtjtPzexa+T1EjiHbqXJlSjvM2c0HtdjTZkSi031ah98i6ZNkmDqV3Z1cQiDRQpO6rSGUN00YbPVmogndDFnYrRgHWdprj1Gtiil2qrnBos2LwxZIqPFk7N86HW6ToEuO5rUjJ02D0WKLjDGD+4LkBXrMPplU0atUWHZx/157cy9vqbUioGdVAsv8suOaaH/iGZ3MH4JCzvveA6PWoK9L7UMQPzl5fwbhkQWXCmZWe/Ac+8bg1Tvtsx1X/70UtDeQgXLuba/8vDq9qRlMXCfBwsjhVcSc9Hh2zNteKhfEgP3S5cUF+Ilgc31ur7doDTFma1M/4PrabkaQ==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="720">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwWlI03EcB+Bwf6RowzOXo1zq7EASmTnSrH0/P3OiguZyZiummOVs2NTeRGCGeeGKDjOz1o1aLteclJrmwdYEkXqxZVbgoGRddixoFpj2PJ7SzaRcOEjS/lVMVx6Qqo3R44eln3YeGqDnj3xy7c9RmmiVMW9HLX0zmHBP9BvxjjnqlPBId6EFacsSRPG43bncKPh56TQ20sg8v6xw1E/R07FzpE63YoWhDY3GQEzul7NbrZdIdTMY5ckalC0Uo0LaTqXhTrxeDGdNM8ABZwlTnBXDts2PNUxXUHN3JHxKGZYTJfgiyYbDeA2FvE205L9IhwUtSHi4RFHjsZix3sF1YQ9lxppp5VYzzdWYyX6DB5nmHVyhHF6ts5A3IoCd1lso5/JHVGo4VNvjEZk8i+0hUkQ3hbGXT6wkPuVmmT1GGEUJlK9qgFrcR4JjCSTQbmElpkSkBK1GXS8fBeN8hCqG6c/FYVIM6KC3P6N2y3kK88hpvZfHQtIKMB8XCHUd4UU90dAbwueMIPztD0KM04QNlXb6OmiHc0JBVz1udG2MQ9L0CTRXr2FTygwc5YQIfiBEUV8vOnLX4nthFp05kkWTfBG0Kdnw43JguxIBqcdFez/lIbVKRb6kfOzZkY+qXfvoX3c0ipPf0vsaNRn8DSypwIbOu11wK4pw+0MpHovicPx+GUbMZTRv4ljbYBXV6k/SrGsI/wGtu91U</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="81" id="sample=1 period=1 cycle=3 experiment=16" defaultArrayLength="109">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="224.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.006388337832" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="12449.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.14855" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="16"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="762.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="762.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="43.639808654785" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1160">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxX1QkwUAB2BIFOQ0Ee2k8q4xm1yHeg0kAa/bDxgVOFTmIRJtwjs22IBt7z4YbBAjt+qmgOzUgmzjRhxOdLACzcGBck2Tw9oMpMgFOS6JTIEpO+8kep9/nmeXronfZxUiOKD3MocL0Z0Zm7/fyEfny1y/ys0HGTJjpO0owk6/LUg7XoTofVmcTksxKubO0ZdDCYxydgzk8Al8pjkwe1ZA4Ebjb8nvlhC4ujPOsWglsJD+PDZvhkAPK/tzN/VddUgGJ0QAG2f96hqaAEfiGbdZ1OXbUr6ODC0B3puyu61CDB6RnvH5hMhi/tfu9gsRutJ0wU6IUOvf80XttAg2/XVLv6UUrR8yX6R2lKEwTr2g4IlBfJloG6Ru5A1/km0Q4/WnFQPN1G4LI9lgk+Aea+TQFXY5bjiG817KLEfPD/l9kbQK7B8vm0thV8D5S0DWE1aJq/O+W3p2JRz8nJjzYVIkR/ttf5ZIMbZVEl4vlGLo/LxSZpRCPN1/Ocotha4uSsVbK0NSJftgeIMMJ12T22upg7ufEqVcOU54A7lmQg4N+6vBCLMcbNndgQLqvTFviiacctTFX5C+c10OH4PbJ6eu8gajTo3IwZngNegX5Hhty/RHa2kkNtS1X+NQR6lyGzISSeRtTBC0UZ9yttiX00k8PP7WNl4GiTCDp5GtJ2Fk37n53WkSJVv+reltIfHH1Kxv0UmiQTT+6bloBYYk40oTXQEriy5qTVDg14u7XK4iBfYos+1SswKj5d8b56ntD5+Ja50KdA/50o4FFNhqzU9soi4bZbFz1igx3zLGdBQp8YZEMGUwK7HvUfsHMx4lGF0RHrpXibikQPPckhKrGH3SOazC2LGPW7kPVGhuWyXSAyrc6R67/RNXjUo6edBVrMaLVPOB3g416idNmzqm1ejaXvW7RVEF2ohrXPxtFXonqgvW0zQoDT+520jXgLaJsyGBqcE3u3SHfjRrEH/lbdErTg08MbfSjsZW48nf91NFzmrcYzTXvyqowXNd0mTm6RrEn3gU/Nlag0hV24MlaiF/r3bdZi1Ej/u7/knUojjlpnw5XQtPwWzuRqsW6zrUKzzqlRldbnS7FktNJq7Jo0WEJO6wyavF5rSj6otOHRyLeff7HtfBEFn2V9ZhPf4HViiRNA==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="596">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBtAFL/hVsSEJMFmNABOucQgUl70Ar6vRAk6/2QMjrb0GsXcFCIqaCQInOBkI8uwJB9zmcQVmIk0PdjyVBgmeuQR/4x0Bu+cdAXJnuQcUxMUJx0tVAygx+QlRJNEFlyzpCJScUQYlPF0GQSuZAKUzmQHX8GUAk/OZAv6dEQRsVM0EuyO5Aoz1ZQuuVykGTNiRB3P4FQnAEp0AmThhCZxM9QVVpKEA+pf1BuwE/QXhTAEF8VABB/bVZQXCBLkE+haRBXZ8DQYwlsEBXcbBA7J1yQaJ9MEH0bjFAXM0FQc/OBUJnGIZBuxkGQY5VBkHeHjNAwVk0QVuutECehgdBRK9iQZ9Ft0DEsAlB6mgsQi3QuEBuyTlA2su5QIFkOkC5lmpB3qw7Qaz6O0DHVI5Bh7m+QGnoP0Bz5G9BF7BwQc8ZuEEUmg1COP4TQa3XeEEJL3lBGotIQCSgSUAuQcxAnGLNQNBawkGQhBtBJJ3PQChQ0UCD1tFAkD7uQeKVDEKYwodBRZdnQno62kB1ZYhBPRSlQaOtXEC1sSVBPNMmQdUSBEI8c15AWIaLQYRB30Dp3mJBf9xrQPavOEEDQLgI</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="82" id="sample=1 period=1 cycle=3 experiment=17" defaultArrayLength="108">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="235.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="12528.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.150233333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="17"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="787.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="787.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="45.202575683594" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1156">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxX9QUwUAB3A2RFcX5xwSy7o2JjZL0WgYnsH8DpgC6UDccafpGG8OXRxu7+0H2zK3FQ2mnQknMBMYDnRo0wJJNI5AcN6B1fA6JLQLUOR0QaHRIXhB7/PPJ3jIFVm49SO85WuJPS7Zj6xJZeDtLxR4HPTutQYU4DgvpMhWK/Hr7suvTSuU2JJY18ZgEvDfm7+oFhDgPlj+cJ2CgFCpZJ1SEbj1vu3f/zwETgkMqTtHCXxHTHmkYSpkdo/kZfNVKOtY6EjMpx/L4D4TqJHGnLlc5lFDFyHRTdCXuB8P3XyoRtAl9JDjapTvW4za4ijEUvFU2YcjheBerb4gbTyEdQlNi5n7NejsF3szSjWoCUVxNno0uJbk3HNlVIPt92Jqv/R+jDM6gawuvQihzLgUibQIjZox76v1RXi0bTpMnl4MkVg+IZQWo3t94ul31Ydx9/neS2eWaBEKzbIuRmgReO56JHRoEV87HjTQ9/uOdq66ocUyF5V1ja9DgTm+qyBXh7bFjrU19FdW17S/Qejwt3DrXDX9XHrqzchWHUyyiGFetw6kY3J9BoPE4MmEmFkeidpwoz+bT0KUYD9RTx9tqZT1vkciaWBJhVJEwtZcMqVKJRHL7jeE6BumAneGD5Own3dtPlJBYsJ/tvgWfRL3a+vktyRyYlbIzT0kFhxxiuBTEtIDBeO9DApZydq8Sg6Fn1NywtlRFDL7fFWnBRR82vn2SzYKjPgTZTN2ClU1B47PfUWBOLjzx9efUlhgfzBgow8M8cXl/1D4pvS2NmeGwrLaNN+fHD02vRju4Qr0WDn4+0GrUg/ptpbC5Dt6zE23OXtG9Nj8SpPx/DM9rtevja5jGtBsKy51dhmwpy/5GPuBAUd3nYt3/2VA1cD9HatyjRhvV2XzCCOqmjd+6q00wnmV+eZvrUY0JK18+ZceI3yd3mjWLhNa3+Es7Wo04ZxkOyVrNWHwfpOdGjPhpE0e6aoswfV91bfXjJYgx6QRCeRmiPImG14QZkwIGDxbixk/tX2WnxFmwWyXpfPJbgv8GtbZJzYL2DYe4fVYoGxfIx6iH3DYzPwVVrjnKxaN9GxV3AZ3qhWb0nYsL/dY8dIMMyFW8gkiWbn+H/44gruzfd8P5tvhvhH++YbecvwPOqaD5w==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="592">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBsAFP/padBULZvBFB8PqkQp5bs0ClsLdAaq72QAlVnkJn0AFB6fhDQTAVxEHvjgNAQDp6Q4N9FUHvpQ1CnysGQKxjg0FMEXhB48GNQKVdnELJoQ5AsNjGQeR2yEFdI71BwIYZQP765kGsTZpAdxIbQKCnxEHF+kZBDcnuQOBM8EAQX/dA+uukQWsY/EDHxilAFq5+QScaK0BXVABBnscrQAnZAUEYK65AQiyuQG5nuUEn4QJB1iOlQULYCUIQVQVB22ayQP5qv0JXarJAdW+cQbolyUFzU4ZBjBwzQO3/s0Cq3mFBliwNQqhOtUA2QghBIZ82QT/wtkABusJB0HWJQYx8ZUGnEAtBhBULQSO9OUF8uAxB8LkMQRI3pEGGsDtAyL6kQb6SPEHCUw5Bc+RvQVIkEEHtaJBBqthAQLxexEBhwZNBHIx2QaYPR0DJgxVBBDzIQJoF+0Fa1BZBG74YQTUgzUAgYk1A/DbOQMJ4a0EVqINBjeaEQabk1ED+y75C+45XQDT2WEGMD4hBH/I+QrJkiEEJnvdBcBxcQGXrXEDxPvpBFswoQQnGkEErtXZBj7EXQdjrumk=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="83" id="sample=1 period=1 cycle=3 experiment=18" defaultArrayLength="125">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="278.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.011561868436" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="13320.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.151916666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="18"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="812.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="812.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="46.765327453613" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1320">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxX041AcAB3Av0aNWOORtzdvUeJ4wknnL10uevEQxJko5zuG8/O5+7s556zSMZnFZal46bHuU7bk59Fjm7ZyMWZ7iMcl7WM16JuRlXGu/zz+fJEljiH1BENyrrBiOHlHwiJkfDi6Ixjgje77/YTRK5fMFphaXEaDkpNN4JwZu9ceLDqjQMfn35ikZ9ZsMJWhF06H79Rdqn1ELXo47n6DTUadd23Etlo71mR+G2sR0+A1qxYbN0bHKUjxzVorFIV/VogGTWDSUd3H3mcZiLPQD2qfU7QEqrzn0WASHrxxxV46Dtci/KsYsDoofV3W2zBk46tLCvitmIIV7qlG2wEBD4mThkmo8dKxtDYLy4jEZ89FW8mw8DhRNdkSZMLG2I7BUmDGx7PnlsJqYifsanXY1M0wsEpVfKa4kYGqjf+l0fiI+WbNZXJhOhLvFidCJ+iTonNnf2u/DQs7DSK++OBY0rLoNhabJ8HZYOunhnYwynzsjtntSkB8/XV3mk4JzTPMBVUYqpgMjvIyupqKkuLpS0peK0fba90Zq0yBzoRls9qQhZctssV+ZgHeI5feaOgRuu8k7X5kQ2PshQ68hhID+yrbbeTqBtoSL/B0Rgd78yL27PxGw0cy+2SUl8PpdwWGtZgIOLef/nOgmYFyTM+XaQ8Di+jCrkNpmjf/40nMCz4LvK/GU2XDZ6R/97SAb+gV1DwJN2UiI6Z7yc2AjkCerq/Ziw9t/t1ZWxkZvDzP9gYgNR0lQk6SWjSi5vnpaExvEUsu1JBoHAy3R1/WEHCgtN19oeMLBkehdE9Y6B6K7B2WTNBKlHgpizoxEWG7bwPvmJBylUxX3qDdnesfdQkj8UuKszSdIOJewHhlzSHAMx2bYV0jc0khzKxeSsM/QurgqImH5e5T1hRskBnxT1Uupj3LVfL2fkLDVW68qpM5KaN258ZxE8sRbXscaCTfpOduI1HRY0dcFFd3pSBnMLSmXp6NS/Q/DipF0+J1U3uGd5ULSdOimsZCLjazBxKo8Ln7+5p/2sW+5+DivftuzmwuaVKAgHnNhF8F/lGjOg9zvePiGHQ+M0LOvXgh5UNTXTcxI+RjtGpr3nONDklu80nw5A2d0Wp/6izNwjDb0xlWaAXm551UJdee/Rs6fyzKQFO7qZFwmQM1h/dlmsQCm+95KrHUzMRNzL8BZnAnX/U+Ls6k31JlDL6n/ipxfWJNmona7xkmslQWRXaqqpnYWVJZLdMUWWagpO6Yy+V829PaYGNl75KBy7nTArZUchGWpZebNCvGr3e3EPmqzd+WCF9Rewu8KLhnk4X8GO8hC</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="684">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwB9AEL/q1oqECx1jZBDKAyQn1cs0Ar6nRAA+v/QI6Cj0L0XoFAwPfDQKqkM0H6s4JAhb4zQk5ypEHL7Y1DXn2VQdH2x0BE+MdB3flHQdk2BkC1jt1BZSjNQIuqHUFioVRBthN7QoEXhkEbnRBBrVgWQn9CgEH0RbdBJDK5QQjvFEAx4xZB+7wGQgsKG0Fj/mtBi/tGQqmMn0CygXJA+hdzQTO8uEE2TZBBPg6TQQ14UkF5F6lANXCrQGzVAEH8eqxAAtgsQMXVAUFzLC5BXciNQd1sxUHUFARBBByEQZQwXEGMfUZBQWqlQXWQ3EHnJLFAQnJ0QfyJBUHlaLJCTtsWQuB9yUGfGB5CN0pLQUigy0FFUTVAkHMJQZJtuUB1QwxBweMGQrg1jUEZtmtB75K8QHSVvEBRf71Afo4OQVwbvkCBXD5ABWK+QLi2PkDBuL5AlQuPQWLwCUK08A9BfC4QQRmMQEEW3cJAA+vcQeZxxEDauERAAcr4QfblR0Dv7EdAx4tIQRbIFkGLAxdBPh4YQTFQGEEigkxA/9lRQZGog0GsCIVBcnAgQdGqoEA3tHdC0N+gQOl5I0L+OVpAxCfcQIe6NEKX7RhCj3JeQd693kAKQ9JB+DYoQZ1wKEH/I2hA/yTpQPvfa0DV3gxC+t8MQjyInEFxjB1CvpPYug==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="84" id="sample=1 period=1 cycle=3 experiment=19" defaultArrayLength="92">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="228.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="9963.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.1536" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="19"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="837.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="837.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="48.328063964844" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="992">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx3tQywEAB/CaRp677Q7tVFM47DySU5cV36gcV12S06Xnr63HVdt+v99eGak88sxVOD0sTOSRq9Ef5lFm0xEyV7Q8Wisnr1Lp0MP5/fW5jyUr8mzQxt24kXCF7XUoEVWPj5fnWBLR6VHBnpeUjCKvyd/5TckIqHU93KRLgbKV5//bmUCLRuu+IJQA8VhYKk8kIJvnLtqUSqB1/FN/fzWBXT71X7fbCbRrP5VwF6Zi0OZcw0pKRb2jPGrSSQxNZVC30lkM1RQn4km1BG9n+YuaeyVoGLhakNOdhkq7KXmuIB2j5niWlvGOJSbboktHVUBkv0ifgXafi2nUwUwITvJnx1zORNwavbTdngmT8pLKGJKFeCV/vjQkB2W1oukGxo/NTmKBixQuf7NfToqlOE27+UVLpKh/HjtkZcyLPcf7wpJhfdtEKpctw5VppaeIAhlWaqWL7jvJ0Z+Wu/ksR46wp+HFa0vleFZTXMirl4P/OXZ8TrMctrwPvHhG870pZccWkqAGy2uDfEjwjY6Md74kDspXuIWuJTG2pOrXK8ajY2GHijaRCI+99kaWT6LCZee3IyUkouZzYzQmEu6vIsYKeRTCbP6LzYyH565aUOBNIfj7iX17fSnUuQofclIo2D6QQ8P7KXC6Art+lDDv5My4NExB+KdjnWSEwucWw+CEF42bXts6krxpfA+0BCQk00jofa2MsNLofcAJfeigIVTwu+khGtlfH7EtwzRu37rRGJGvQPi066rKJgWEBoGxp00Bj5qlA1yrArslrlVLHArE/dS1vGR0cxxvzLithKDt57dxkxKnTXWUJVoFI624O6pXYYdtwlVvUMH3j4TD9VZj652QxpADavxbHf3czjg6PtN8pFSNonzpdPcyNbZM1Z1Z1qBGw/seu7lYg2DPEW5NgwYsD8PTjupcWCP1rA0XcpGgk/g9a8rFSc8dteer98Aq7nuxvE8LkbGcvSclD/8BwY1SiQ==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="508">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBcAGP/qjGqEEGKhVDeVuzQNUtGkFqITtAIvE/QVTIiUKacsNAnqYCQMC3gkD3VcVAslkzQ0ZQBUDxKgZB4JjuQHuFzEAs5YRBtEcyQljKkUEg39tAApaSQFYnlECz92JBBDytQSldmkCR10FBcjwVQk3CYkHzYPdAFQOnQJMRPULDEKhABRIoQDKj/kAJyKlAMlQAQV91rEBTxaxAeFXmQUEcsEBsVIRAllUEQfUD30GqDAZBT3tfQfpxHEEjzjJAQ+FfQaBaNEAs32FBNkIIQTxFt0CGL05BsbAJQRXnt0BGX8RBqxELQerGOUAmvgxBVJdqQenIsEHMpYFBnVOOQR/wD0JBR9hB54VAQdF6KEGoMkNBOAGHQQ6BE0GwsURAx2GsQWwFxUDl00hA79QWQQ/EGEEsIc1AwgoaQWJZT0E8C9FA8g3RQFH7nEA1/RxBtdZRQXCjVUDAAfFBkzpaQCqtI0HcESRBrj96QV1MjkFgg5RBLXqT8w==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="85" id="sample=1 period=1 cycle=3 experiment=20" defaultArrayLength="91">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="244.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.011561868436" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="9825.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.155283333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="20"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="862.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="862.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="49.890785217285" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="976">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXss1AEAB/DOTmraIc3p2roL1aQU0m2y+Xr0cFspr4l+3P2Ok3J3v9/dT55Jeq3usmhLU3PLo2g9EGuqc7oLSyzJ9ZC6jiK9KDuzWek+/3xuu35Nig5LgbNUE+wpT4U0OmTN1tOpkHS4jAakiRGk4509aRCjp51of1AtQcuirF6OA4kXoZ/NtVISHIGmp0lHQjR7uTftEwk/qeoNx0qi9UpkpXWUxLiUGElaJEVy0fTEHfuydgk3VCCFw/h8GIeVjhifhiizKR1DvqtYTboMpDcezukZy8BI/yHdBYsMcd63zi3TZUIruNHKqz0EJtx415XIwsBNbRtxKguzRR5DhTWH8b24aN3zqCNIEHbPveZnwzu/a6VMkA1qf1VdMVsObUilZTBKjkhbwg0ZW4E5Gm0V6Qo84lytWZ+hwPQObmZyqQJOCytudj9VoJc1mfuOpcS6iVivCbYSWXFMjaejEh/vZWq+8imUPCgP5HpR8Pwy/I+IpRCip5yiSQp6o/4cY9/nZfeCbwWFDt/HPGEnBQdTl3KxiYLN3UkuY9Hgkt/HaTca9FJTcKSAxuSSzuyYIBq8sLnNffZTiR/8AxE0nriGS07YFyU1vlaW0HD4VVulLafR0zg86OyuwtRAwj4MqPAw8a3/rhkVDqyu66DEaqjLvMzbX6qxKUIdE2tVw9TUxNvyWw3UOjpm27cdTLp23f4Y8eH0lT9qDBu2/dWKGYS/YugIA4PzhqHKXvuBwYVR7FcM9k3d2UlbGCy7JgpMGWXw3v3NQzaZg2d5GouzIQd7qlrrvg3mYLfYR3+85Sh8LgaZqo1HwVT7GVqW50LIXeibrMhFzYJwQ0RzLp75lW1xi89DsTm+4bE0D/0Bs/3JzXn4abS51dv3+FVf2qHLx8bKxPK9ugL08edL1a6FkJTUh/qLC7H2vkRHhB2DscBbdEl1DEEz+dZ8lxPQEGeq6jtL8R+Ge0k5</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="500">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBbAGT/hPGqEFqzO1AKBCSQpUuGkFqIbtAZ+t/QPhWXkKBZyNBZThmQZkfckMGkSVBWXoEQHAZJkEMVMdA9voVQsXckEEw6YpAxuSEQXhOY0JYypFBUDzeQBkjPUF55z9BXjytQedSnUAP+0ZB3akhQG+rIUHZUPZAtdfDQdsDp0DOFXxARhh8QaiRfEGEOj5BOr8pQHTHqUAoyClBBx2tQI7eAUHP8MNBek9EQcmALkHMXVtBOVWEQSaAMEGwcUJCKBuyQKACX0HunqdBC86yQHMZM0DQUwZB+EMHQQmGh0GSGWVBDL1pQWSru0CwUw5Bc/AJQlkqkEGMhMBABKfwQRRlEEFri0BAQ5tCQXldRED+X0RAylLdQYz1REFKA0VB5VnHQLcJSUB7ZUlA712AQeOrTUB2FM9AvVBRQUnXUUGgeh9B8OdUQZI51kDF5IVBXmSIQdlv3kEVNShBLpBhQUHcLkFw8WlBw9J7QJYCpUHluJX5</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="86" id="sample=1 period=1 cycle=3 experiment=21" defaultArrayLength="101">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="332.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="12427.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.156966666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="21"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="887.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="887.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="51.453495025635" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1080">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxWtMU2cABmBAcBCMjigxSIVSMYsOoykKRE7KSykq8QpkQDTQG21TC6ffodBCtWImoKIutpgtSCwoBAWvqEFNK9hKVVSkCmZxzDJQq5O6CUwBccvO8+cJHpx9vStlFxJ/D9mUVV2AqRVD7tSaAtjX+Wi/NAnCNqZZ08USLI6NlNZ0S1A6djNowCrFkyX0iwl/GXxJ8b8elcvQN+cHe8cBGTZoBeluqwyVbTeObf1DhoUHv3Vs8pOjrTX3WgJXjsPb363m+Bci8aSwfQv7lqOuW4ONCtRmZt949EqBw7lLeQGBSoQMp+e3eJSgbBsydMNKRFDaPilPhZ73bVSLVQVyqcVjaVThWS0lyKlSQ+PovHdVpMFGs/Z8CrcI6pmM2t60Irzf7a2LlRQhj1Nd4+csAtPQ3nWC/f7QqwlbYDEMkQlii6gYnjt+hdGBNJLk9lytgkbGX+c+jPXQOCQ4cqF/RAuVePfeGX8CW2p/4edogvGP3aSdS/C9mJPUy/7P7VFncwxBcHGdAzwC4YKYiog1BNXfeAW97Hu4t0yZWQRJrgUNLvbwmLgVWhnBFD87atRMYKU5I8kWgvqvnP55ZwiqCkbuUVcIQp3lzXUdBB/DheDeIRBtM3XmsXd55wvq2Tvj7CeC3QTLbb5ftvoz2BuRohRxGRSGeaLOsgc8LdhM4hloZvNDrEIGk5ye0ONmBsMKVdPFywzWxrU63zoZ6KfXlksnGGgrI3828Esw99QQ120uwezSbH7OZAmW/ZZ6P2ShDtXKB1PLeDqoT+ePmSU6JNMXUlc+1SHj7twXNPtLh2hwzbgOGt5D16UJHb47xn9OTerw+fo5fUN3KSj95NnTA6XwGZLPMzvKIKp9HvQ6qwzTVe0O19UyOKDUdLjLUJ8TNHDIqce+D4rxNz8aoFf99/hPiwEVzZ8SbGcMeDm6R+n524BZaVPAJ2E55No5qoaOckR4Mw/SxytACRoXrWqqACf0Qd68MCN8sYnb/403gt8a/USdZcQVb+aXlY1G3LWODqzfYUKUevrxuNgEi0mo+ql5H8JL+iiqqhIzxp32ruH9+B+VwW/6</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="556">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBlAFr/nT40kH5K4xCwy5uQLBkuEDusPY/sYH5QD/zH0HxLK9CJ1ZQQtgqA0DGigNBMC/RQ3p9lUHrT55Bqng7QctYCECwolRBcCOnQksIj0HoOTZBv6/aQTWfEkDUoYFB2ykUQXSco0ET4VpCdxXKQVCVSkFDYqJAADb1QPt6o0CTNiRBOWB3QRUDp0CREKhBQ15TQf4frEANfCxApWRYQb/YAUH9xUJBUiatQGB0WEHbcy1AphkCQVd7b0E5LS5ByuACQuGEpEGM8j9CSt2DQdgVBEGaLVxBEn9GQZZVBEFfc7BAlsQwQGjjvEHd29NBb2oyQIvLMkL/GjNADUlLQQz6B0HXr7VACKI2QfzmN0DRxrlBr6s7QGZIPEHoACVCH1QOQVbvj0F+6stB7VoEQoCdWEHjahBBH19EQcq9REHiyXhBf04VQcTr4UE4W0lAgKtNQBMK0UG9UNFAMDEdQeEwHkGtWFRBt3I7QvL4WUAHPFpBs5fAQe2t3EDlLd1Adm9eQaQOL0GKPS9Bp/gyQaQF8kAYI9tBBCOpcw==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="87" id="sample=1 period=1 cycle=3 experiment=22" defaultArrayLength="103">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="173.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.004663847325" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11560.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.15865" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="22"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="912.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="912.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="53.016193389893" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1104">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxX0w0w0AB/AQrtRZqkdX7SY9cmcXNaT0sm9DUnlEWS+yhx8/LGttv9+0jXJy04vUE6soz23Ty9WlaOisXDfj8ahQ8pKOblPSi3EXqZRK+/zz2Uj8HRGa9xfs23nNHG4cdjYeCX9h+1yQabZvngD52wZfqpsEcIxL8803JkBIjH06rknEAXKeYb49gQWKu3ErPQnUz1K3cAUEvHxzm/VJBJa9r3rzSkvg2WfdzCU6AmGRJw2h/QQiYkrhPS0J2pEemadHEtirGNV+dsm4VDpgaPUkoagMelGrJXGuwN50x0KisHA4tnWARMWNlDOPHFKQxK1O2GdJgeqBOSublYqSidGl/eZUHBFc+ep8NQ2WjgH2hnghJoJnPqVVQnRat5dVa4Qoihvba+WmI2++tq06NB2RPlX0L5YIwc+Tk1UhIrhcc3N91CCC66bx1NrQA0g3NuVnJYsxHIUgq21N2606BSnGiagnhiGVGF0ebn/WNInhWHePPTL9IJg9zt9Kcg7i3unz3ps3SqBs2P9/dowE7n2rz7IuSxDp7HV/Zb0EDk8Kh0R2UtA/O8O4HlKUX7947JRt9eCFUR9/KQqW3u4U2bbyl7vHh0gxObed0V4oxXWSv4islKJLv4WZa9uPfppFN0jx8FjVHyW2R2t9nlvcKATteu//lkPBpatSXsyjYHbaer4vgUJ+d/E3RiKFa5XRrSrb5XvaDU45FNS1FYmTuRQmmTs4/E8ULLc//jDb02ir45wZX0Lj7buRl3s4NBxZ363RCTTC+aZtg7k0xh+0ucov0/gv4FKi0zMaHVs3T7FHaTROmWKlAhmGdYP0YUoG+Z2bh0qNMgSmkA5Dtov31TAWNcqwYr3ScapDhrWPI1bpojPgx6rfbaEyECXu/bLwVQbcullFuopDSF8nEAmL5JD98q8J1ssxI15nLvBUoK/PmzlHowBvXWNvmE6BBRJ1lkKvwN4yL9MVhhL/mk7u7olRYo1HjPu0s0oErmd/aNYqEX7VRe6uU0KTZve6vEOJC9DLF/MyQa75KLPTZsLZqJngGzPRPV52lGk5jNiQ/fqMf7KRFhC4djYvBx/Gelv6LTn4DSn6fDc=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="564">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBnAFj/t5oqD+3B2FBo6YMQdpc/UIZaSRBFYL5QAzq/z8puINClrfCQOlPo0ECuYJB0lXFQJ2Pg0AqQERDp1FHQQ/REUK4NjdCJTjSQIYNOkLfNjJBBb2CQtyLVkF2zONBKeHbQLbvFEEHUhdA1knmQPY8LUE5TBpANiGfQFpWgUEKdQ1BwhCiQY97o0DJJc5BPw6oQOvUYUKYF2dBYPvHQWyn/UCkAL9Bh1IAQdDPLUAB9RJCl9IvQD5xsEAUVgVCja4hQvRpskCZFwZC7qvqQZbmX0ERtDRA8ku1QFqh4kHPF2NBpkIIQU51CUHW7glBZTi4QLZiEELut6FBG58KQUdtOUAXfDlBw8AMQa32akH4kbxBs+K8QC5TDkGvCG5BKQe/QOPuD0GMhEBBMpFCQdXwQkHHdnVBkmBEQKxvREDKukRAbA1HQUy+FUEdPRdBelFNQOL6HEHlQ5BBq16EQfDlVUGF71VA3p1jQhfgIUHA8dhAVHmjQaSrI0GWrKNBoRJbQF3p3EBz06ZBEzinQc2kZ0CPUm5BZ9T1QINyekHoqLAD</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="88" id="sample=1 period=1 cycle=3 experiment=23" defaultArrayLength="100">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="220.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10774.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.160333333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="23"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="937.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="937.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="54.578880310059" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1064">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNz21QiwEAB/DtJJw7L+FKZF0urTqh1MWX/tdKU4qGTujtWVui1rM9S2vE2gqdu9KjnbrS0nqZvBWHkrvKolZ32Fp0dZQ1nBHKHVKc59Pv8+/m2kdjiWFHIDu8bV98cTIS2lcLVj9NRrn64cKh2jSIb61ZMc8mIIgtzaoQEjjEihtfW0vAespyrl9HYLAl1dm9jsBkbynLo5tAOyf0zBUzgUWC7rPxEwR27tiUEskSItD608/I+Hi6OeoTRwjHPv4kz1OIclP/hY7PQlQv3vI7nJ2O9X79tQ4vEWwj31tadCJUeXNuO9WJUHAjiPNkUoQvdvfe7XYRtIpH+qpxMZLeTrHNnAwM348ysnUZCHCMXYqzZeC6OoJ21x+Do9Vc8geZCNa4hfkmZaJ4fi46pigTxkQht46RG+vK0tYfB0WsC6mMOIHzEsfK5ZEnQPjEneV7ZuGr5pr4vFM283rTp4rIRknK484Jxps9ly2z6RLwFnj41ogkqHp9q2JwXIKkjBK2xSkHTYvoMqIwB6ahgR3BW0lsWvjiGy0gEZ88Fe1DkJj97WcSMr4/yitZRZMw77rRFsN4MKjLLqon8ZZb7zbaRqLA3yAJ6SbxwV/fqWAUFCZwT9tIuNYO1hxhS4G+NGW4pxQz81znHsYQzl6PlEApommz9WiQFNquPffLwqUY0Wl+qculCBgYchth3Ji1gQ6+KwVPtl/c5yJDR0fmD2OgDO/mlKQ7LcOw5hUxyxjq9dIz0YtCTugMt3MvBX7daEpZKgX9sfRnchWFFvGZju1mCiHLHwx+nqBQYN+9wneaQpP6H0pnKKgim1jaVXJIn/MDGsLkuBZuti7ZL0f94bRkP5scT8ZcG6an5cjO20L7CHJhI65/jb2XiwHFxfGlXbkwtFY0au+exLDpavEUnYekwjzDUFse2pd9bM5pU8CxOZUn71FAVd1adoDIB/sv2Vd8KR/a4dHWdl0+nI23qxq3KtFwwbrUW6dEd69ljfaOEmMuc94T75T4sdjOZ+kLkLrS0q+uVMHwWmMKcCtE5XeLb5ChCP8BGTFyDw==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="548">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBkAFv/vLGqEFPGJZCdVqzQC3sf0BxsyFC87iCQUGIA0E+VUVAUo8DQEkAxkBvTSVBjjGDQ3HhhEEW4wRAgE8FQD6kv0GNEipBUFgIQbk40kCsoVRBR8KNQHzoJEKE8dVAHsuRQZzi20Aht8tBjfoUQThPl0FWyeVAXYYZQPWbo0Fu/OZAMVMdQEvG7kA3MB9As4ISQv81pECG6iRAYmH3QG0XfEFwEahA6WEpQFvHKUAyVABBb3QtQHOZ5EFp3wJBeYCuQJlU5kHcfi9BAM7FQaQlMEBXcTBAGFYEQXslsUCK/5VCCkKnQUPQBUF+xjJBq0URQn7pp0HkhQdBlEpLQV5aNUCXRrdAoug3QcnHOUEbWQtB55O8QMjPbEHANu1BcWE+Qb7whkKIKBBBWoRAQWtoEEH0dHFB3v1BQV/xckGZwRNC7/mTQUKEG0Jp08hASccWQbiMwEG4emtBztnRQLdyO0J2f9ZAC+ciQVX5WUAXOtpA/Z9cQYbTJkH/s15BeIVfQXyx6kCyXnhBfg69QaOMCkE6k6uQ</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="89" id="sample=1 period=1 cycle=3 experiment=24" defaultArrayLength="107">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="230.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.013286398331" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11476.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.162033333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="24"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="962.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="962.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="56.14155960083" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1140">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwN0H1QkwUAx/FtUFzkdRggJBsOQ6WOEgea3hn7tWHOQgViinnuFVg2hs+zZ2OgeDHc4MSXnEqdKNuwOyMY0qAOmCAOM52XSt4hocizMphwIA018pWevz7/fP/63pa3uL5fm4thXf1DtXA7XnFNKvlWGZ7qdv2huCRDCJRdHXYlfIFOhHNUaNqfcG6jTAXBmmsj36hVCFTSl7X7VGjY9F9tu0MFQz1XlOdXoc4X/ZmEpcaK8U9f/sTo2R1zNpavRlShJz6RnY+Z7lP/VjkKwMqxl08ydq3l0oP3CnCxuft8IV2I32aT27NEGpz07rf22DVwDwjSEx0axB3aovQwJo2+O8377gt8nVSVkWzZiSFeXJgtQwvv2V4pZ50W9Am5/F69FtOJImkcvwgxS0Ki0lEE/0BVskdchNUfdR6MDtVhVHw8vD1DhwdOVuyv+cXo03zs6PilGDGNP0ysv1SMzVLdmJlNgHum33RjOYHyQPWJ+UcJDG6YSc1llGTKswWnCbQ6ltUG3QTzA76UCwTGenYIJvoIxN8fYOX2E5AG6xcv8BN4EfFOpJlFIsTvo7exSVxJOfSoi1Hou0ml80kcO3ex4bGARKIrYJWlkpgOO3CjiXHMOi9HJyKRMjgy8TPj/edHst1fMf1cg1NnI7EvcsOEpI3EnbY0SbxSD2Gf4oPlpB7N2/o7X63QQzdUEvWIMbL27z6eWQ+xLy3Da9Mj3HZwMO2YHqKIrLDDjOo8YcLlOT0Uk+MNY29S4LztucJdTCHi/YR5NQoK33p3jfYzvp5fQw3rKUyxzBfecFKgqabzq36nUO567e7SIIVbPdGCthkK4iJRkOIYIN8isd+1GSBa8jhg6TXgWXNqDc24Qngm98ebBgRezFqUtAFzQW7yc0bpsvgHw2wjeO992f2W2IhQTrolM8sISyCB9XmOEQu3rm5MchpxII6MNfUaseZ48W3/0RIYQ1aevHW9BDJltqmJb8Jhy+mhEbcJT65mfviQNmFVS12pWlEKWavGonCXomsk6G9kLFgnrJ5/pAx23rOtoc4yfNIjHa/+pwyL2C5rjmM3/mpuXVAn2IOn/Ox8KbEXvd652anNFdC2rL8q+rMClVMdppRYM8ryUhdxJJX4HzhNhug=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="588">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBrAFT/qxzkUAY6MRB2vSXQnAk7z8B8x9BkYqSQiKmAkH1fCdC0b7EQIo4ZkGLtW9DKCZ5QY6iz0FYpCZBGI/dQYnAjUBcMjFBxCqKQljKkUFUxTdBPicUQIAolEBWKhRABiO9Qb/MHkKB+sZBLsjuQAFM8EC3WgNC4waiQKvODUK9NCRAfog5QYOMCEJbo/1AHxkpQIh5LEAYFoJBtlzbQdtO8UH60i9A8CCaQR6TgUKVn1xBI8YwQOYYMUGvwrFA8HGQQTg7XkHAUPVBG3xfQdwYBkEGGgZBmFOGQZQbM0ARQYdAO7I0QREECEHAk/JB1yI5QUdtOUByFQtB5XI5QAvGuUD6WQtBSVsLQT/pu0DLNQ1BvpK8QYTpsUGIOW1BCR++QHL7PkAe7C1CzqVwQeeLQEHroRBBpaQSQcvq3EFJSJNANW64QUH1REAeuhNBwzEUQZHJRkA6B8dA0BBHQL56yECmC0lAvNPMQExqGkGJfptB/9nRQBl7RULTB4VB4tXIQbsC8UGMeSNBWTtaQCWRW0G2EgRCGtRgQIjo6UA8PXZAxXx6QeoNvUHAVoJBwQWwww==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="90" id="sample=1 period=1 cycle=3 experiment=25" defaultArrayLength="96">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="275.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11904.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.163716666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="25"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="987.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="987.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="57.70422744751" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1032">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzmlMkgEAxvHwyGrVurZyLVOhY3NlarkipUclshJ1YVKZmuCBosT7AgPMSRm0TJcdUqYGzbRMmwtiZReiLpflvVY5LUg7TFPnMS3XqvfTb//t+fCECBL3s3WR2LVmxBa8Jw76ooh2ji4BHl5pKxSuifCc1iy52nAC+QZFodWQhD8zUx2zNAGqCqs1dUIBrO7D+w85BLBv0gQlzRPi08Xood2eQqTyXgjptGRc6HR2MEKSkRilYlUaU/Bxsyhzx60U/M2rH2kdTEEKK+DhQXsqgoc8eO2GNHT1q+NxW4Tig7Fj48fTca23npYRn46cIbeIOG06Sn3Xv6qqyEDga1aFhS1GnGhx5BHPTBBlNdbipkw43TcNl7hkQT+V2XOLnYWNv7/Zm5Oz8ONLVHlFqATvVTl3RpIlGDvVXOOqk0DHzG9d8FICee5jn1GXk1ihnDN9YZzE8L0+zTmaFL9u/LYSAilsf7YpZi9LYXzi3JJ2RYqjlu3FuTYp+Fvn/MIHpBCP743eRyPA/DZ/y3nKmU2jH0o8CfR5WVQqLwLn0wuyOQEEjvW60LWUA62YOxpKwH19uKqB8mXQ4d3CMALr8pr0YSS1t6zS3rtM+cbN0kuJicM2rplAcE5etW8TgdTCDuGifwRMBYOdlV4kbjKq9De8ScTzpf2d/iT4IZ+dfp4gYXiXVr2YIFHu4VhO95bhkZjNyqKMqCsXr/OXwcCNcY8lZNAU2d+25Mkww3NunO6SIanf/2xAtwznSjvCAidkWEjEyC9NUv1ZZPM/I4e14e5IW4Mcfdy7MQ965Lj4gMNjDMhRtnTUnEB5bO9qKTtSgVryQ1xNkgLjDjM9tkuBVawNDDe7Aqefm599dVLCeyioOtRPietM0VqHTYkzzMqunxUqtDi4HK5JhedG5vf6RhV8QlaKM8LUKMl9UztJqvFUS9ZNn1Yj23RcOV2kxk4+r0VvVFP/u5eNUr4QT9aPbcuGxSLeTBqzwf/4/dm/plPwISXdb//mwNxG/NAe0OE/u/poRw==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="524">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwFwVkowwEcB/A8aRIPiwwzTKMl2WRZrt/3LzThwRUzFBpF8mCFaJpzeHAlZ4tNqJnFXMU8kCSRGuGB5hgtyZWX5fh8bqoXktkHEeBFeqZIuG+kLvKE2ycPt8JsZt66iqeL9pQvQRPkAjdmwvCHfJGWGmZseFQoUbemY0yqQ4TH31BSMIsxd3IwkOGgVJeSKnK59OS+g071B1zNeoqWGKi8Zws1qXNkMIeT7+ksc2nrgbE0FyZpHgRRalw5R5HeZkJQ6zJFlRUjsaADNWEiKr/fRuahCFncKazUiany3sLYj8XY4cRgKSAGgbxViIaP0NjlDoXFQtfyNRIaY1F1JyHH4AYF956g/5WFsLM4CEOlZB1KQMZIArT2bTIPemG/NonGX73h59yFvMWCkD6CU7JHv5xNsJ5VMDPfNKYvgfUnDdEaHwwXyZA/LYPafxLs9QBUBebAw3VOo+lsRtd2QfrlQnp/6YZYxofz+4o00muSGvlYfNBCV18KpUIIB78atwv9+AeQdKNS</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="91" id="sample=1 period=1 cycle=3 experiment=26" defaultArrayLength="103">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="300.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.011561868436" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11080.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.1654" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="26"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1012.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1012.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="59.266887664795" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1084">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNzH1M0nkAx3HIM1wS9uDStlOwlpWllVe7TKVPDi97WIa1lkci8RBqhL8fPxFITStdrZYP7VaQGUVmtrQHwmvrySCKdl4Xzly7aT7A1dXtykxXirn6/vX64/3ZZ3CaS8haK4GMTk1vJs6IczgzqqRINUeOTBAXXwj1BtxSdG9anNv6WIrl3S1V76QynLN1Wj6ck+FGoaOjsV2GmY+4x4fZcoT+eKlVNkWOkt9yQhiFHIm9c7ku4sOee5I3VjlaI6dmigfkMGu6U9axFDjMsXY2EV+f3GacK1DgTsPT8S3Eo0dTrb27FcjeOGd9OFuJt8+bLFrim7bRraL5KoRGLRVXWFXwXN5wvo/4TP1ztdevQq1k6ukD/XswwPmTz7aqUepW7rcTewQJ8y71qRHcPka/tuWh8ts4LyYnH87o2N/XVeZjszKCYmwFSLF//r9NtBfPjC08H1+DbGEEu1igAS+131Mh2gfTP8dKY37QoogVQncotdhqX1Njdmvxueu9Tx5ciLGShvWeB4VQ/dvw3s+nYAjLb5sjoEAX/510NovCox19lZvlFH455f34vI6CvFo4wLdRWKn35y57SKHe3bFHQoybv9py0UVB+WI0eJI47FLh+CD5+ZUVs9BHYdIrvLuETQP7QgoKiGHh3W4zkevjemUCGuXORdHXEml47vrTM36ikWjQii8SI8Lr799LoyEM2mCL15H9q5KXt+poWC0rWU4X6SqKmr1bB09eWYuamPC2IG27V4emk9fj00Z0iG/+S1ZB7BrJfRk7j4H4m+QrrWMQmD1pvn2IwR3uq4b4TgaNUWV/GIm9jZywjEEG/oCjror47sRHQ+wwg5okxuL8xCCJ0/PfUFYRgo4kMzJfEcTJm1Q+gR5nnFemCc/r8UK54ur0W3oMzdp1uHxAD9btTN0WezFKc9Kb01YYUHOtjL//pgHHIp7a64ksTbZitd0A3vbMnrF+AxKctcm7bhqhMbU/qSaGTsTtXOU0ojDIIVk0bIQ2kGNSB5mQrsn7Ul5rQlMLb5Y9sQRLOV0LAsIyOMbF6vb+CmSJpBkTMw9i1JhkE0UexHePQnJi</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="564">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBnAFj/lMHYUAJCmFA7EeaQv0tbkDkIu8/miXvPziu9j+6jvg/qvEbQT0VRkKwDMJApRTEQLC5AkHTcqRB4FeVQ6qfz0Gz4gRAlExpQaClJkHRNIZAgZnuQFaFzEC+OVJBmDAxQbrlhEF5ZFpCrq0IQgY83kA+KpRAIe8UQYtOF0BEhplAQfpmQc5SHUC0+8ZBUN81QaCBckEMnJpBRgOnQe+V8UHGov1AXK3+QMexVkGy1QFBFx4tQOAsrkH9f65AL50DQZbBcUFcjVxBT3IwQB5+MED1fzBBjCAxQMBIx0H5xbFAb45NQnFWhUAdryFCLHpfQe7XdUETzTJBzn7JQfYQNEHoHJ5BEa+1QG4F50G/ngpBhT4MQUyrO0Crl+pAjLdrQUGkbUH1B25BUejLQTjrP0HXKRBBtioQQdVzqEEyjEBAN1pCQWMDRUBeKUZBIXtIQUDSSEEcpMlAVF2AQWXCgUGdJoNB1tjRQF+9xEFS/B1BejlWQOvWSELM3iBBTnohQXWovEEJSipCzoSMQSAkaUDGI9tBQOV7QbYOPUH8wK80</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="92" id="sample=1 period=1 cycle=3 experiment=27" defaultArrayLength="114">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="272.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.011561868436" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11104.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.167083333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="27"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1037.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1037.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="60.829540252686" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1208">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXtQ0wUAB3DGSzjwOkTEiktehdCRGRdmJ7cvyuKhuGNgWIONbUxw4/H7bWMPZicEmBdIuFgSHowUaBkcB42jQ3GwTgxJ2GgjbcpDqB2nvEYPCIV+n38+xru34jPobAT4NHJpRjYYWycj3qviwHa+++UVTg729MZeLjbmIKthIbi8mYcB3Y7zDuqFzp/j3Fz5GEhvtbwI4aNt5AqHweFjpvarpWoBH62HV8ZfNPHxIyvr4ZiOD2eXSMqe4eN0pdf8yVk+hq88+b7ORYD28ITMY8ECRIvH9Q+oJy3Jm06XXKDPLHojTAjaH7rln3RC5HsHXX9mFCJ3aPP48JwQFkPsOmf6DOwKc1bIzBl4PLNmpoTm4VrZYHNvcx6cqvlItS4PtQferAq5no8yd8agKPssyMAgyaHKs1Dcr31pkTr8nH9fh0mEx77z8WN0MZojHNyOBDFGA3fp9jLEaPM30N+/JsbmWEjiweACiKoPV7yKAuC4PepqQiFeCxCKzaZCdPEfmGdzi0BzPj3l5VEMtl4eXbOvGAbTzS5xeTGstyq2P7ldjJgp63wXjUBTa2cBl0Ug1SNujsMnQNDjPSYuE7gXE+3K0BAwBST+nTpIwB7FYZVSm/vgWDIRiK8ZXz7yKwEmu3HgBI2E8gd2UX4wiYLcU0MfxZDo1yZ6+oDEo+zn6vqjJAIbvbx7WCT0i8qa3TwSKbIm5eMWEm3Maa5LD4kYh69xp4lERxYr4g61dIR7oGyXBEcyIitM1JPOrQl2qAQMTVqkgdpTf89V+w51d+HKuzwJ2l0PbawREmykfHfDp0yC2c1S4hWNBPvL//xNvyrBWnzn1wGhUnjN2RckOVJYP73gbqdmkiPrwxopLL3e5lCLFDZebHItdcjR6oagVSka/AzrdQdluOj5QQGRJoOFbtPHpcvQ/vseP0OLDKM+evlVowy3P/7lef0TGf5peuvzh2kl0DJ6fe9MlEBtrd+otMjBc3z2zaO3Ffhw52a2m1SB0DX3b+3dCiT5791vHVLgxBiTtmFWQN55P8ZlRoG/olYvVOUokcTUtQg1Shi0r39Z2K0Ed0l97AZ1QLgtct5PBfm/F8X9LBWmuPtOJ/BUSN2+m9n/hQoZk0kOjzoVdqRfKhJQX9KKaMs6FXb/Z3ta6FShx3c67KZ/KZyL26MCXSncEpOVpjA1SmxzzVtT5/A/9Q2nZA==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="624">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwByAE3/oPGqECGFWNA2TdXQl8tGkFOgflA2ul/QMLs/z83ySlCbbbCQPGlAkHsZqNB3oeDQLb/k0HaW1ZD1XSEQJ1TR0FE93lB/FIFQD9XCEDjOdJAXHcAQqAqDkFnFK1CTCL/QavMkUDqnpJAJScUQVg+3kD69uJAtUrmQDI6ekFy/WZBy4rsQAUhH0FFVoFBileBQRFPSEFunRxCfwaiQOnqJEAATSZAK5LHQa45VEFxEKpABhurQI3AK0GAeixAGCuuQJcg2kGMW1tB4I4ZQmCO3EHLcrBAqn8wQBKgBEE6VQVC0c4FQod+X0E7SgZBzhozQFdus0CVygZBaQE1QU5ZNUFVmxNCKEOIQecV5UF+RjdAFymVQSCXN0Gt7QlBDfIbQq4hOUFgbTlBycc5Qen/AEK+kjxB0sQ9QfPGvUDJuj5Aq+m/QcfwD0HUYhBCzUsRQQ1TQkHAxBFB1L90QR9fREFEwxNBZA5HQc1kyUAp781AyZtPQTKSHEHO2VFBbJgdQYxjUkC2JfpBMAiFQTez1UDGcjtBRawgQQPWckFE8VhAgi9ZQfL12UA091lAo3ojQQGsI0K9P4lBtJeJQV2iQkH6cChBUaRnQaxMvOc=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="93" id="sample=1 period=1 cycle=3 experiment=28" defaultArrayLength="103">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="225.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="12917.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.168766666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="28"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1062.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1062.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="62.392189025879" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1104">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNx21MEwcABmCqBsOoTqBMJwFKZdoEI8PWOcTIC6ISMsrWjRiCFHp4QEM9e73CVaxinVUgKtQSjDW2bPgBIWygDtRlFiTdcG5Riw41kLYpGy6muFHwAyh6v5483w3MRnSbZDAl2H2b0wvxija+TTIpEJMhT204rsDiWxNTPzsVqJOunv7GUYJ3seODszwCWx6vOvD7IgLF5vq3YZkEfBKv9GgpAW/BhZFwGwELe/LZAzuB2C/8wfBWAufjxEUyD4HVK3NGApxDfzqs/4SUYmPS07hNwlJUvJhf6OIceDQcdChL0Z7ZfDeLtxeft7tuBEUkHm99fv25nUS+dGGixkHiTatEfNNHwn2+gCoeJ7HdRfV6F5cheUPeo1X2MuQ4B/2V7jLolktHR2zlcPiCqYnucnyQEl0d0laB13L+9xRn/YnQDff3qJDauMJdckwFycF/la6sSoTlF2MyXo1ZcqbhiFCNNXOJg3EZapz6SG9PV6hxKTJtXUXWPuR2jdGtnJ8tm6tNM+6DsFNvWbaEwqEaFePeSyFOkBetJimMvRwW7zrKPfl2Y6qJwjvbk4h7nLaa7KdrnRTYfhW1wrgfzshzI1M8DU5/qhzOJzQgd3h6Us5o8GGtzR/Vr4HF8Iu1jNMc1tIc79FgaNi/PptHw/Tr0igD51pBh+IqZ/flv4Y0ETRO0dumvxTS2P/3xLwxgUbDut0DBRIaDxotVkMmjYud4p/4Whr8juPqs7U0rmZPTTrMNJbXy2xNP9JQSETXIpRaOAfzWoRGLYr6ZGHPzFoI1u/gh1q47xbN1AW00BpmNZ4EBmlrQnJZEQNym0AuyGDA5OZfS3nI4A9K1DvqZfBxbMy94H8MNlubvNFTDI7lXH7d26pDb/qt0G8dOtTJf4judOngqyppbgnoYJNS1y9KqnButCjjk7YqFD6c4/f3VEP41YuFIVc1mpT3rZUhLGZ+i0n+msdiodOZ+CSFRd8mTby8jUWHqnjlEg+L+YDoQneCHs7wMZbs0SNQ7Z/u4twZ+r9acEcPcbkl7Yr9AO5udBeesddAKFO8rIoyIIdO2rpn8hC6+sYjJxSH4TRXLm13H8F774Z3ow==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="564">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBnAFj/guffEA9rZNBi6MgQ+0vbkBoJW9BiID5QIJWXkImixFBdkGCQMS4AkEQiINAKY4DQLFWxUDekFxDXK1GQXnjBEAE+UdBZ1IFQG40hkCS3RBCBDnSQFd3AELCPdVABZirQtZ1IEHoB49B1/wQQDzKEUJ4wHBBOI6nQakivUAwUBdBTYWZQFqdI0JtVgFCRS/UQf0WSkFnCaJA2FwiQU/qJEEOTpBBYJUlQeMCp0Aw7ppC9RCoQe6Q/EAhnfxAZmooQXEYqUEOGqtB5FwBQSPgAkHknoNBWlSEQeKO3EAXGbFAMjheQVOrpkG7VoVA9xqyQfRP9UHjbjJATXKcQVIaM0GTEDRBRVa0QBZoqUHRTDVAUQZnQhPcrUGHxjlA9pKiQbXBjEGUkbxAfJQ8QRorPUHI5G9CmDpAQZikcEGtZhBBf9kSQa/qXEE9uURAgVRFQDYheEG7qnpBnF9NQAy5gEFgws5AccbOQAygz0CHmVFBtyarQebGU0FIqyBCnwJxQSyCVkHNOVpAA3FeQRxu5EBI5DBBsy8yQd1wekCn9Ka4</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="94" id="sample=1 period=1 cycle=3 experiment=29" defaultArrayLength="98">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="307.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.011561868436" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10980.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.17045" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="29"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1087.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1087.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="63.95482635498" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1044">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXtQywEAB3DJTrnzyAlt0copz0zRKeFb24lLXYmGnZ89a9Tqt99v89vDY9JOznmsjhTX1kRdcYy8cteSR115lMd159FqyTPiTF242OefzynRbN3nwlT8EaRq+GtEeGffXnHUJIKK5KhMAgIj5zjXA8wEMjzu878eEPDTFBG0U4w+X//n1yokuMue8og1VoqSzqvsUpkUswbrR8bZpEheOH3j1h4pUgyP9bFjZIjj1wk7vZ+cSr0P58owKS0yf0KoDDuP142wfeRYpXK3bvGeWUVoLlgV6Csa2dfsUiBGljL/Rp8C9oT1VU98s7Av2bFU6MoCoxF2N3qvdo+u5YVl40r1opeeimwkX3p7ItWdjT+tnBNZ55SIFJfmxRfuxB6q5mG1IAfCXY9US7i5sLSU3q/j56JtsoWQj1PBMlOa+IWvQlfnsrtGgQpxofSTvfI83ImpS3d7921wJJ0Oy0drWXlSS2M+8oqGHBd8SIyycrZt4JEIp+xYLiWheHUmxGUhYWEZlIHFJDKpStbiJhLi/B9GhXenIdD8r5tEDTFxkcRHjb9zM5WJAWq81CeuA1eNi+0lr5eHqrFloF+REa1Gl/XgcIFFDb4xiHwaRmHWVTaHI6HAEpV3RNkplB9py1jZQaF50tH6/T8p1FJBYzYH0KjnEV3hYTRo48ASVgKNwSp1f4eYxtxAJqqsmMb4hrMhc2w0hmO5ruhOGl+sLCvj3UOs1sl/0LDG+b1Ns2lw273ims2pwabdp9mVPzVQt0eYz6drcXwXWzxhoxZvGv2Cfku0YAtX1MyzaRFSe7O88JkWBzycacNcBsH33rxu5TGQp1xWticwoO4Ebz9GMvjwfcZTPweDptF6S7z3xHugr7sYLIhKs8dM1UGW9LEjyqFDhC3aUup9rMO1o7lXhyZj98OGKXr4J18q+HBQj62Dyj2rrXpIhj7d+sYzQHUoIWaHyYCTJXqB0GpAT+xCkbHYiK8vvkempJlQKTW7e7NNaJnd1vYpqQDBxe+dkVYzPI1XHjjLDuM/g5phkw==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="540">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBiAF3/uZnKEBn58RAZRXiP3ktbUDQwblCloUGQbGB+UAa859AUf89QnqX3EEIjwNBs619Qz/hhEEv4wRBo/qVQTeoJkG8me5By1gIQNMwMUIFZSBBX8SZQreL1kAur1pBgssRQTzyJEHrJ5RAjfqUQCP44kBB+mZBusZuQeWCEkLAzo1BnDWkQHdd90Bu6iRBjRNnQT/NDULEGKpAlUmWQeKYV0HrdK1AgX8uQYl8r0ASjplB0YXRQU9yMED8V11BzRxTQjAaMkE7zoVAV20yQGz4vUFBhodB2rEJQe63oUE6GDpA+j2MQXusO0H8Lw1B/gClQdAqPUDBxj1B6rm+QOA8D0G67KdBavAPQSGFwEHTykNBakcTQbNURUCFDUdAIZ66QbNZR0G+eshApGPJQMeUgUF6tBtBiu0bQf230ECmJYNBZGEdQXP7HUHygtNA/jhWQWeWDEI9C9dAYeAhQaJSI0EPOFpAynglQfdypkAu7ZhBZnuNQQtA9kDE8fZAA+yiQXa/DUFOPZpB9WCt4g==</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="95" id="sample=1 period=1 cycle=3 experiment=30" defaultArrayLength="112">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="159.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10820.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.172133333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="30"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1112.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1112.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="65.517463684082" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1192">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxX1QkwUAB2A3QM1jEB9dh+5khR8kVPNQhjDkB2OIRzcc60RYEoxtiPtge/duY3MzuAYKneHgGGnKaCoW3UEzlDulADNQRJGLI0RrIElwxDVYhyB9vc8/z62lkGsNKWL0z6wekqYXwE2SB+KrCmCP2nh1Y3UBNsmTq4meQvBEr6suNBch+dRY4B80CUb2nwvn0yUoCTLvc1F7J9xLp4olGBoaau91SlA0lZ0rmJSgXc4RxLOKkfkJeyWNJkXFVfpd/ygZoqxH9nQ6ZSi6x9jW1CJD8NO+yiMuGRRNBY/Gp2VYPyX0tPjJIVVouD81y9G/LIzK88ixkDbI+qW5BPy/XnxruHQME10HDU22UswHMHO1ruP42sobfA0K+Eu3t7anK/CsNpMzG6nELu54ooOlRKA40DrKU2Jm9mH1W4VKfLmj7oLYXwWbLnZKxFehQ1y+NOenRnL4xQfSQjVU8QHCNaka5xfUK9kyNUZBfPPSpkZVV+wBs0cNOvfnrpnn1A2WTyMqy7BUvdgeQddgf2tEuCRHA7ZPVHySWipqNedLNLCunVxNqNfgi+tb7qupp08su5NcGqxGrram9mqwe5P9YTZNi+gtaqaRpYUlX/tEEKcFb6HxvCVNi8mttDtBhBa7Dw8nO+xa+E3erNhzWwvr2D9LE6EERtsY1ao3Ccyk3n5eS/1BTPiHDB4Bt4DbvFZIgBCGNQqKCMi66379iNqxMiDushO4E7x842/qGkbCWlY9gdPH9/ryfAREpuhHn9F1+J4ZGVIRqUNlSpm3pl6HmsO9y8wRHeaFCY/l1CO8rU3DXh2y+ERQ0qIO+dGO2jPU3ifcwH/fJTFtFXvmKkgc2ku842wh4eWlin/sISG62xZ3v5fEdlX3wK4fSDzNiR086yFR+l3BlZBnJBx+tg1hPhLjAYz/xoP1aCxlv+C8qsdYBCu2J06PthvD3ld0elyO5NiFPXqYh4wLmy8ZcP3juvXSEQPKSXbnBN0IQ+bBzkG2EW+XPfic3mCEK6vfl+M2Iual6dzOa0bUddw8HdpnBEPIo816jADz/ZJSdzn+VPhXZvSV43dTHCfxrAnbNu/w73aaIExlxzzuMCFt7quMdevMuBJmc+almKHN2JCU6DTjvarf9imp7wVLqyRHT+BWrn7xGN2ClfTLoUffsCDjzPwAX2PB/yx8jWo=</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="612">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBwAE//uAIYUGUaQVBpEWPQlmiskAgIbtAoOr/QN0YiEJoXYFAkV6BQLi4AkG7OOZA8WY3Q5n6lUFEbipB1C8vQYGdFkI2xA1B08mNQNqtcEK3B49B+PuQQD7obEGJMTlBbfjiQCPuAUJuqIlBi7LuQIkOOEIVf/JAZWfoQRDPDUF1YiJBRFD2QPLsJEGAAqdApgNSQepTV0JKGXxAE2ioQAphqUCpcilBnVMAQbp8rEAYK65APvFDQVBQxEHknoNBon+vQCzTL0AmVYRA63FCQgfPBUGuGIZBB7ecQZkUYUGi32FBMkEIQfpGN0FnsAlBCH1lQbg6OEEBtyFCFNO4QCXUOEDZxblANMc5QcHIOUGWq7tBZPkMQWdkDUEIaG5BCe+PQInxA0LOgkBBUFuEQWOGQECQH3JBjzVDQUfMQ0D9d3VBvGTEQPdvREEg9kRB7wHFQBZSxUBp2UVBJ9vFQC4ieEHhvhVBeU37QU0dzUAgEMFBUkCBQe+OaUHq/BxBr2EdQRRknUH0lR1BeKXSQOn5GUKwflZBE/jZQEk6WkG5flpAldLbQL/dXEGPb15AZdQmQamEYUBxmY5BYxHIQXfm5UBPC73a</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="96" id="sample=1 period=1 cycle=3 experiment=31" defaultArrayLength="99">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="261.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11758.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.173816666667" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="31"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1137.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1137.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="67.080085754395" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1048">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXtQywEAB/AVEQrJ86LHTtzudLLpkIvvteZxVJrMkNRv/TI3236/33rMDOnpomTaKapFsRznMaeljm7p8qhjQzKPk3l2lVhy/KH8Pv98oko4ScEFcXCveSEsWrsLEb4Sn8KYZNhbpx7bXpCMEsmVn67kFIg6puVxPAmMVfx7f4b9T8s4OkVGYHdM7L5m9iZxkvOJiQB3C9m9uZdAdVv4Bf4HAmELyyqFHBnq1TazOFiGjfG5706lsis/x670SIPcLZzr5pIYPOn1qdhEYrS9Tj/AXjr6WGj7SELUK98+37QXmhu22oA6OXJ7vNUdMQrE9iXuWBq8HwVqZqi/bT+qA+6fdxxVok97acLfNBXsfc3VgQUqcBKrymZ7qTH8OpNDp6rx5RolLW5Xw/hLft3Tk8LvmqCKTUEUCrsVY/fYdeZl1aZwCivbh65YxRRSzV2JGQSFcQaBg2OgsKTcxyhkt1vx9XsbhcPm61qhi0K0oG+6hwcN3iCvIYG9hSR5OeyF3uHppX40iovSjYtDaEyS9Ebk8WlQ5i+hUQIaU6P0Q/XRNM42nVQohDQaL/hEJsXRGKH2KjpVNAYCR76bcmi8Wm0+e+IUDX6VP+fWTRq5PLFsm52Gv+5P/tUZDMKll4yVXAZbxyZWNfMZfOa6PAdSGAQRl2cHpTKQXwxdMOc0g5Y3y0munYH3g9L4FgcDpVF6ueYHg7BBu/9TNwOnTG/8G6JBvCRiX0OKBtqAxoFAQoOeeYc21Bg0cEp9161yaNB69E6klf3l3Vl8i1uDNzPGS+4nZOBFAnncx5CBDkFCp8CVgSVih8i/NhN7ahcpt7IjtMPP0pqJFT3pD8/xs6DMfx51Ii8LEl75RaMlC8POf9OKbFkwdB9ud4Zk49Vt309EXTa6bBo8u5GNqzvTbk/qzUa/1KISybSA7tvw+ptafJzp9+4a+6P+BaLJFi3WVcRYp5QdwHvp0sJR0wHU3931dXy0Dl17vJujc3RoUonkSa6D8CIbrSMz9dgS9/bcirAj6NysL4lsyMd/38FlTw==</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="544">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBjAFz/ntoqD8hnYVBqi1tQKblt0IGrvZAINQtQl9eAUE1FERB/21UQVBVRUHArHNDcnSEQD8neUEyo9hBoU3JQCB5O0HqJQxBicANQQzCDULrrpVCgTI5Qef2YkFRSYtBYPq/QfN7o0CIYvhAJUyDQnZoqEA6yClBGcQqQa/cAEEvXQFBvBktQSgcLUCpdi1B7ywuQJLgAkFPfa9AKoekQap/MEBSJDFB+VMFQcDGsUCNqyZCvRsyQQ1tMkHZx7JBSX7fQWRUBkEpHzNB4lezQIv/YEGYWzRAS7M0QsFXtUB59DVAb0a3Qb2Wt0Aq5U5BJNG4QLPsT0G5zDlAD/06QP8EO0A6nrtAEqm7QIxtDUFbN21BJc29QIe5vkFC43tCW/EPQeeLQEGaVMJAEYfDQFvz6UFCekhAhHtIQbcMSUHbVRhBmmoZQWJjTUHzpk1BaljPQF0zHUFa1dFA16eDQejlVEDW1chBYKygQSUEcUFN99lAHYL1QfroXEFV7l1BB6ZjQDV0ZECetnBADt4bQgYIpm4=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="97" id="sample=1 period=1 cycle=3 experiment=32" defaultArrayLength="106">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="268.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.008112838187" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="11763.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.1755" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="32"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1162.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1162.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="68.642707824707" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1132">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNyG1QkwUAB3CQSTdbN1C3BVkMyiGYMEAO4zD+W4B1Hnc+kOCkfNnYkJfR8zx7cyN0MwZBCIJpIpfMSDxNPYfjWB0CzbI+IDAoga7aixQgvYiTUyyi59Pv7rfhw8XUZyX5kN2YyhRmFqFpWbVlg3Uffpf/cv0Ro7Cs2bxqlRy+4+pbPQo5prXbXRMdctxsLM/5wCbH113bRG955ah8yrtNBCmw05vzn4NRXdva/qZQgZe6s7PTocD8p+MRK0HFiP7Cwu3tUGKHlTOdPaZE6UJh9NA9JZwktzp3Wgm2j/DYQlRYOae/3+hRYZn1hj85pgS7iAjZ0rkSXM65cFfkL8FrXyXPoPMQlthPoyQ1pai31MzOflaGFXZkxmBWOZof7JJwjpXD2T7ODRVWgPSR1yJdFaDaL/d/zNjTOya+wVLDs/fn78xZasyL+ycT5Grsrsr3eIsrwVnkfyS1VmIuva4/8E0lFnM5Ds3q97BmSjS8VUwibrxJOtlCYjQj6eV/GVn7c9KebyXxeWdC8JCdxIw4MeWVQRIL1iFVEeOVuqFeu4tEacHDguRgCsKjEcNKxm3eu8tdjC/wNl6KD6dwlsidKxFS8PpMwYIUCmOh+vsSxoJGcWQZo3hiR26elALXt+n0KcYn5VfXp7dSKJKtf7LRRcGwr4toG6VQFhYi6l6gcMU92edcS2Ndw2+p78fQeHspOzb2II0DLSecz1A0pj4p6OZbaIQK+LwfW2iY9swMuFtpxAb6/oo/SWNMMbA3aZTGYyPHQrppHB+5St0O0CBYhRV5MRoYTtdd/B4axCX96bYd0GBJKhkQHNTAkZzSu8WtwRlB9ZepCxrIn5vb2WDTwt/vDHQMaFHfV5XFGtfCxG8Oc3B1OLLdlX+L0GE5lZ0RYtNh7k7t5tWdOrzot975NUgP/x6++pBdj3Wn7H9ccOtRfS1KOSw2oNqb8G1ongFR6a8mxJMGzHoeCGpPGtD2Q6KKZzfAJiruYXuZ3yzc+hNxGBn/yNK09sPgnb/udpiNaCrMNBAnjDh7fv7xSIcRNRPhDa/bjCDy1sS1MR41j0jvhZmQ+Mgil5lN+Ds8JLpLU4UJW8o7a/1HcDMwWK87Y8b++ncrHqYdw/+a1XwL</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="580">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBqAFX/u4qPUB85kRB3x1UQpotbkAAQVZCyhCTQXU5ZkHGkINAcm2LQ0jLnUHM4oRATnsJQi3ABUCqbapB0TbvQYtmDkACtaxCpXUgQTsHD0BYPbZBNu1bQTytpkER+hRAafdiQV38GUEzqURBiiKpQdjhH0FbL9RBoHmjQPt6o0B7NiRAn+qkQCk+JUCRlFxC2WgoQUf1E0E3rX5BQRcCQVd8r0DTfC9AVVXmQQQchEGHm3JBZ3KwQMGOxkEqjf9BtI6bQcjIMUC1GTJARFB1QVUjSUFtGAZBNMwyQCgZs0DOr9RBpogHQfirNUFJc2NBjJ62QLp0CUEplrdAKUUtQhEiuUAiz2dBZzhoQV7LOUAczTlADL1pQYsDO0G3rTtBGZS8QT3fDUFzVI5BHMi9QC7um0LurvxB3L50QSjr3EGpb7hBN9nFQZNKlUARekhAhYfIQXOql0HKWoBBvu/NQGabT0HkL9BAP7ZQQXJT0UCD1lFBuKeDQdKZVEB8BKRC3bVZQXe5vkF6OlpBPa0jQfY9WkHsGVxAme5dQVXg4UBmvJVBT154QXIdAkFAN7IS</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="98" id="sample=1 period=1 cycle=3 experiment=33" defaultArrayLength="100">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
+          <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="151.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="151.009837348388" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="10374.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.177183333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="33"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="50.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="2000.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <precursorList count="1">
+            <precursor>
+              <isolationWindow>
+                <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1187.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                <cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="13.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              </isolationWindow>
+              <selectedIonList count="1">
+                <selectedIon>
+                  <cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="1187.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </selectedIon>
+              </selectedIonList>
+              <activation>
+                <cvParam cvRef="MS" accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+                <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="70.205322265625" unitCvRef="UO" unitAccession="UO:0000266" unitName="electronvolt"/>
+              </activation>
+            </precursor>
+          </precursorList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="1056">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwNxXtQywEAB/C1pCKq2Xmea5KF1GULp1vnW1Y67lw5ZdTq55dFavr9ftv85LET4qik3HL0XqlDJI/jpqSHPEtxMRxtzfvkMI8Kze/zz0eNqPDoZQnwG+mRl3MLg/KmEfIkeLgP75uck4RIy9u2oINJIIo8BhYmEzjSFzPO10ogwb9nYAKfhNL+Z+aIkkR1N8/+sYLE6X/jpsZYSHxundEOK4lXyW3NobwUVAmmXJgqSsFVj8orTRUqyKIdtcsqVQhXCOvv21RwTxcmzHujgtp2/WZqfyqeP5PENnCH1CyP4FtSIRWO3vhbvhmy4X6euHoLnAKmHyOVaZjflStcfiANfpRYvsG4FcXNu8QP5OnIkbWUjhdlYP/OsLGGMWoo9A1da+Vq8OmyXes3bcNQvuvoT244mV/IXDKxauKN40FzMvHd6CZ5np0JU+uXvtV8CiuP3h4aG0xhrqZgUEFSuOm5yBpSRCGeqXIJvEXBKcO/1N5GocnkaU12ouHIDf9xkluan5W8QkQj0ksxckhC4+GYuoIB7rzfZ55kSGnUhrUV10XQKPQazLPRNOp5NV2GQhp7Oj4VL7hEY7z4d1qJgMGHNRtLOriPG+xLuyUM3GR3CmdFMPAtW2TtJxhI4t0M7hsZxA9H+vtz9zYUXHelGSSGLpa3FjK4HFjKm25kUG5aMp/tYeAc0xhC2Bno9rY3T/LWoNH92o9QXw2eOdc8HIQGiril9DpCg4THxGhskQYtjvxOea8Guoq3ghzuDtX71VHfNIjzcT4vZbSoSTeVmSu1OHzZEWho0UK9hu/dx32Wt+Pe/ltanP5bbVa2akHnvhPqH2mRtdf1fMlXLX6FzZg910uHlPTQp8HBOtgD6hI9SR2a8shwnxYdvvkKUk9ZdHjJlAV0xm4Hn4r6WdC7He3dh4keEYsYpSDo3iwWtk2dyskLWbi8tpk7wcKUuWDDRIpFVPbdmUPc5/ZcvHMwm0X0CTEjLmKhs9yWJhpZfKq/b1Y37kCSqF3m2JeFYiPRG1eZhfe7H9tqffTw8yb1VdV6/Ae7I2NA</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="548">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwBkAFv/ugH4T85pgxBFi3tP329I0LtorJAp8KKQdJ7+kBPsyFC+aSCQKWOA0JpCjRDvHQEQOIujUHs+EdBjp2WQW6k1EDWZCZChPFVQF+v2kCErohBYcwRQAY83kCz92JBC4cZQR08LUGEUp1Ai/tGQY+qIUIjUfZArCROQfQNKEBEkTJCbMgpQdUfKkAwHCtBT32sQVXQWEFUsJhBvH0vQtxUBEHDf7BA16qmQV5WhUFEG5xBdseyQEzJMkAbzLJAZFQGQSUTYUEbhgdB2QOIQUp0CUGwRjdAmuVOQRI2uEBotiFCudG4QM2dCkERIjlBrTdoQQqeaEG0/jpB2JZqQbg+PEFVAaVBfckTQm/EPUGPuL5AZeq/QZvrv0CSdKhBeu9CQVDAdEEDR5NBI0gTQWRKk0FyZ8RAPKrEQHhGxUDd2kVA0tQUQRdax0CTx5ZAE6XJQYirS0Fb781AxVPPQBiCG0GonE9A1uJPQVKIHEHUuVBAfgNRQVlNUUBFldFAoXK7QcYXiEG0PFpAB53sQCmh7kB42akr</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="99" id="sample=1 period=1 cycle=4 experiment=1" defaultArrayLength="6820">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
+          <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="3649.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="395.090204995859" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="6.55162e05" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.182033333333" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="360.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1460.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="61048">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>eJwU13c81f8XB3CUjGRWSgNpyEhmVHJIGRXCNyk7pCH77o1oyE4q2RFlr4ysRMuOFJUtslUa8ju/v54P997P5/N+n/M673u1pP9O280igOK1+IIHqNgcX7AxmwBhO+zvvEQjz/I/8OQQoDW8Ypt4IAHufv3y/Rr6JGjQb38oAXaXb7XsvEWAF2V/q+3DCeBKXYzOR90WhzXcIghgWrdetBY966t13TeSAF1DSXkCUQR4Xic/O4T2KUx17YkmQOO7yp6LdwjQeexwmOJ9AmwT3LRiRwIBUslefRsSCTDBnnOxQUUkei+pJxFg5VI/MQclaThfP51MAHeTyz530MZTlW3D/3dqndyhFAJM5W85r5xKgHja+o4a9Ob9CiXGQwKUFsXbOWYRwHhyuo0rmwDE30Jvs1G/vM2K/TkEsLr17U1qLgGEYm1KovJw3/SwDPd8AtRr9M9KFOC+eSv+eaAvTjwMnEGN3Z9ovCokwN49szwHiggg6zN3XvcZAWaapt5/Q+0LLkYZVhPAkzHQno4+35zat66GAD8PmzeNo7TogccXaglQc47zm1pHAO5nXYSoegJsbTn9cb6JAKPb+zWqmwlw6LZY3O0WAhgOPhbd3UqAU17PJt+gWfqk2XttBJgcKmm3bMd1F3pve4KSCJRO2Q7sX/306iR0/+reQIFOAmj1T0efR/Vv3Whs+IR1lWyZXv+ZAGM9O8Zp6FJRcdmJL7hOy+9aH9ACxTxJ+36sU07i+2xUq8Fez3OAACVFQXbygwQ47uaaVYxKGv7N9BglwKbpP0NKUwQIV+Zxq0FtaqoiwqYJsOpesfMyWm53K8lmhgDjLV2H5Gexv49jwz1RuoZSUhpqkqK5nTFHgLjT/rxD6LURLp64ebzfw2fzL9FTRCm9A/8IcF7Dtj14mQD3D8uf/onOB9hyWXERoUK6sXsczd6xpsaXmwhPp4+dKERbB5em7HmIIDxuUzuLFs5/bYtdQQTrjn2qRWuI4C3spGgmQoSLD1fnrRAlwocTnQ430Do33+eN6CvhEo6aGBG8vkXkCokT4c9VgeFrqO/Vh3uFJYgQ6B/plYlGZOzrDdtAhIO6OvJzqC8x7xVxExGua6o4220lwnDd4s6faPZY8Q0raSLMErQNQtFE5u82LhkimNRHfKlCE9ad/3lclgjTkd6/X6HzVy3uJWwjQtDHljR5OSIU7fP5dVPu/9frzbfsIEK13ZCohgoRkgU1Pg7834/DlTv2EqE73O2fIXpFfGX2Etp1z8z8vioR9jpdm+JVI8LHh+qRfmgnPPqmro6fj5L/+FODCHH8kt9PaRLhJq+Fe+VBIpw7WXnRUI8I96toSUlABGlKyOwafVSW51kFWqx11nejARF2meipxqBRHd8L29E00YnC4MNEUOVNv8hrSASRy+vmDqJfXzr2rDxCBDWl9zFsVGj8VpOTMdaLt/KZjwkRnj3gVf9nSoSHQnNvFCyIIHVvc9umk0To83noUYwqr4sf3GaJdQzlvRGLigi99f2APpU+l3nZigjcLbaN8tZEsPBTXlL9jwjmg6HHR1Hu7iT5ozZEyPq0ZrrFkQjks1u1xZ2IMClt9DgR9XxBkdrjTISZF62lcahxefLjaVQ/tFJgvwsRahnHlu6iu+SXSKfOEWHN27PjQ6jiHe6vTq5ECLjMadnuhfepeKJ8Bw1d9f2HoDc+r+OAQxgaKNez7rIPEao2HbH/gSqduz1B9SWCrZvs4EY/3KfO0+9JaNErYcISSmE/tKoiEuHEugPvHEhEsPzU/cOLQgSFuGf1vDTsh+JMgjXatubYOVMmEVwLTn6fQhvC3/zJYmGfHzs8tmJjH+u2nTfhEOGn4jXpCfQCr42mWyARXnwhXF4RhHV4z90jGILPrVj7ouUWEWS4N4mtDSdC2FxJTiPaMtI7ciqCCM+fx13rR80aIo8+jsT+iGTrFEYRobLtYal8NBE0xNPur44hAu/QnfOCiUQ41ayvG4caFHMfeJlEBMISt39aMhFYWRGrf6G39pXHPkzBeqr0SUqmEqG8yb73A6o5xrlrmoPruOWs3o5K5jQK7c4lgs6mfb/iULGd2vfG0OqL1fab8rEue9pvvkEvBa2+0VGA99mz9r1xIc5zR6Y7tRLnfVHIsvwZEfii9Rdzq4lAD+bVeF1DhGOtDd90a7F/znWX3qJsp/UF9Dqcw4dl1Am0OKtBbKmeCDymJ0k1zbivrLfOOi1EKODb/OIVqvSGea+5lQjudhlrDrRhjpuafzxDO7ZvVZRrJ0KZpszPB2hoYGfyjg4i2Lx7dYGJPjqd/lfhM87Ho45T86jji5UrP3zBc+KvjJpSP85jDm9wCfqqp5F34wARzkR68GSg9R95NicN4pw86UgWGyeCaMHAXdUJIkTf9WjQnSQC8dxb5dQp7G86t7zMNBEE5wQf/kRVs9cFjc4Q4X1B0paDs3jd2PLOtXNEmOilLzHRTZXRRufm8dw7J1SaiOa9/rU49wNzJp9pF7lEhFIdmlH6PyKks8gklWXMjfmQSz9q2avccJKLBHV6NWE96CeHK3lG3CTYBZ/4TXlIEBFaNDGJ+n08HeW+4v/v77XjWU2CmPsdhSnCJHCvmsr8T4QEjAs1FTRU3UNx8BtqMVN56IIoCdZ+P0+ZRAPMkjzPiZEg44WC8Fv0Vchv3jPiJDh7zjatHF2sDr7kLkGCvlVt11q2kEBw7Jn29q0kUPSrPD+K2v149e+zNAlIvn9mT8iQ4B+9oS0W/fnhzQsFWRIE0qqcb6Ato+Pm31HlpQlLnW0k4HnDSTaVI8Ht7VraeeiN+1Fb3u8hgVJuq4uYCgkWhDL47qKkrqPPdu0lweu765L9VbEe9ib2z9RIcI+wMUdMnQRPxU3/uqP82lYWBw6R4PJxwb589EEp97lDQAJ2ukvISX0SsHqG3V+ikHpV/bMBCUznJC5cPkyC1HXKRtePk+DPBe95DTPcF2FFka45CVYw7h7ORFUMQFPBggRlhjK66ejvC6/9w09ivcgct7NWJLhz5I7nOJqgV5a8xpYEIYsaXix0x4d9IyscSVDRx5d40okEEwq092LOJHh0dyGiEO1rzEmXdCHBGReXiS3nSPDsqHZpPnpi6dErK1f0bu9utSskOLVuN9XciwTkG6fr+1E+6V8aTt4kOEDrbHuH/li6aHzaB9ef8kOqE32XNJ9i5ot9Yw6RtvqRYCzxZWU76tD1QvaKP+6v070omkGCfLf+vyYsEriZx/V/Q3mS2so92STINcj814rWZvmXHeSQoOhJRVEqesbUfsUkejQ7uvxkIAmsD4rNCAaRgPMmWJ2NVv45NtyLPlp8pjgRRoJVV6MjFm6RQPyIBGyLIEHHOwfFePR7+AnrzZGYgwBhOVIU5mI22+RENO43uDhMOYYEaZovuuNR9fAX5lfukODIklXEgXj8u8tuxYUEErwgdn799YAE6yRVT9gnomF/pVWSSJAoWhT0Go2i6jcZJZPgWuW19KgUzJW8VPmdVBLMVXic60Xn118+rJxGgm/fqi88QHNkNsq7p5NA+HXqi6QneJ2jqGl6DtaRn87WysX9l+/XUs7D/rXXB3qg/D+NF73zSTAiescqq4AEurk99TeLSeCieL/saDW+3lay62ENCdrvL9iQakkQf0+aW7qOBMw71094o6dEG8sH/m+cj4r7cxLs/2/7doFXJNDwK/Z1aCbB2+cxYb/Rj2baIRYtJHizd8utfDT2dcwtrjYSdG4kaBJQ1yBbhSWU5HNfoaIdPz9vZnWvgwT/bTJM4e/EOe4QyryKTsdRbBv6SFDMKjq36jPOv831l7FoYP/GA5JfSGDwbeCOF+q7kvywCZ2O5HJi9ZNAarzo4xJav9mO7+oAzvMTucZJdOz2U1HXQTxvIl1iVIdwrnT1RY8Pk+Dlszcp96fwugzGyrfourINpKxpEoTXm/i4zpBgqPa13WP0z/C7w7azJNDUljcUm8O8ZI4TolCvMFKt8jzeL1bs+F20OHMu2/875pvTVdX4mwSHPnrsl/1Hgh5YCu1a/v9cjvwu5SKDfWye6R5uMjRpUh+w0fTuiE2zqGLs1MaTPGRorRb9rbKCDBpfXtZLriTDUOQ48TYvGe5m/MeQEybDR2HV1p7/27aJ8FaEDGVXvuqniuLfFJ3YAjEy9KfP5giKk2EVzVF5Nzq1xulEOToHULJGggyRZ679Z4LONjSdeb+VjL+zJ956SpOh/Z0xr7EMGTifpF5+Reu+R26nyJLhStnslWo0W9ivQngbrlu/t/s6+sPfXmqHHBluhe5Pa95DBrJ1+yRFhQw1TattD+wlw4PGfd+j0EGJa1s/o/I7VtTqqZIhrWBRrR490u0T5KCGn9uQIqitTgbTKxq68ajRH59adQ0yXFzb3NOI8hnf2vJLF6+L9u/ZrkcG3U8CiW3oUc+a9blABkufy8Rr+mQg0ruvHjMgw7VBwuZdh8mgo8Na9Q2t64oN+mZIBuvfoRdfHCVDidiMebQZGbafcNz6wJwMhQEJn9dbkGFfR7xzFWrOVTXx/CQZJv96KZyyJIOjY+CJAvTdFWGithUZ/BMSupfQbjW396ccyJCjVeJr5IjPUWx++wQd/G3lvNaJDFz2K5PvoZPOebJmznj9brrQDPp065/XBBcyXFri2cx1Duv9Kmt6FpW7mrb5vBsZotqDUz56YR3H9/6meJPhwAfZ/CH09rJLqIcP1j+9OvcPmu+5mzTki3k6StWN9iODJjn7nYw/5uWmnU5wABne//ixdomJr0fZhVexyLBn+OjBRDYZkrZ3LuzkkIHnalju9kD83L910Quo1deUA5siyGAoM1D+BI0z5y8rjyRDHlHyYngU9vcSd+TOaDKspBzcdvg2GaYpMu5SiZgz4WF2D5oU9sc1J4kMEzVrnC2Scd/ez3P4U3C990i/fVAf/ycz3DlkWNh0f7EN9TkmN/MqlwzG955UJ+SR4cKRctlf6IKurCwhnwy7U570sQuwXjmJnwULyTDy4ZDbXdRJ8G5S0zMyfDI9PlRSjfNTS3uwtoYMlYrWLj5o88bKqG502xE1HpdaMsTHpmdloFV6ZKpTHRnOD2tkTqNVf2wEdtSTwe2Kr3scOphz1HfdczIoKI2LTbwlw4YekS0PWsiQqEPq520lg8t8ks59dIt2c5hQG+aHR7YoGD1/YVPAACpBOmh8tB1zNiTz3wtUxC5+v2MH5qBCs64QDbjWslm0kwwV/GsKxrrIsE493ubcZzIUJ/fWlaJ3Oz7OW30hQ4po14hUPxkk6w1u+aD97P0P1Adw/ko33mhDxzPTX20cJMNqx5ub09DwhqdK64dwn5drt9wbxX0NzRb+myDD296CyvvfcD+yeTNPp7CPN8NjLafJIO1cKcw7g/VJV20VnyVDaf6h5Kto8ZvXZ1vQ464ltgpzWF+5d9aLqLbRkYXcf5iLdt0aES4KyJZWFgyh2+Nc87K5KTBy+KvuJh4KCJy5ZzSBWsg+PMXgo0BpMOX8Y34KxJ7fa/RUmALBHulZiyIUoMbw+3SIUuDSzvGvRmIUuHjsxolZ9LRNgiWfBAXyvEuqxtAX91xpM9IUcNtA53OUoUCvbWZACXrUcq3vQVkKaMmu/lqHjsXwbjq1jQISGStHStFjuvPDK+UoUMG9dLAAVVHhctinQoG/OmVv+tGHS1ZfX+ylgAYjNkBVlQKbdr548Ro9MnDejqJOATWtgA/iGhR4FJf1ahBVinQOyt9PgQ+cBJl7BylA5uqM3K5HgeMr1h5uQdsCm29s1qeAYGWl1jc06q2jzHMD3BeXxovjhylw48LLpyKGFNjt3qQpd4QCVda71XecoMCO6phMGTPcz62vDlzmFHiy3qnbAuUP3kocQI2sOcH3LCjAO8M18hsdCb7E+nOSAuXFugNWlhRIrn5vGIZaTT8XGkRphfO7FK0oENcuy30W7TYiDkajotVDxBH0ttY+VUNrCjzeY+M2ivaum4y1dKAAI8Hs/nZHCqS716YWoP4b1yrNoYax31SbnCjwn0yWjIEzBSK05yXH0SKFO83tLlhHnx2br5yjgIFC1mArGhkxukHflQK6u4+OW1/Beru8YEl4UWBir8B+OW/MRWSuWBWqc0zT3MGHAkTRzJg+NPFj0dRRX3z/k37gc1TCc/F8PIECMnbrTYJIFDhbnjuxiYHP+8V5z0Zb7sQ3cTPxuUncWgw0q/j3NzMW5rI/1IjOxn4Z9JsPcSiQMDyacSmIAhuvqBY9vEaBladKPaNvYf/INo8twilwRvdSm1UEBQ5LK099Q4/eq6kwj8S6Lezel4nezeyUEo+iwF43q5u3UMkbmpQOtMa15KpONAVY/+xUqtG2nb++0WMo8HSuJJgrjgJNOpv3fUigwM30XyIXEvE67WQ3vSQKfP5tXxiRTAG7jX/9vVIwl377f+umYj2Tbl67i8qMxNzlTcP6n1xtREOn/mqasXIpcK80/r5BHgXuiMy3dqIy32+7aeVToNVdfyYP3W29vdq1gAJiPEbvFQop0Cy0tOkR6vjih45bEQVyLTWP+lZTwHj/gFA52qKsKbW7BufL7+Kmd6gd/4PHl2spULwpvGweVUubmHaso8Abl8VbbeiBkEzV6/U47wNaEq3oks9de0ID1kXe70nWW5zPWndzhWYK8Gx/ptSAnm4OvSHfgjmPX8WsRGsP+Sart1LAsuDf7RRUa3WE3eE2CnTc9ONe306BwBvaJ106KKBwus1G/iO+niKz+vEnPB+q7HtWfabArcDPDWu+UEA8oGs+FI3JaBpW6qeA+c+jD/kGKBA28fVaNFq7hf5AaZAC9YluT+3QFlkdym3UvXOV251xCuwx3nN4YZICDsd1LZ5MUeA8ISRq9zTO13Dlw0R0xjP4iv0MBbaUEOIPzOI+X/wQXjFHgeFWl7Uj6OkNa7JOz1NAWkHQpQwFmcTCkQUKmPJPXrj8mwJ6LzT/rfuHn7c8epa+jH0amgusQN/8a9i/n4sKUbRiwVhUQMaF6zY3Ffs63ObGQwX1r0KrOSuocMP5x2e+leibKw5jq6hQMVykJ7+aCm8N3TYkiVBhk8P8h0xRKsz3XufTE6PCKc/w3EGUtv5Qq7Q4FRjdx1ovoC/5DA7KS1ABlAZcm9DQeiLbZC0VDB0oOqz1eH32jYeHN1Dh8nnHq4ZbqWDJVD6ULU2F9z3/OKkyVFBrFp+Rk6WCf0nely+ofr38c6NtVFikHji2Uo4Kv4mOjlT06SfHh77bqfA1QfjZX3kqdF3LDrRSoYLOYkJrDBpflLZhBm3zdYZDe6mwTm5GowjlH5qsVlKlgvxaCVV+NSp0xJGCW1GdfSciLdSpIPYhcKYS3SQ1VjiLNpQLnlHVoEJ/sV91IGqhYzF9Zz8+78EpKV893NfSk7G/qLHfbTdboIL1cdP5JtR0QJJD1ce6N3pc7jKggldd6IiQIRVIZntNfdCL0TWnzx+n4v+TRR56ZlSofHAjtgUtG+oy2WJOhdmmVLG7qNiusTN7TlKh7qdgUhcaXz5q329JBWcvbY6kNRXoIyIPDRyocDbmv+urHPF13ixHP/S6axsPxYkKW6T+vJ5DxfKX24OcqWBz5XPMMxcqzFy8LJ99mQo1R3e9zL2C63UpeM/yosJ+SetVQ2h8qkRHmg/WRWj5UbAvFUYPTF0J9cP9WBAUj/lT4djRDAtFBhWSbgkW1qN269JL7jOpMOm6dsKY9f8+cgdvYFPhfPWSyDVUpo6QxOFQYdf9fq47gVTg2H/sqkLtjzyL/y+ICj+d7pf4h1DBtSGxIvMWFQYVQ+K2h1Oh/JfRM64IKlCrpc8HoNc3LO9jRlLBaNtxOa4oKix/7LY7iLqtqptKR++ua0/QiMZ1TPyRzkEfNSeffP6ACn/qb0X6JFFB+tEMj3oyFWIHHkinocFW699ppFDxPElVi0btmOd1hFPxOUX/bexGJ1w14og5VEi8W3pWIZcKY9aEl0mol+SilHQeFRZcKD9YaNQH/eQWtL3txLJAPhUkNDPzE9E7+ZsKuAuo0P1SLYiK9g6kGK4qpEJPxOnBBNRn8zaltRVUkHPV05h6huu6buJnWU2F730iph3oCmXxktM1VAiiaDotokmvfG/p11JhT5zJrqdo77c4Hbs6zGWnS/N99LIhj19IPRVyXj93m0fTZzpXaL2gQuCtrQKf3lLhqtaBtaRmzK8H6eIo+lSOUmfSQoXc3ZZzlahEqOq2rW1UcO9fI9iKzuff4j7XjnMoPm0s10GFhHohj3R0oGttCNc7KmhH0LqFe6lQcLfMavkTFU5u/zwf9hnzUxEufPoLFXwduOyXUQsTyfL8fpy3t0UyZwfxnAm59un4EObK9OO6ga9UiPZJ95KdwvkR/DwRM43zLqqyWX2GCu8+vzkcjSZ82rfwEv326PvNrbNUENyuPv8eJeqHlkfOUeHV0sLy6nncZ5TCzAW0W31H8hI6z5xR8V+mwpmhYzsH0Zn+U7aqXDQ4P1Sr8BD9KU7+voabBhNh34rdUP4Ql0w+HhrY65Zu3r+CBlG2nyz6Ucq6VMHra2hw6PnwtpMiNHDIOS4bhZbHmd5dJ0qDh/xFtj3o6Ds53iQxGsyTPz9aJ06DcNF1n2rQKs6XM0kSNBjqHAg1WEsDK88P3j7o+1f3W7jW0eCAcF7vh624DgarMUAaX/8VtGIYzV7ZlPtJhgaHi0y7XWVpYF7jV1uMCn1fMBPbRgOPunUa4+hBk00cNzka+N3LdtfaTgO4fm4wAa3ad+l6xi7cr86kxLs9eB/m9StVKjTwqvASUNpLA0NHzbCnaJxo9+PVqjQI7Tf2UEH35X7cV4Y+lZWkBajR4ErFI3UZdRq8DNkMBLTssrqmnQbWr/7Snn1Agy19pWWlKOmGTf5zfRrcubyux9iABroqXoHKh2nw9tgL+jZDGozd8PoXYIr7H+uLLDWjQbTqrzWq5jQo4lT4taKVws+6yi1osGKe61P9SdynzRrp45Y00Lpw/sYSGh1/3LTDigbXntzV0HOkQf6dfu4OdCwviFfNiQbbD/HffoaaH7s0vM+ZBpf3baY+RDu6k99KutDAp+lBYzgaar7ksfUcDb9/WxKfog7ptTIqrjQw2iReHnCJBpFLT+KNrtBAvLpij64XDSSmxF5VoiUqymOC3jTYNv2Gsh3VtNCW9EBlnnRZtqHDk003J3xo0Ei6XujqS4Nl8VWvxlGekPzSEj8a0GTGz7kwaJDWNbSzj0kD9/2js/dZ2C9xfatllFfj2TYSmwa3HQgmwhwaEKfEjaho6Fmn5KZbNLB9+TloJJwGgfGbqyoiaCBwN//ViUgaeLNlhWfRR94yHj5RNGD8DLk9hfY1j9DMo2nwo7jpaDPqnXdWrfkB5oS9e74pkQbJ/yltOJZEA4W5IOOvqLZh2H/eydjPur2e1BQaHOnl0zieSgOlBJW4fLRDLuCsZxre51OJYlEODaq5TSV1cnF93iZGoahES0pPSB4Nnle/bOpCxZXu/TbLp8FJ9iRhGNWOuteXUkCD40Nnb2wvpMGXAr6+LPT5v4Y1utX4vOsDj1bUYN7i/34ZRDfat/lN1tLgVgZfA7mOBqVHueR21dPgtEdl8jTqeo+gE/Ycn6+ou2JnAw02yFt1GzTTgJ4pYp2OMr/eLuBuoUHhDC+/LTrHSZEeRkmVD5JYrTQ4xrdKzLuNBgNy/Pai7TToaWiU8EPP7aAn9KEHX7+5T+3AelaLrlTqxHUpf7G/gW6OFrDsQrfFc13f04VzKvun1+kTDdb53I1bQOur2L+5v9CgOeS7bz0qFV1sL9lPgyb55kUX1EtaAfQGaLAYWTcahVpvI9MVBmkQtBxqvW0I6+rwMb8JfSoS7SE0jfd/8d37IfpcWO7hd9S/QHZZfQbPmfJbvXfR7+Zi24VmabCHT/4REX0fe0m7BwWVYVvdORo4Fwnxm8/TIOMR6zj/AubWzrqbhZ72254YtEgD2SvvJb8v0UDsuX/C33+YF9oW+4ZlGmxdzYyX4aKDq8qzy1mo0O0tGke46SCTbBZZhhLFB6VEeOhwdXr+xfoVdDh6aoY3HQ3+8zhAYiUdfv1aeOcoTAeyMStgEQUh9e4TInQYzJ+0lRKlg9xYLMkT5edbR69A5cWa+HLF6FDSvldFXZwO0wnU8HuoptqJ1Zsl6JD++c3gbbQhSy3RfC0dBBpO12ShQP7wJWwDHSpOJlZqbsXrmw1r7KTpYCizVfIX+nMwOvqQDO6DEemahb78dy6vRJYOH5sVx9S34fVp4slD6LFV0SMmcnQ4JZ8/cWA7fi49nnZEgQ47uQZGiXvo8ML/cQZLhQ59ZsmuAXtxPfZ/n51RpUOvwVjRZjU6nLV3HwtCN1Y9tTmqQYe9YM3ecYgOe0RM78SgSv132vX06HAnjSEzjIZqvnFOBTrkP+1t1dGnw4ebJyI0DOhwYe6SNwNtXC4/YXyYDh46vXtfoj8DBnL+oq05IiOahnR4d3m1t7wZHWZ2DAxdRpvmLPK70K8+tZGa5nSw+bJpKRDVchwKKkaLBSscPCzo8PvHljz1k3RQ1VzQWEJD1yWdcrSkg6mBs/pt9Ny5qq2yVnRgMO4uZKMpllmHNazpYOv+3OqhHa6/NnuEy5EOPcI/5xxQnQOr652c6PDExGP/Wmc6BHyyXixDky41Scu60CFX1VGagdIvhBn2o7S8X7MO5+ig8uPBVBKqfzLxetJFOoydLgoU8KKDYkKC82lU7Og41yzK/SbyoqM3HSw2uLSt8aEDq9J+Fxvl7u58W4MOvOz5tMaXDpsLCids0ToZiboWlP461iXED/s1XjQ6SaNDv2YU7RiTDuE2OZOv0bZUopQMiw6XGuUyJ9HK+ASeA2w65PkQqhQ4dJB8v/nCD3SwPerK7XCsl+kns6IIOjx3XxHyLJIO+zgBxjZRmLN/uQOe0XT4Mqk2vSKGDuPN5seCH9DB21G9gZ2I/VQ3a7RJwvd3/vBtQ2/EHMoTSKGD+vqXw5fRNdtMjtikYo4mvu4qR8N+tQypptEh24PmV4Xe5h2d5s3BvHbA7mg0Zq9WpFouPj+Euu90Pq7L20hnAOWzMQ1QLcA8rzXwCkYvhcQfGUBvhMp9ci6kg9mAQvI39BNtT87tIjps/e9Jk385Hd5v+SL/+Bkdiiof+QlXY86kDhey0Wr24xyLWjqsy7lqIVZHh3n9OBuVesxFxxViOSr6eGqA8hyfc8Yr5j06Mkhfvt1Mh1Gx7kypFjrksIfKWGh06Jz+P1TINF4nqJUOOxTWXh9FN9+QqbnfRgfPqAJv3XY6EE6cOOvXQYflyhZXpU6cH5vJ8TvoMXVipto7OgzfX2cf84kO9p4Ha6c/4+cPjihWfaGDm/wtS8V+rPeE2oNR1C5Jc6PuAD5H531INarcuEmLOEiHZDb3BpUhPE+Sv3yuQnsvLcfDMB0ebm3ZxZyig0TrauU3qI7VqaCEaTzXhD0vc89g3rpPeX9HY7Lu34+cxXUfGlR7PYf74b3etYxa2jt+CprH90/ucFBawFwV8JhHoImurt2ly3iOQagCLxcD+EhZx2+jCatLcoGbAW/9fbt0eRiwSzhmUxYKEWN8a1YwwCpsVWcEWmWav2bPSgaMXyHujBJmgLBO8a87Igww85uK60Czvlxbf16UAT8EPC/PoGPqZ5IPiTGgrLp48Ct6afWbxyRxBtj+rQuJlGbAlqMa7wbQuAZqQJgMvr7o7rlFlgG39OIKG1CX6UTGo20MqC/8fp8gxwC3lRN1Fegvg60dEtsZ4EEVKRlHo61Pni/bwYCI3Vf/jSoz4Hty6A9BFQYQnnyUz0bdivTOp+9lgHtw+R5jVQZ0hx9Yya/GgAvPgvUbUR/XhgRRdXz/QtAwz34GHOt9tLv7EMrw8RPSY4CxmWFHALpRS/NKNTri+9BODfA5szK5beiUFw//iD4DGpQuRt0xYMA7e69IfkMGZDSnXK0xY8AHD4/HseYMGC4oMVxGKyqvRn20YAA7vuOOsCXun2H3+g36rOet/5QVA16NWlbctGaAUsG5/2z+Y4CdaVzidzRqKYo14ID98Qg/ouPIgCRC6u8xNDbvz6rnTgxYXPOC28QZ123q77TOhQHnff1XX0aXlaV+jqP7Vs0+2uWKdQtfushBe6dHPp/2YMBK7giXkisMKE0q6NzsxcDvZ7m2x+ipx4pvBlDdXT9Bx5sBYdSLma/RUT7LWDcfrPcf0gc7XwZ4j66++QhdnSz6Zw7NmpkVuO6HubD1lHZkMqAtekLfhMWAK4/WcCegr/hNNE+xGTAtMBpWhXoe4asw4zDgn8o+UiG69Q6cFw1kgFzCIJWFzmdt53YMZsBcrxr3nmsMkM0QDioOw3r/yn/0+xYDQpQ35U6EM0CAEFEaG8GAg1tfJNtEMoDf7PGq12j1Tv0TGVG4vr0LTiuicT8zr38Q0I+GZ8x60cliubcOMQzYxi0rkoYGLh4Y8r3NgPRmg1aBJAaE129Zl570/zy7G51OZkCNQcXmCjT6b5L4zhQGXNfZmsOVyoAv+lzhVeijVVeNOGlY3yfRmR1oF31996Z0BljI0yR9MxjwIsz29r0cBuznUc7ZlcuAh1qdH16i07Ir7DTzGJDy0u3zV5RSInJ2Lp8BRbsPxd0sYMAChSFxtJABs320J29RAakAZ88izFnS09GvzzDP/178s6/GfRwvrPyNbupV5X5ag/WlZFT+QlvTVrf51DIgmet7uVIdrqfWzcGtHvOb1Occ8JwBUu8ab4y8ZcDLoUxV/2a8v4MvZ3ULAw6ZrZDa2Yr1YtilPUTZi6KuP9DwYC/rhTbsb7GGenY71n2dqPmBDgZwV7fSC9CJVzWuWp0M2OH+aWzVOwYE2Nh8ivjCgMgrs9Fj/Qzg/Vn3KGYA67EuJk1vENc3psV8jmoPJ/18OMQAtU778McjDEjtE1tFGsc8fpsuODGNfTzDdVhuBs8jZdexEVTVqNBzaJYBg5IXRQXmGdCkT/6Tj95wem59fYEB33QSJ279YABRZ2fxjmWsl2OA1nv0HVNrZwgXE/wqXhVHcTNBXMpnxw4eJqhG//V2WMGErI1awWdXMuGDVfGbemEmKGcfPXBWhAnsq/xtr9D0UwF8J0WZ4KucHOKH6jxSXa0nxgTpZefgWbTu0lqXRHEmGPt8rQAJJpDE659YrmNCfept6/6NTLBel3CkaisTLA0jjylIM2HF3qL9AWiKtMnbKlR9xqFbU4YJ9/mUmVKyeJ1rVaXYNiYI1qe6S8kxIeTDr9ZW9PN3tacq25kQ1ffU8LcyEyL0Sls99zCBVaGyVUWFCanF/AE9qIwk9ZLlXiY4WSScTUL/kbISZFSZMM4JHp5HpZ+2lMSoMeEaNSfpJ9rj2T5+TR3rsyX3v0H0nkjXSTc9JsSOZssOofZqRu6KwIQmib3pDWhRQfOgoj4TVrbyfwpGx8t7SmfQn6VlLFsDJpSMkl35DzOh0p1fS9qQCV0t/3U6mzGBemSa1IdqGtstnTBnglSRSnKZBRMGg43Kd5xkwuxOUg8dvdMlEfkApWUEiv5CJfVtrkVaYh0dr/z8iw4fsZQIt8L7ysZIbLNmws2h7ZuG0G+R1ev+OjJhZ+vPLW+csB9LXR/AGfvnJMXuQBsUQ3sMXbBe9V1bhtAff2NFOa5MWG/4u7rjCl6vfWxR2gfrZbS6JswX665tfd/aD/vts37hO3qu2jLmnj8Ttv9777YvgAlrnrtkNDKZcCQ3Y78kiwmnR5p5XVFzz6fjm9lMmPqT+uIRumfb4aVEDubK6ZvdxUAmPH71/HgD+kxu7eozQVhnmfI843Am3E60GOhFOfm7+L0i8PNKZ7PfoayZLBGDSCYQb5evLUSHnPvM7KKYsHrLVYFeNE2CV+hYND7v44NNNjF43wnmUsMDrDPLQYiRyIQ/sVdr36MCGy336CcxwcY5e0wrmQkPOv0fxaEtL4Lff0O/RjW56aYwgafJtLcA/fNoy0mpVPRv5/e7qHYyY+p0GhPuGsnsfY3mVr3r25/OhMgmyQxiLuZX/iP9DSq8UOrfnIf138w5ZVPAhNd1hw3FCplwIENMqBQ9Km7ssquICWHLhz89QfWOp/qalTPh7zfnFEI15vfUtlNv0JfLpyjxNUwIT1c+drgW60AY5PuMrtzPS7pQx4RHd54PjqCE+cq5I/VMYOSI1HFQ+jqeMf4G7CeXjeJwI9b/Db0qr4UJFYyrmXKtTNh3lkv+E/p81+znS234XIYPQ7Md99+1lhOHTlvQHxzrwL54ucZZdmKdw/5JpqPbbPQP/vrMhMMap7ft7sf5Daj2f4Tqun368Bm1vqEWLzPIhA0LZ5/cRtdoa9UeGmLCoZUrYq5MM4F3byblNaq/WVXIeIYJNYoxUoxZJnR6rk9bMceEwkW61mf0ncweJZN57FOKj/LBBSa4yR2UCvjJhBNLEQUKXCyg1NgmnEa5DwgJtaL/7qadUONmgVfmR3MiqrP2yY9mlFDJqyPFwwKLcy7WtStYQPckHhxbxYL0DAGtW3wseCloK/IeXagQqFPlZ0GC0pkJOpqnJmVQh6YNBRdKCbBAlUNx8UGPHDF8FIV+qpD/U43KDnqmTaB5kjMMXUEW1KjsDLsmwoLM/z46ZqI/t20o7kIt0y6GpoiyQEWgwOQjOjk2clxEjAXi2oFjoeiPgwrnV4mzIPojYVc2esa+zcx6LQtayIrMo5IsqLoZvf8y6jkaWNSEHs0JSjHZwAKzpYwmHzT1+NWqUpRydFZdbiML/oY58EWg1fZxkX9Rg/Bx/w9bWdC3VvD6OWkWkPrHBcLQRcpMzit0w5Sf3cz/HYmM3yfDAsHJ92V+qPYyhdmACmXE7p1Dmz1/rDKTZUG3UMnoV/Sz2ZNXtbtYYJK/IPIbNZPcVWskz4IT/Ff4W9A1B4WZtrtZ4NJdrxWLipFKd7ej3M0BqywUWKBMfsbTgHr/YHXWqLDg3Jyc9jx66sZE5Ma9LLjsJkgwQW9m6TYko8N6mu/a0cm3/a0zaNdZ9i5pVRZs0zO3O4nuEL1hEPh/k4qE/qCCI+YtFmqYA8kgVQpqpFczcmYfC84PsPQ70ZMlTxYEtVnQKytoqYj+5Qv18kcJywp9N9HFvX5Fa3RYsPbjSpoFutNBf0sYWtxzwWEI9bvJHuDfz4KyUXGXk6inptyA5yEWEDMuGLXpsSDrHO/uLcCCRqZ3sAn6iyR3DqcYrETd/HPQL3dCORL6mCNQvBeEXvtj9G4IlapZurHBgAXvjtd1UNDG4uHyDCMW5JfsfNGCKmo07eU1xrrfyzE/gC7+nFRjoQbGnoGCJphDC/Y5E1TdKUstCH3sEl7WgV4h/GtUNGVBp1z9HWt0ecf3pDJzfN75Pav/oMYff8YcscDcGQyrxKP1Nz2fv0aHxRkXeU6y8Pf9zPYLaACXz9N76Pjt5ZXdaGHqs3VHLFmwOouxcxFdp5EpdciGBRlPevWfoATptGzh0yx4dTJ4/V3UPr89qQs9bKND226L/SyiMiNR3YA3xc2oXLvrRt0zLOC5LPm10BFzO7bDda0TC7iIQwKXUHJt5OcOtOkjsdLWmQXfA5p5mSj3EklzFGXKnRpQc2GBnrpm1WVUkvrudfZ5FmTf06Vze7CgQPDNpCnao62bHYZSOl++y0Pjnx0XVbyAdbOZ8LiDqhXf6htDJ9+9G7L2wrnvEOmdRvc9kLp5xpsF7ek2dRI+WCft7VfPo5G3DW/fRAUyHIMG0Y+x5HcrfbFea7mW9FAFrljTW0Tsw5+XmSPoVjX2/U0kFsTmKxn5oFNhp1cIkVkwaOe6YIB6xe91D0a/Skr9y0ePffnc8Au9dPd1+30GC5zu/Gdhx2RBkZwTDz+LBdOVM1nuqP/RI0W3UM2MqPRBdIvaRYljbKxXmZEDCXXQ7iM1opOMnZlyHMxZrs1m0UAWONb8KHoTwoK481Mis+hC9GKicyieizEuBbOoFXuZbHIN55q88T0JNbmwinrtOgseagrarL3BglXK73clhLMg3DmP+QtVYfvfuhiBOfgm7NmMFq0+GWsayYKOFnZuIPpI+GFFIXpU4UBzQhwL7rOC+1ffwXXmP77MRgOMn029R9kSvgdPxWM/POz2l6I1lLMmq+7i3ClJvotCZ6MjY34mYr9tfksZJuE5UxB8k4bq8MXOL6Fx71eruibjebE8e6kMFes7pP0Zbd039UU8hQW7YiV/HUF9dKt4LqG1AWUfLmdgPnRvKRagfR91X3FnYn5jfO200ENN0fIR6F0j4r461EGBOcT3iAUjBgV659CGi5/rQ9CuyJaFWrRYJFKJL4sFN6Li+u3RWJs27vfZLAhbvyXVJYcFhq7LvhG5OF+bLkx/RdVdaX+c81gwMKJTyEIvRTu9HkeT2rWGzfJxXv9RiwZRHxOir3MBntO5o3nHS/F8sM1q/IP+odl5B5dh7h//3PEZ7bE+x3X0KX7vMaPHktGBHynkMfSVn7mSRjkL2rp9LaOqWfCfwMnlMrTmTWfFRzSVcn0qvgbPv6C+Rp5aFsCHX/Y2qG6JkkI1WnnJ4/TeOlz/+rR6EupmUvdWpJEFF5+81g9BPWaJGoJNLAj5eNq7ENVQV1TSe8mCFJ4U3wL03vmAqdWvsN6RibauqHSpx/GwFux3QfTmUjQn0FN5eyueX92YZHR7aIa5SBvWqZMrwha1kT40caQd16EZcSIQtTkl8y2wmwV1HzbVt3T//xzMPrDpPQt4Y65ln0bvGxS++oKea2MVaPfg3M+5G7DRZJ9dvtno8z3PEwbQWYWpWOUPeE59GbEN+8yCGOeSvt1fMOeZkwnnUGbJN74CdNY/yO0neu99OCj2Y25DC/XOoaN7VXNi0cHsrWHd6Ln0JnuBAcydq4OYDXr5xGk34TE8Z+vuCluP/T9/Rl5tqOdc2VqZr3i+n+D6bYZKq/8Mi0Rru99P1KCXQ9+56o3jXJAqDfdMY98Jr28/Rg9sv86Sn8F8tTCZAah7f2J6HlrxZajvL9qwa/Rs7CwLVhCt5fpQm3bvtr9onalAz8Y5/P4rTZkx/8mCQFWHjzVo1zu7xin04sW4VMVFFlinX0x1QX/vHNb9hXptchnc9wvPmctPPtxA80K+ufWgb0MSf+3iYoPyCW1YRF8Elnw6xs2GmG0hxhFob2BsyyC6mH3hTzofG96+Udi3lp8NDgLPLlahNdTiREsBNnRbP9QjoS00+cg0dL5np8hqQTbYqeT+ly/CBv/i/hNbRdmwg0ul+RJ6N4bFXYP2vNUa1RNjw71SLTIBPXJ/8ICEOBtkjbmmD6MpHOqCL3phQKG2RJINf91bD1tuYMOI6EqJp+hncY9Ap41suCQq0TuA+o9JUJWk2KA7cj3fEVU4WxA5KM0Gdylh/n0ybPAWrBW5gA5aHgjLRIsfpY5Ky7LBhPp43h89NmOcUYaaMYWpW7axgejtFZ23iw1ptTnj+vJsOOhgbp6BGpjmjzaj/e82pU6hLk/dBWR3s8FxZsz9DHon9JFsKnp3OjLmG3pSfruKogobRN0W+wPQ6gsMkdz//z3rIPYPPW5HhZq9bCj4O1QepcoGq99M469o/ThPsZIaGxqbCXqRaOx4kL/xPjbIF91WCUFn9rn2taKqh0yrZ9AjlcFjJG00rnnlEzTHUS1vAK3fQDm2VQf7SzoxdwJN+3BZmY5e33Z8Ngu11L3i9A5lmM3ILKPU15sop/ez4cBMbCMFjQ8Ssv6Hqos0sH102dDXQBP+dAj3mfRluVSPDYciQz0W0AiPex46wAbJM3dsmlDnfI3JHfpsuNx/RjsQjQ6esuI2YMM0fbpbDi3QuWd+ESXfCSxrMsK+bWTzbjVmg5TMb7IeSrzyTusGKpj0ubkM7awpTllAn05lC+4xwX5wZXuT0ebBMv0mtFfFO+CgKRvnx7AyFR1e8qzPM2fj7yhG2QYLNjx+fEvSBXUkHmY8QLW6fQxlT7LhYs3PRBI6MCEhU4H+/W33Ut0S69iWV2JnwwZ6zfXSIfSYk078ntNsENrQ++AqKt0f15uNNsemJsyjosUf641s2WBhI9B9F41pFopoQzNCemr2nmHDu63ZKa8c2WD9S2D/H1RqrzffTic2PBu7GnELvVD03LAKdVjUFud3xvvXhRi5oWqmBvsS0Frul7rz6PRrOWMDF8x9ZfsXs/Ns0Ftx+QsDHVppvOc9Or1Ky/Yfuu7FgdlTHmyYrdLdmYjuONXr8w0dth1N23wB6xsv5sFC46xuV/FexLqO54tdQCdafj1gebFhbefHyCk0hJNGsvVmw0Lnxv8O+2CejviWeqG3Zs9cW+WLuSz/ZzdEZIOpCdd2KxIbVr5KvJ6PTksQoleSMU9PPe3PoZ37VWLLUe9ai9RF1MU3SFmFgvtNo3yeZWIdrRWvurPYcC3ZU2YSrdNO3RTAZoP4hhKlZbQ8gv/iHg4bAr1XZxHRC5LVTqQQNgSR7/VNob8DvV/bhrLh6o9+zUB03LDvexd6wE6x3vgazu2WYHoc6nQ2p3XjdczbwoFXbmj8s3eb2eHYhxPFDdOoar/UxNEINuy7s+q3N0pz38zdjV5hTtqIRLLhUcrQfWd0O5W8KRJ9fFf1zSB66gp1xaooNoT+8Qm+GseGih0aC5OoxFj3t8t3MAcBRL2XKH9W7nGZeDb8E5awOYUydZ9P0tCqsNmmWHRNr+/cLzSRv+XZ/rt4fWb9wwTURLt9qjGRDVzjb2L5kthgbBEoUYJ2SjUe70HZt5011yaz4cZzxnYrNFlTP6scvZ7NiBNKYcPkPaPVZmh0ujZPILpfyiGCKxPrJkkQcURrPO6Y3ESTxzZ7v0HdD5W2bnuEfeXOYuahY09IZuQsNhhmXhh5lMsGHieZRYU8nM9Tthx/1OjDiFgPupHnr5VuPubsz+iqCtRYykRkCFU8fqCdWohzprFWMaYUcy1+bG0z2iqodHoAjbrnelezjA239/JoXkbv3fESfIW+enLqKOspG860hrlXoF/O8betLMd6K48sH0LbZoJ0/dGLa14/XKpmw+GNRm0HavD7wU+KwEINxExnu9CXc89vra9lg8b3Zlvr2v9/30BFDkqsI021oNmyt6SU6rD+6219yhvZAD1BO3c2sSHTWzwtFr3S83bVZ3SiccBf4yUbBEL4TrignU9qHe6iH84u/+5Bd97Mec77Cuf/Is3rMBpX/8frBhq0Xuk3rQXroF5tkoHu1Lol0IOmLMlJ6Laywdah4dp19Pyq3jMr2/A6xmTMTfR9qV1VDcqmLIm0dLOh8NIw/ETFXgkfUH+P58LzY4Nn0TNK30eCUf8HE2LTKP+p4JltPTiHqpf23UFHCkF7Hi3TIEZafMa6vysJ/oVup3ROXf7CBi+DI319qBqpQVS/H+emy3d1MGqfFfiyFL2g++M0Y5QNpNGuEwno2/jGfd5juM6zPVlJaCgp6sQ7VLY8VoL3KxtcRao/GqEZyrlV0WjQ4lCz6jieu4OmDrHTbOjYIh+zZwa/7/7YX2Kj9VXCfn9Rd2r1qOcsG27+vDjTiHatslxhNIfXZe9mJP9kQyScOT6JGnQqux5cxBy8epZbhpZeF/Jf+4sNKnPTfgZoSuSLnSVoAuM11xx6WOfM02O/8ffKrj6V+2ifLkWoGl2XPfP49DJ+H4Ub3qhCH4fvZkhxcUDG8EqaO6rXMhhSimakXZr9gJK8NucIc3PghBh5IRAtN5B60oo+3KWbrczDAZe764/ao6Vyvh/q+Tigmd+TIMjPgdd3uNlWqPP5VcMhKF+vFjefAAe+nUun2KPXg+z+5qH8TDuhMVTKmnjYUZAD6S/fpFut5sCbPB+uQyIcEBuJ63uN3m9fmNksyoGweW69m2iq7X3fenR6rpCLJsaBYHutxBq0y8HB/g+6m/FcmyrOgVuNL1sS/69lue0Iend0NDpLkgPZppI12zdwoCnt3P4gtHi5ISIDXSETaiCxkQMj1BdxJ9C9sw6L19E9Kw9mVKDaa9PXXZbmQIeoj1w1ejTvLUdXhgPgH7tAQnmK2sMKUfHDiew5lO9aU9hmWQ6Y7BJyPotKSWUX3UJ7Wz35DXdxwL8ygpyJQlPgZIQ8BzhiGsf/oceG3b477eZA/cddnbYK2I/415Y30N5dzbsDVPA+aZTVv1DpJ7WzO/dy4GTbS4N4NNDKQ7IdFdjxUltelQM9Htf2NKBXvXemLKI/FPnM1qthnTeKf92PXubqsnVCM4oblH33caDo7ebMBDSm/sstXm0O2A2NcN1Ad3nMZfehpXqf4lV1OPCV4eCRjp6SfJojtx/7eU/ek6SHdVsOJfEDB1qLJiuuo5nE9xdeoPR3uQvy+vj8N839Ueias13lHWjVjhIuNQMO9KlBtw+6zK3Bk2uEdYl/ryxgjOv70GNniZ6dWP+Ejnb7jgc+Ql/2zDwhmmA+NwXVJKGWtx3UO9EAvSPlG005kDI4+FMPffP2b48vajNgFrnSggPGwC/xFnX+b5jmdZIDspvfXRGw5IDk1cFAHfSXhnNCiQ0HyoKSvf6iG412ZB45zYE5y7krwehAA/fMI3S503rwH1os84/ib8uB6MuN5tJOHHj7eib4PqqwUfhEC3o4KSXl3///Tij0Pe/Mgf/4qUqf0M9dS22qLhyIqNK1vnieA9s699GnULVX1QmaHhzwcyrfUopWETjev1GDm3G87AscmEr3S/2FLunf4FhcxLm4+nPsBpqc7bNF35sDLW+GjKmo7ET0hznU4aHwSicfDlSe9e24g0butCMe9MV1qtSPe6HjjasWs9EeRRfwIOLn1/5J/I6eerNR8DAJ79uzRacB3fWLK5uHzAGtz628TqjmPYEVT1HrndHOyhTMt/SpV/6o/6D792Q0y1Cp2ZOK/VmwlKpkckBxa9DXOTRjS1zAARYHVFtV49pRrQVOuzQb9xX8X1km2vjZjleXwwEui4yGxBAO5Ed/8ZcPxf6Y+ljcRJ0y3v7rRr2Z1ieVrmFeU72jSahv0y/7JvRouD/t2nUOzDyRNcpAT1TrBs6Gc+CQ0r9Rgwjs5ymhS7fRhCsNqQPor7WsHKlIzJUwR8UGbY+SetaMljJI4Yfv4Od4B90uohsHhMaS0ZDtW1eOofGC4yzVeA4c+LHK/Qo64Gz8tAlVUdn1OTaRA5f6/oiuTMJ+e2S80P6/dd4PwtBs5em0n6j5HoXdx5Px3Kofn/FGual+v1NQ/RVv97Wj7VvDh36jKbKGesopHJCoWPzmm4HnxEtruwfon3LGjmZ0q66z6R/0NFdshF4mrlPIXjoOteRx+NqFbtEf/XHyEeZC3+R3NVrZtOLnjizM9+6QbfK5HEiU30ieRNfIdJ06mceBifNnwm+hsbvEb4jn4/mYsIMvD+3MjXA1KeCAxZ7V4gdKOeDauSvoJbr30KSGRBkH/qpftCKjRjkaebxP8f7UbuejqNRbhbgY1PjAB7mX6N8VU/vnUE0t3bLt5RygWEeYmaJ7TygcpaE/OI3V5tUcmGxy2/selRgusg6twXxUTptz1WJe3cq89qMbVomHx6DCJzKe/EO1i5ySj9VxYHjy66xBI/ZP+GnwJ7RFo+Tnniac0xEVzwD0OEtnWywq0GiV2Itm7C9vNX6JfdT6LXsdfeW6vqEd/fhU/KvpK5zLXxpcxi2YJ7sPog/QmtKkmAV0qmi4Xr2VA893Ww6/QQ/YjRrIt2HfXu2Nlm3Hc0u9WsoR3cfzcG8MelAhouFeN/bvY2LIW7TVauDKivdYV54pvvPouctJgS/Rm/jL+RfaX0X/rdeD5w7ZdE8a6jnhxzeCCryIXcP5gPfxHhK6j0poXfWs+MyBoKKljK1f8Hvg/IX/UVzf8VS/bRzA0bBaVEapkDQRpYhyERkp0qJllEJKqIzssxelJDRoIkSS0ZIyW5SK8AslokFWKD2f56/36xznfO/rvtYpz93Q6OnWhCfw2UlS0GqJouzivAuOcJeDzuYsaPxRb9XO1iiK0Lh2/1w78ubhJfURxk9W3ejRgbn/GX/1MTSUWFrWDWXqrs/W/oq9r/lt2yHoZG5/8TJMOMdZ1wR9FHbsH4R3MgNXWnRGkXOef3IwXGuZPD/wJ37HTYt+iHVHUe+O1WIseHq/cbBUD875OE/NAg7PDYo9Bs38gq6mQ20V5R/jf0VRBzdL6PA7ijQuDp86Bk/Xl9unwyGhst0fyFPbcnjtEM5LWPcwGG74aaDzGOYfc7ExH0b9jGQ+8P5hPwn3ejXD9KDe59fFGHSo5r3IWJxB1e8Ck9Mh4+yjt1oSDLpGGsJA+O5JXJn4OAa17OGN3SvJwL+3k610pRh0NMJ+TyislLht8wL2TV9+X14afz966cYRGOFq35ALO8QCTodPZtCPH6F82SkMcvj1cKE1bDKc0ZYCL8X2TqiAHybM91GQY1DYfSuGFyyMFFMthLGCRaMq8gxisRf+sIOvOZX7z8KHsitzWIoM4h/Jfz5diUFMDRuxTXBf0uMpcTBjKGn2I3hhuUUKRxlxKk7IV5zBoBNaebN2wGtWq98Ez2GQD3PPub/w0clSzSeqDPIOS+B+hpdes6fMVmPQS92MKz5wyNp4Swssi4/cbKOO+zyf/ZI/n0HnVZNWqixgUCIzfI85PFV5/XMAnDzam3ERBt1M5b+A268k61ksZFDy5z5REpT9b5GUrA6Dus5f+bcWPuMPhHGhZPDUOSuWIt/vNa9HwnvtdOU3fOzyRpWpyyAlQcTJl/B4HoPtrI/8Gp8yZq5kkEdr1TkNAwaNds3R2A23ZpwQtMCB1K3fdQ0Z1J6YcCoY+i0ez86ALcu3V1eaMGjGvc9la4lBNT2s+e3wtmvjy8WmyN+xU+Jn4FqHgHvFsCQws22tGYNsL0/d9w0OTUs4MssKddq4WI4H/3t+RbMJim/zadG3ZtAY5Qdj78DN+Verv8F/W4unudswaEIyl8mCZX0FhSftGDQve3NUPpTt2n3Wzp5BluFufdHwllPH5iw4kzOO1wv/NSouUtvEIHNND5EIHmed+nkfdteOqHXA9TdyTy9zwPtNWZO2OKJ+PGniwmnHpUV1UKXnaNtcJwZt2Tax0A06P9k24y68Irlu+D0M9HhQO3UH6qi99oEPLGmYnv8Y7vDW2zXkjLz/Cnuw3YVBWrKtNjfhRPuS420wdf6r7bNd8Xzdg4WJ0EZly4/fMCMu76K9G4PeTM19t94d8+W0pGqZB4O+PrlocBAm7JY7NMOTQY5j79q7w4xZO+6x4PuLw0790PaWbeErHwapH81cq3kEfTRjo5I75ATPC38Gt+aOVTbzZZDCHS+zBri126clOhBx/Oar3Ic7pqy7pR3EoPoj8g9Ow6DPCwqr4VBfMmttMOolXxUVAUffd34tjGDQAQePfKNIBqm5h5v8hvtN59mGRmEel15l3OQw6CJn7PwALvq498TZQuh086JQmoe5UfN7awyN1Tp7n0E5huc7xZOIa1Ne9AOYmKj4aNwpzNWxF4sN4ct5Xl9ioEur9+02OHpcRskqlkEmaXOOv47Ha6tla4LOYS7LfihVwCMxQgulBAaNb27RcIPF0k/SL8IrS7b2fIQVW1a88LyEfbOWe+k+lAu0kmqCOQevCVYkM+g7V2PvBvjgonJ7NcydOG1YKwX978Rc9wha9jwr2nADdTFy6z8FlRwv+MxLxTxqNWnw4Q7tp1zLNAaNDBgPsqHivVfWT6BqXcS+jenIx+LPWWtuMahIdKLyFlyv98FvSjbm7ZJC/3l4sGGv3nc4VP3hslEOg0zd7ytVQ8mexa3L89H/d2VrrAoYJPJTeM2GY2+X/2dTiO8XPJISwOU+u0+UwyDt5pfjipCXgvg6C6g5mja9AN7cwF918xGef+DNpwH4p3ZhiH8x5tK+eOMDeLq7VmUQrpin9MzyMYMW7hZax8N7IXWH/8HPN1kft5cg/rzytGK4zmeH7nAZg2Zvur76djmDJMLWiKwr8HxbpTYvuHyOxc5COKPuraFVJYOUGzMtrsBOb7fiNlgar73ldBWD8uZ7NCa9Qj9V1y9rgNE618Ytq8Y8+DU+SYIm429vfQtTkzQHx9WgnxQeGejC2YZjl0bADVU7H0x/jf4NVX1Z9p5Bm9I2HRyG/xXcuehch3uNxvw4C73urzlRA/VKdW4q1aMPKtee2wl3efGPJUC1C5Ja8z4wqG6345xj8G/Dw+Gij4ij20DLuplBawZWdpyDrEu1Yf/B/kmNkYtaGPRi04ve3TBU32lCCdx75JdvN3wuyLgwu5VBYmfOzDoOzWx3lla2Y+9FjZEw6kA8TYzVh6HtNJVLIhgX16mRBp/uPTd5FPax7IbNvuJzV6seOEKpx55rb0JfF5b8MPxWpvx7SSf29MwmgSv0ZaqXX/yGvSXMCh39iX3x/uUzu24Gef5dtfoeXGPk0t8CjX/eqXfvYZCwdqvwJLxp1s/rgKeWOf/U+IXf8QHNxCuDyK/zS33P3wzSUP956RYcPC/J+QXPPhTo5A8x6KrDBfWpw9hzRw2muMHOpnyPyn+Y11iPt3piTFo3wa46Cmoz73tpijNJ5eGh3FRY+Vfd/T2UW6sTKCXBpHu+uaK90Gy3aH4ilNswd/V3SSaVzk4gdSkm+ZXXnDn6fz0XfH8Cb+H/HT1wbMulRGVpJplrb5tqB5fnC2c9gBaTPFMOyTCpMOO8bQKsS73cFTmRSX+u3XRQmcKk2F1j+8PhevXhuaUwL7V1zDQ5PM93hWMbnDP5TZWkIpOYyw7uOwPjMuaJaSgx6WTZD48QGFVg/+0XLL1yW/azMpO2aCR1hczBuZMz427A9M4XcZ/gA7UB6RhVJrluyCitgDPSc73/Qm++sDFSjUnHeXOmm6szKdy4tdhpAZN6IpMf/IWlUjKTBxcy6fJo5WO/RUxqn6bclqfDJInZzV4fYN7umb92LGXS8Cdl2Qm6TNowuqNwA9QzCls1CJ3K2I1r9BBXwifHsQZMmnuWcc4ZVik7J/RD1c/2yZqGTMrea7ksCI69JT33IWQO35NWWsWknc/Zv9fB3tkrVIKg5K3LI1dhydzgsftMmPRfxsTgWrh0TMcXZ2JSTOiEt9mQs7ErUdWUSWuK58rvg93uuieLIIMhd3C5GZN+lHvpJ8L2usbhC5ZM2rNhf3crTM9d+PD3/18rxrcut2KSY1vkjqMwdorrf4lwv9gUz48whWmiP82aST8d2Pu94TyZoYYL8GlibHctVK0O+jIKSzzynunaMGnHW9GDF/DCozv7P25k0vS0nRpCOyYVnZA0vAb/y/T/9g3+u9XWGmOPe5osn/0b7m/atWLXJiYpjk0Yugqrxujt4DkwyX15qVLBdiax0zyMxjmirvbXA07DM/G9nmXQrr6rYZITkxawnBe6wWdW9YcfQ5bhlpKiHUwSm1UzytjJpCu9QRV7nJlk9NZ54lkXJpl89Nk21ZVJoa9ELRsgJdedq4UNy1fwrN3Q35KTFzCgTj0/PvAAk/bxTDaoeDBJacW+dQeg3dhba3Lgf/mbn4zzZNKj0y0Fi2GWqCAsDGZflfoxDJ0FD/ZGeDGpcde/pivwr0VwZJMPk2yjjC4pHGHS1nlauemQ477S4TWsNzr4drwvk6SnJLn7Qau+RdLafky69C/DY00gkzbmtE/mwvlzJSKb4Q2Dx+EBQUzKL9eqK4eD/wXoigczqcNHPVgAWRKj5QbhTFoRPK3+Irx4e0KcSgTqr5WiZg2bXkWOY0Lh8TO1/dDxNnNuWCSTlt35GzQCB6qfLQ+KYlJxcvnfSA6TDi3f3VkMFxyZJz+Zy6SWlUnPNsMTsdMGRdBjZUDIB3imsLxkBY9J9907vpyAGYneezNh4smYpQp8xKUXKXU6BvHW2e/5A+X7zD+6nUTeqj+oX4SH2MOdH2BqzDtN3VNMqsj/r+ECzJpoP+wWz6QjEQbisueY9HZis3cuPGhZf42bgHnvHxTbnYg5nbHBow6WFmRERlxiksD5j79iMpN8v3RKmsPSO9vU8uGF8xIFi1NQxxMn/FzgQ/eukUxou5LF+wtfzdx8d+dl5H154qMlqUwyln1Uew0unfPtuEIak8pXRQ7fgozZ/Yle6egXm21BS26hj3KUPJdn4/M9ilFlcPAoc9IodLEcsrLIQb0MjHQeQhf+2krz23i+8ptzN2BsukP+wgIm3bR72O4C53pJbbsCV6ZeePcTTpVV1w8pxLmXL/t8g+OeC+59eoT+efVmg0wxkxLk0/yN4J3+mOxjcI0gM70VLhJKe1g/ZlLuhomZMVCL+V73M1xtHfT+H3RXaKs6UII5E9xwqoF/JsuVJT9h0rRHefK8cpynUH1wTgXy4lymvhe++27a/BCGpXx3l61kkuj7n/Fx8Kvxn0sNsC/tmeuqKiZFzzz29R38a9sgX/0Kf38ieeUnPKXWfE+zmknNrICM47A89VfdA3hay5WhXYO9NWVuLxfKXq9c3Q5/Dh2X7HiPvtv42cuqDr8H+hcXnIKJ8Y6x1XBpQJiKSj2TFst+fhcGb/p1dF2Dh3xmVrfDaz3ndhh+QP/c6GpOhA8X1pkrNuN3733Dl61w66UvF67D2/r+8ktaEMeZJQXh8E257SWtViYZTChfHww7TfTHP4fLY87afG5n0vbTY1wWdzApsF3v41PYZEi1Jl+ZpD5hVnEMfPNfcdpr+Cl4wwGFTsyHo0R7BKyxP0ZPf6IOH9g/FLqRT8ZE1XTYn7EtoRWuM58/NL0Hc7LI8ZAj/DVR6VsS1D4wXqYeftKdpzb7F/JwZNq/FJg1Um32cJBJBc+uXaLf+B3Ue7nlFswb8Q5dPoS+yl15ficcs3tjzDm4N2DXl1646PWBRauHmbTQdvRDKJzRfT93eBTPOZEc5/GPSY/z5Cc3wjENY/5MFmNRc2KivAs03TkrMgnKXGmraoMneVEH1MVZNHJ0MnsDvBmxNYgLj+TfnjgMXQMdytZJsMilWH1hviSLthiFHzWQYpFOekFxEXS/fXblAHz1xHnBZmkWLV/REnwKetVzZnZDb+9/5g8ms+h5846hiVNYVLp62oltsDLn26wYuMmw2EJajkUTC1UuH4a2h9ynpMMp61dv6YQuew9YzJBn0e4fCkUcWLqLcY6hyKJrz/2zimF7yorESUosKmwq3egB/7WZGaRB2d9Tdh9UxrkTxC2roUgh3GbCDBZxb6TPD4bHQkLEa6DeNGb67jkssiieW1gKPQOvvJmqyqL887cD/GBe5am4MugR/i7JU41FJ9RmTE+Bg2p9u/qghIOMl4464lB5+rRhPouu75iVGrOARVudF5dWw2taUY92LWTRgfXbvePglI+3bLMWseizZ45vE/yyVInzQYdF26y9MmKWsqh33oGUTniY2cxaocuiInFp6xOwYLL1/EcwP+hQt6oei9rkE/v+rGTR38/u9S8NUMcVRaUehizaEzP9XdAqFvm45y/5Z8Iiue/fPjoSi5L7F4WFwn2P5LLaoPXOG7LrTFm06OGVp98sWWQUX9aoasWiqthXL3mQpfnXqg1yKtfXjMDZ359ZzbFmUdhLfrI+VG6Wb/WCUu2fpk61YVHx6LFFhrDNpdzvGZy+ZPTQZHsWhWww2GsHfQMnREdDmbNb895B+dnxTL1NLEpdeVwzDIoNlqwc78CiBt+9GuthyBPTJeKOLOpSaGueA9sibxw/Dqs+NAkbofrIXkcHJxYZbJb8lw3P+d/Wbodje3VytXawqLFY9PKPM+q9uld6vwuLRgv2m3fBpFvVmxa7smj+PQ+ZI7Bk9eLtZ6Fl0W5TNTcW5bb/sGiBR+xHrpTux1zczLvv5sGiFT1Gwedg3d8zCVaeLJIUK7+SCKftHh3R9WKRtNPPR6nw4ZKVX9t8cP8w42bVIyxaf29vgR90TP2Y/xjadq4Mk/VFvOq9qj5wWkNk5h046DHEEvdDn1vqqKUHYq4y01YOw+8vC2c5BLGoJdWgLAWuz39/bhDa+TUlXgtH/GGr4lQjWFRuqZrGhEu3FMfcg2dcfjTJR7Ko/u0byQPwgPr+Ou8onLuzY5THYdFPm0rblVzU7bpv423onu1sLcvD/XlnFK3gmEPm+gEw0H7e0Tdw46TmZr0YFjk/vnswCX5/Nv7U3JMsCpiWExYAb+RGmw/A3G2fNi46xSIlr22zjsMpNi7dL2HAnpKKIfjgV8ZBv1gW9UtJzUiKR78+68rSP8eiD122D0Lgm4GK1luw697kmb1w/PUV4TsSWCTcO907G07W7FjbCmdvl5SzSUQ+eZURWpdY5P8i524yfNpQmxeZzKK4F9mPS2GSbv8k0xQWMRSvnLwGd838rV0GP1bMr5K9zCK1jtCXl26wiL+163Q9PLzSOdgzFXsnX0N2TBqLfof+NNsDD/PL+1/AVW4j+ctu4X5KvJTF2SzKLts63huuTdGoG5uDPfFiIh2HqrcGIj/AK05F1JGP+Uqw2nWyAPtCsUV3sOD/+0UyZ08hi957BHq2wOqtweHLiljk9yxxUTSccH/vUPkj1EXh3fxpxSyKWuIy7AxTLwe3P4GvDU8X/IOW+x//Z/0Ye6DIJTEPLtXLrFQsQX7bJ4Yur0Af9CyzdIS7r8fuOANlm8baDcDbMiFRbpWY5/zzpQlQRf7csjFVLNJSbhzeCHVfTT11BVbOv+I/vRr3t/uj5Q6tQkqWiuAd67xFRXCn07ZnS2swr+5Sm5LhszqPnWNes+ie637rM/CuejKr4j369PjfV5PrUP+2ha7ecNVXefez0PGFL+cmPLaYYy5Wj3yHzzPfDiuXcs9yoP/3kGKZDyz6pXmv8vlHzKFSo9uJZhal2McW50PTnhDZYbhwO0vKrQX98E0i/RYMjLskMa4Vc2gUkxbbjjpP33/7M8z8uHRBfAf2gZHV4haYm/JIc95X7OFl25SD4Jn+eboj8HvQ3+P5P7HfHFIbbLsRz5u2olq4LSoyz6wHe175gPFX+F/BKrV3g6hvxrZ+td/oG/ExCrnQrbhHrR1uf39+yvwhFpksDt5+GNauFFy+Ch9H20/og0sn93pM/IN97PpBW1eMTWluQevvwgjXNV1zxNn0a9bK53thzjZFnacwIO1k5HMJNp1VfP38nySbbAXNUSel2NS74d37F3BXSvzNfiiZZsjRksZzwrc9OwJXL+8aex8GKfvLjpdhU43TwqmbprBp8Sr9lylQ8bXQcKUcm97ezDXyh0aWYjMz4dVCt9MT5PF82dYUqalsEvgfs7mjyKZzozO3+Sux6WVyaPEiZTYx1Q/u9IfHbk+WvgZDfqpd74WR9RcHNWew6fS7adONVPHcjKM/j8H9h9SzeXDvJqaUhhqbJg0f33YUZsTti8+DUlrtU7ug2D1RgNUCNv316upWW8gmt8MfbfJhYGODtOYifE9QLBzQYdNXxztypkvZ9NN+PeM9/H1c69k+XTb5/PbuiIPnNXet+A+uZb3PFNNj04sPMy9YwOGzxju3rGRT8+r8pz1Q7mbur80GbLK5+bB2viGbNIs0b5+EGzI4P6RXsSl+zphaM2jg1DfpIYzOMk4/asKmRV+dvv6FUuIbFJcQm8p9e0pPwFwVPWElDPF4uVvSlE3L/5xZbwf1zf3youEV+7eKmTCx9fXmQdiUenLrfDM2jfbpxAdZsknr2vRqZys2eR/xHqmAY+Q8ns2wZtOHzoxaH7g0WaO/Fk4bLbY1tmET+4vgq8x6NvV1ZzLf2OHeTvumDkCjh1e3HbNnk57k3+An0DWmRiizCecPpF63hK37q2eJoOmVSWTpwCbfSBvzWDgh6lL+K/j3WEjh8+34/lNxQzNHNqWOK1leBSPEplSNd0KeW+QDl8IDRSEWcTCi+jLfbwebFqrbBWk6s6ny1Z2R6y5sUnNMWFQLM64cW/IH+mcdb7znivtPWfx9hRubPE9XHa47gOeYfY6Q9UD9O6s7beGqCzPOX4G3uK77GiBbTfWysiebwlbvDvwEY70/q+7yYpN1sllvBjR7dyZtxhE23fMubYmDemKrj872ZVP45Ffb3sIixzNbVfwwFyciulyg22aJuPtQuzJ9VkYAm1jqnPjn8Py+hStdA9mk/HV4TBKsCBaltEJZiSN31waxqet4asNr2D89ZNMoZD1L0zcKZtPDRXyZHVA95/uVz+Fsihl4c+5gBPJ0S3/ueWg3EOY1AGsWzR2zNpJNJ22OGZ+H8Y1zfkyOQjysSzwD2C2hFOoNtX6M4xzgwhsRre/hcrb6yAwem+JChxf4Qxt5/5dH+WxyNkjJ4cUgb+++vv4Cr2dtj/I+ySbViNu1DbA2y+Go4Sk2fQuXlUmLRX9OyPhTFI+5zuJnJ53DPtiY8nYQHtknr7kygU11j7r/XYDTPyeeMUhEnTYNa4TBoIfpB5YkIx/mgzkhsP3txf7xKegzmT65ddDqjZl/OixL91+rdxn7SBDzam8qm1ayXn49C51P7jW7Bw3Kvk77Aq+5pL8wSWNTZuSqnidwj7hw3JZ05G/Z/Y77t9j02eG7/x+YrLwrMiybTaIzyXPLYMJFg1CVHDbdz6lu2ApfPQqfy4B3DEZOr77NJhf/+eGPoG7r2ml/89k0s7vS4moB+vP8Y7UyGNBTfnZeIfZF7p2tF+Ei9tpa7SLM20ut9AoYJGdYzXvEpqNdyw4Pwu06Y419i9l0SVBsO/0x5uOly5J4GGWUMvAXnjFvmhRcgr5LXPfnHty2UWZNazmbkg6b5alXsCm41rvZDRYnxG87D3t1zrtUwpol7sdWVLLp42adCYnQzqExTqqKTZu9nNYZQ9NjNTM8qtk0Y7jvrlQNmx5UVZmmwFXFlapOr9l0POQ/l9Pw25hGvYnvkYff932y6tjkp9C35zsM6VUwUqzHczdMEB2CNmN1Vt6Gul6yMRVQY372DNEHNuWvv62fC+0e9d6Ra0bfjvplXochkxiLq+G4le7eui04/3nW7UjI+a4Wqd7KpnXTdp9kfkF/NXnojbZjz1p+OaTQgf16+OLk7ZC/w3hFHLSqEpN6BTtXPK3lfmXT+uw8scnd2Hf7o/N4cGn+oNx9OLXoltQfKMFY03RtEHlKP3xj5m82vdml7REPnXf+rauB0T9v9yoNIY5muZFAmDHwaN09uN7OY4XKMJscRs7NKPuH/f0l3EFSjEMHuU91p4hzqCb+3edNcNXYtsF46Dts1j5ZgkOOIaol86U45KJiHrwfzg7hrWyAnU/F/8hLc0jl5wHJ7TBi20WtE3Ak+KXHOBkOff458ZLaFA65Ri5U74fJrztSjeU4VP3LfFkwVNGePuUmdFh/S+IdTHCZeWKaPIeGqiSnceFqc+Pho0ocOuAQcG8EvjSTLL6izKGqmU2f/sK8Zb2LbWZwqOm92uOL8OSu88/XzuFQyds9TW9UORQXclVhnBqH7G/m/NsChxq3rTgDv47O+iCnziH28tNjpi3g0L7hLu8dcFb6xaMsOPTC0GIQxshNvc5ZyKH6iYI1ZVBRfFfY/EUc+rHR7r4d3B3WLR0FKw/l66cv5ZBJ1J8UcV0O5ZdKt+fAFVbz16zT41DXupu1oys59PY/9VovAw4dHpKTaIdBZXvPWhhySC21+3QpbN1lbrViFYeeNW6eWGPCIbGSDjsT4lAu21EtHCq/OL6kE6aLe/qam3JIe8ne/VkwzzpWsgPaXE32XGzGIeMWkxJPSw5p3KjdLmnNoct61hIboaT4JJkymLlq3gs5G+Q/xrg+C07Y8CxxnT3qqSPj5A27+ha/ugQ1dh57RJs4dF3ucVcyvDByOq0XFjgc1jzggOfNrvC5BL9Xrm+ogHPn9QfpOHLIclz2Kx48n5o0tQMOnppzdb8Thwy2af98DYPrtBr27ODQlu9JcgnO6Kd9VgrLXBG/dYDTPjhG4b7yTcjjmWmVwyUbHw3McONQo5Laujx4zbr/9ZoDHPqbL/Cuhx+mpjcf8+DQl+5bYTdh4WRu/guoZLJ7i6knh2xrf108A1e1hKZO80Id+zoVG304NN107Z/pR5Aft8u6bLjxVuxeCV/EKRVENlBcjn8Z/xSno0rRO9T80H+P0jK6j3JI4tMCsbGBqC9LMvoGXMZt1RwbxKFTZmnrfKBy37Qt8sEceiFW+/MIDKj89WB+KIfMl/X37IjgkE7Xk7MRUO7Six9Gkeg/r7U/wmB71uHVHXBNlO/okigO6Q3OO9TOQb+lvDTz53Ko9ME56wewJ7Bk7UQeh7Y/8PVMgWvWvphbB4u0bu5X4XOo4Z75teSTHBoQTLhTAB/27c/QjsX8qtfo+ML/sltmF0P2oZs2/+I5tPBxcMb4BA5N1A72vwtfpl5/OCYR9W9sl7iczKGQqrZemRTkbehl7z6YeXj8+sfwVVPNQbHL6Mev+tLnoZHCdOG2VA7Jbo5d8RWqDbJqKA193Oq5JCQd+Wr/vPoFDMq1+HYgm0P3bWdGf4I3jsw+KJeDfN+UVNgJH6zetykTzuyadXHVbeyH4GTL5gIOaU2ZqDexkEN/jt/abw6/DLAiMqHbt2PxVMyhrOeBJwNhTOha21/w7q/FdYseox6lxV4CeDs+1rcC8lyLzJRLOFTxb1TpQgXqp/g5tBlu1JPvVank0E/G9EPbYWh3e/FluP2f2D/FKuThel+OG0wfWFGWWPX//uGNr4FayyrMZ1djLrL/690M7RMu5Uys4dB7o+UltfBmVsLhPzD0jsHPC3UcUj2efbcIXttT8nlePfZhfP12W7j10R7/MJjjv2jBAJTYMUFAzaj/8NWTr6H8tj0ftVs4dGZszjsRrJSyiOiD+eNfHZNtRR8dfXPlWzv6vuLtU7MO5P+ypD0fyswy9euEmcMLnJZ9xf1C4gwOQFVD94uXofSRjeXdMGLNB4cJnRw6kXpi68Vu9KP30i6ZHsTRozvgBYtKu1oG4dG34ucW/+KQgtqJmTwYU65Z4PQbdd6TGVMAWQvffRw3xKE5kc9bnaC7sYCTAse9if89BIWbOnudhnF+tp7Eeziua7xNpBiX/hR8ejJGnEt9GYMhBrDB/ZulBzwSsks0AC8eD12+V4JLdpPWf0qCGVfur9ST5JKppkjMUYpLDr0G78/D6KsBR8dKc2kk7LMRwVpp3rqDsOfpB0E+HJt1NUdGhktGlT6bjOAseanZ/vD8z/LyezBk1rW0+ilcepFc9nCxHJfcKi1YZXDr1PrHozDRpFNgK8+lxfU16T8VuWQ87cmWfUpcOmj7e2spLKrkOGgqw89mbv3QJ9AlwGwGl6YrmjCN5+BejFQZY1UuXTOnrnCophoSuEoNcSXuDf0H96xcPmuzOpc0UndOSFjApd1vrveVwfj9mZM1F3LJ+fYTFw/4uWO1ViqcU1/36wuc/GW2fcYiLul3vDE8sJRL7Y4r3mfAh6Nvoz7DQg1xTUldLi18pXhrHfSbJakcDHfNGZXPhV3TOxtn6HHpmVOPmA9cJ1AdfghbfS14BQZcehexvtbCkEtCZ6asL5xbavNDfhWXxvyTvzeXkA+x57fzoepzudXDcJHOemtLUy4p7iySvQo3fn6lKmaGes4yeWUJLVplbe/AxjF3e95Zcenyqt8qc625NCEvWnYXzK+x822FIk+D4Jk2XPpRvpi1D2ZvWbe2yo5L52KGfOTsuTQlTlRbAfXV80b+wkXPq2SjN3FpZZ3Glj0OXJrxu1nFYjuX+nUG21jwjdff5cMwVIezwdIR90k+UhsNg9M3GT+Gh+p7Tsc7cWl+pHH21B3wzNWsVBf009PX5gdckY8Ga2UJNy69/igntQXukZhTVgLTB4RKEz24tCVy++ojsFh3TkghVMoctbfzxHnpOUVJ8NCS4kNbvJAXptmKHshsc9OtP4J69eoobvTF+/+Fl5yAMqeDwh5CX/3a3G9wb+/r7Q2B6Lf0oXGrgrjEC7oz8zxkOavNboLxLsc5C4O5NHXWqionGHxgr1FDBPKU652/LxL5vad8LhG+yO/XO87F9+8p/3oFu5K5Qao85KGx2EgI9WuqlBX4XJIYN/hiC/ykzvuw5CTuOe/NUU+4XfVd9Rc42/Ta6bmn0BeGB+N0Y9GHQR7T+uIxp/e+9bHOcamMLbW9Ehr8PfxMN4FLFx6E8C9DUY//0wmJXDoqfnj1wCXMzacs3t5kLjGGjr0pggap29aMT+HSyddPW7xhy+tDzEfw4ryA3QsuI74pjq6H4UHF0Lvn4PTy0gKzVC41fZsVGg9r9loseAbfXt373+001K2vqa0R7mmNOW2fjnk83eG6HzanLg1Uzka/1Sx+fhnu8Y7Q18lBvQqWd4XA6w5qdRVwIFSu4hs8cfGvjc9tLt2ruahQDP/48fO8CvD+dqM7NwqR/0nDw5/hq/iW+enFXHpQqS0h8ZhLm/y7v9jAVuNd95Ohp6KpglwJl2KPGBzmw517C++8K+eS/NCPgwcqEPfLqYwh+D6ly3hVJZfiNC8Us+EfN/cfXVBzWH3CsirM8YKpH0/BxDM+T7ZUo84OSQkfoLRLReTCGi4FlDzbFQuXHBn46voa+4HBYnyC6Z8rBv3qcA8VsQ3T67lkJaf5WPwD+u+3eVcmfGP1+qBkM5f0TgaxDsIAHd+Y61A6eyj0L+xeev7OghbsH9WP13ZAsdkG+jNb0SdJ8d674Tsj5/3f2tGXJ9fr2ncgj8ENjDDoYuGp0AYXBbhm7vuKfdT4qioD1qn1Px/TyaUKk93Lt8Oynb5hrt1cWrHtUmo5fHp4TahvD34X1vc+S4GnTGQnyv1CXQ1XN8zp5ZLt6vl3xX9zKTw8PCECvk532pU/xCX+4dU/mv5xqeRBgO8ZMR693bKlYATqJVsIHcV5FC0zEHpUgkeOpSVpIikeab+UG+iDn9VeSJtK82jrdI3c4/DDuUGrO/9/HcxIkpDhUVxVQKIPbNpoZyg/hUerYw+Z28Hpy8X3RcO/a00uSMjx6ERi6e6tMObE/vE10FH1zrwt8jyq+i915kolHkkMqHqnQJm0gXfPYZl+mPt6ZR5NjHEuzoYvdo27P34Gj+RCblluhccOemj9g9aKNU0zVHmk2LjzrwWsqLxl+Rv6/dysv1UN31sR4x8JM3VeaH2ELhqJ+dbqeM7s7bGGC3gkb87VjYF53KM7nsMZlvku4xfyiGtqlxUJv6hFWmsv4pFk0amrB2GY+vyWlzo8ErxIj/FYyqNVxzUVbsHBIv52SV0eaTRLL/aAod2G/CdQ8lQy31qPR+kzvRIMDXiUenDmwSPQ8+GN1D44K0llV4Ihjwrqg35WwN4fCm5rViE/rjeSR4hH5pmbfz815dGZ7aprp1jy6DfDSOaFFY9CTGcI7ax5lCu9KPwU3NFmoP0dPpPP+mZtg3xmmsU1wIcO7mXH7Hg0bv/6LyvseeRqbeb3Ei6o98vV2oT8BNxLOgXDD/t6l0AVa+NF5MAjM7nNd05AexU97wHYsO9mg5Yjj0r5xoZe0HB5v+p5+GPy7Ktt/38/6dW2iU48Yit+t9wB12S/dT8D34wYzXwJY9P3PbRwxnk3ajuG4LB+Su5qF8T5snFcGLw+28OrHX7sboo1cOXR697v/R2waN1WRTM3vH/R8ObTA+gP+axpmh6ok7LkSQ8YP3fx+YfQaMnw082ePBI6mCyogVMlrJInefFoduiWPl9oUW0pI+aL100+k5LglEu9rgF+PJrw1PeVXSDyozWvVCaIR3NMDlskwMad7079hRu2llxYFMEj2di2GuVI1DtwYewGOG1k69yzMFZbfekP+LNqveUBLuagJ/WSHA99KXmkfC9U2tGedRUm7mvmfId7fgXtM+TzaOiaZmcmzLGLeNAL09QmWq45ifOSx702OcWjuqkagXdhzeHHxXqx6BOm89OmeB55qFz1n5PAowf9ck85sFRzobZlIvJ9XP5zFxQtSG1+kMwjt3NyBvopPGpvvqGXCfVnv1g9ChcpdflYpaKvNttXaaZhfrOfTr8F7aPdE/7Cy70KppSNOWKKXrvD/oMb7s7K4VHGiV8BrnBaS0LGAPxapeFjXYA+jU26zYM1bh+YHdB9alxRSCGPKN5INAprBMPRXY94pHVqf7ZNMY8K365wPQzLZy+4XA8ZgSPxPo/R1/uHL0qU8OhizTiRK7T1PREyWMGjeyUhoX6VPLqbUKH5Ek4aLitcW8Wj3QMSoSXwZtzkTOYrfL6idFNdNY/u99cNLqjhkdgtR4skeDp/0bPPMPlGjITlax69X8IM/A/OvX7mPdXzaKxNy6tcGPNpjceKDzw6bqLZ+wn+ON7yPrMZc6yz+G0LtHgo0zOvBf24MXPzRSiV/WW6RSv69v5IaSZ8UvJXe1YH8jkrdGsJvPzg9QG9r/g7p3GrNzTJOHf6FFzruaZkRyf2atrU4Yk9uIfanCqCrVFyrGK4cV2494ZfiN/u3PaoQey/Lx/y9/zm0cytO52fwL3F1u+Nh3jUnP17oxDqF/bOrIMJlQ+mrh7mke70c2o74NAN6c1ZMGJ+YLuJGJ8+XXxzMh/uaFxv2wbfiH38biTOp3HBM8I7oPbE6XMWS/ApsWPxx/Xw7i6rP6fgnZ7sQqOxfFKTkMpQkOLTcRFvdRFc+qmxchgyxzYbBEjzKcUz8EQLZMa9qzs5hU/CwdpH96ABnd7cA/vv9JWtkeNT6r0x8tGwzCjVbQhWl69cZyLPJ509b3YeUuKTpcH961kw4pfS5KPKiJtbFvkMng5Mch4zg08nF4T2HoV7NUf2fYfDD8Qfhc3h05d5Wvouqnw65J0mexo+nhq7fa4an67fSu29Dr9e8Vw+soBPdr7xRzYs5FNOnEzweXg607V3EP4KXH6sQodPYoXvZzou5VPgW40fk3T5ZB1vkp0Di3t6WZv1+FS78XFELZzoYqIyClUTxmabGPCp44hhBhsWzPbfWg2dOHczlhjifIFL2HF4fs3U8udwHD9uif4qPlUcaMz3gvEbkoxfQvfWXr/5RnyyumuWl2bCp3e3p8y1JD69DB7qiYL3Le8tJ1M+Weh+sy6Hj0xON4zCZ7eW+AaZ8en2v4M6tZY4J87gxSMrPuWf3pq72JpPDTsfNUfCPUmOgZXQ/timYEUb5PfPsBIftrg5Glyy59NamZ4ow018mreCuSIceotSpxXC3/rnP4xzQJwTutXuOPJJfJGMm6wTnrNxks4W6Fw+L7QERnjtMffawafZDNu1Xi58/L7/KdzvyifFafM7r8OPhq2VMm582v9I0rsH3jYtvT3Pg0+ThQofRFCs6d40MU8+/acpdLkKOyPTAyZ5Ic9ZLiMxUDR7XdFbHz7N1YiYfPwIn7qynZ9lQ9cVP67N9+WTwMCV4wWNDD5/iYMWN94lOfrxaYH/jUc1UP+1y51VgXyaKnanMA7KVY5L0Qzi0+HYLxvy4bc809/iwXy6ZVb3KQT+7m0Mj4ng06BUXdMDuLSvym1qFJ82rxutMoXnMwIfb2fwafRBnh6fyyel3Trb7/CQZ90Dn//BntBtv3X5iHtAemcxXL9AZo3SKfQ97xojEi62z56jEYu+ObUztegcn8a4BlgyE/ikvH3SrC/QpK9lc1gy6hz/e/gTtF7g3rgvBfnYHD3aAA/djLdyvsyn7hJxRiCs9FD+YH4D+UmxrRiB18vZsxxTMZflt1fcgJ1T5qUrpPFpmfZvngH0MNJPiYD9ThNa7sPa8PYnJul8atppUvM8m09xvR8YI7Dg/COOXw6fbjjsUdC4jTnpz6o8Bg18b2fcKuDTnE5zlXWFfNqnOmp1Fu6MWl77Fl6UZtqsKEK9J2mFseDxx8uto4sx/0EXQsY85pOnf8rRVPjztFheeAnu2zFG4RccN9oXsLES+Qj1kH8ERXuEd/thEeOaWngVn2bNiJ43Us2n9BOzbFbV8Kl37jiHS/D5p7LKV7DH1OiA8mv040zL3HhYr2Jpkvceebs+Z79MPZ+kU357VECufszFdR/41N5hce0ojDgWuWNFM59WPyjqGoan2uqjLrTg/PrTav1Qocng5upW7MWN0kYKHXzyWr2FcRKmzKlIn/mVTw6zvEPy4I+1ttlKnXw6c2rtepVuPl29UHXtLHRKFy206uHTk0dq6d/gh5JX54N+YV40yxZMHuJTaEf6FF/IWBwZexVWX29MqYVX9CMWzR7mU5LgxVNxMQH5T5pdlATv+7ImKYoLyFnXY/kJOGb1pXuX4L4hJ+WPcDc/222rhIDE+j9FhkoJ6ErWLf87cPROooqctICssiSvO8AWZ79tZZD9bmaimoyAFq9dPWA1RUADYaWH22CV9dlAHzk8T1t/5iCkLW6rnZQEFNDuNiURmr/UctJQFpD1Ein5jzAl7tAD3gwB/VyWoeWkKqDawdU2CTBq/2L+eTUBPf4pEDRB5oyVS9eqC+jaBkP1r/DQFN2ldfMF1LcsbpnqAgGJT++L3AlV61+tTYYvhqUKxRYKSHla/X+HoTbDvbcLWuUst1q4SECbLZO/+kItbinzJfz0zfOF6VIBrZdxUfeETYfDOT9gXfb3T1G6ArJQnzi3Em5et0NbXk9AhpuaSjNgrTmzS85AQF0m41wUDAW0TfduzD6oWFEbkACjBsb0e6wS0PWX03ty4Dr9vpUvSUDvlG1TvEwFFFcaz2+Ch1+NXXvVTEAPvojrPoETMiLON1oJqHjxPJUhawHl3e8fOWUjoPfzxQzb7QR0OWdJk5m9gHqtcrRD4binZllvYLtv3bHJm5D/w5bfCPqYyrWJYPOjj+99HQRUf9wjNcZRQINBikI5JwG1eZ3rc4bz1IwGMuEbD75dHayraDD5C6+VSLSv3SGgjSU9Bio7BeSd+bz1hIuA1hj9862AESQtxnFFH1xOsLgNV3wes7EDDq+40aTnJqCCf2q8XTC1ylXc3UNAGRdsDRqgWUONWqSngOYWdQalQ1ZFkvI2LwH9dixMcfMV0O33Pk2X4MEfOuGdMCR8vvvPQAHJ1d9uXBQkoJkHczefhG9WjX4wCkafv2GIL48Q0IXBc5U/YO0sXzn7SAHVSH42ZkCfnIy1L+A1G9YJyygByd7Q3rKFK6Dswh1dHyD/o9OKnTzcU+/kzjy4N3HqtXC+gCaPiQmqhmrHdzU0nBTQjxp259xTyJeGxd3rMM4iT4xiBXRS49iBE7D9TKHrhnPoN9+zRY8gqyXpj3UC6nfWZ99DuDpGJ7ALRnte+c8xUUBHN6myb8C6mJ2zfiULKCykIUc1BXU2G0uTL2OepsgdNIffrwWd/QdtxseeWZIqoDPtveknoIfzHZ/JaciPOaW8hT76vzpd0gVknL/t685sAT2XkenUyBGQcHzIrRTY5GgoPuY25neTVeE52D/4PbS+QEAjJo1Zf+Cok72aaaGApj48LuTAbJvtNY2wV8LPUKEI+8HNTHP8YwFJF05fthW+/XrC/yWcWqsz5lQJ+txbe0l9hYB+zVex3FOJPWLtVvcQ9hzY5ZRSJSDf7RcfH67G/rF7XnQXGs2++rkHti1u7t9QI6BjRuGu0VCUoXTjyWsBLdl1avcXGOa8RaW3DnvGTvv+/noBpfkPuJh9EFCujMDyEJz0wXb2548COm5s86WlWUDlPzUkl7ZgnqzPvtoNmQdfpt6DVivWz3/SgfNbfa08v2Kevy0zLoHah2WLl3Sjb9a5rHoLv3QG1mj1YE4/rBnxg46a9sGZcPaXqnd/4UDdBU2XIdT3dEHmGbhUf+OYhcMC2ulxUeEcXP9q2pg6WNu5Y/tMcSGdmjRurBdsiF0ybCQhpLfGlwLExwjps5PdHXFpIb2feOCLLYw84escAuvYhxh9MOT1sMBaRkiGWroWL2HM7ztPd8oJKf+uTHwutBi/o/uWvJC+SY4zW6IspIF4/4zTcHTspLNqM4Q07/Uhk5fQWMdc8G2OkKa3XS70VxNSiVGtgbq6kB7mLKwbN1dImlLN78vnC2lJtWJy+QIh7bss0yK2UEg3pexX2MCDdhFHBDAmr9ChBoaUnQict0hIZ+Xynp6BM8yHR7qhdda1hidL8Xrz9DYFXSE5bwipPwuNfxk1ztAT0qGy6t+boewjVfdpy4T0yfdN2BoDIe2V3xt+AUZ5L6xwMhTSsfSuVRmQk3u0QWKVkC52DV4Jh4tYA51pJCSuVOGmIFMhjRnxdmyDv6KePDUyE9LKT4kdEfDnrsvztKyExBiRaS2yFtKge+4dKRshBTM2mTvBV+YVbxrscb85f6tmbRKS7uiEn3lQorbvRwf8zP0Wp+EgpA0xvOpI+FHM4Iq0k5CeXp7zQgj/TBXERe4QUtJ+hYhdLkLKjEvf2Q4zvr0V13YV0uMBwQkRlB5cfSLUTUguF2/92blXSC/YiiffeQhJdNaK1LyEpP+fLWcXtP2qLXESsvlzGhUOCunLYJzbVnhqbtfxI0eEFHDnYGgO1B8zWqDrK6TjAg2n3bAws71lsR/y9n1SbiBUZfzapxQopIW5y0WP4bH6Pwn9MP6b3NpVQUJK55jaR8HKZNt9A1DnbO41r2Dk4foYz45wIc0p+UkmkUK6I7Y87S789d5qo36UkFJz5hm/h+sPX/Cu5uJ8+aPm+jwh7WlsyxbCZTOY8Vv5Quq0eyEKhhNMd2efixFSllrWtoCTQmrNTPjyE2YZ3ZPdfkpIh7eWlJ6Hpbcmi8+IFdIbA29F3jn0YdOHOrMExPvG8ZMvvC1zeN0HaOP8S2JcopCelfo4HYKD09XeOSUjvklpLWyY92icTh2cn+KUNDdFSLnGf8vs4OjswtNRsFHaUa4SlpSKEniXhXR+aXpUT6qQFH+IXTFPw73M6Vk/rK4PUruSLiSFiavdYrOFxCusduqDi69e8j+YI6QH4Ymz7sKHsp+N/0LJ/CrvpwVC2pV7T960UEgqautS/aFB7oX1/6BT23nL3UXoQ932pt5i5Olw8Af9x5jT//4zjIY391lcqIHVyw579MAj6ay550oQb3N/kUmFkOKysqu/wqsaaY1mlULaFOCQ2wW17yss4FYJ6ajPb6+Waszn+ocLVGrw/NGpjWUwScpOy/s1+mLm2GcpdUJyC6u6O6ZeSN8952pchuOXTrgl8UFIlqFe4RINQkoU/bBPbkafV381fgPtJr2Wk21BXW4u1nGHxho7lyZCbfvzRyxahaTkMz1GAF8FNj4t7BDSNLfGd1u+Ckl9kpL2U3i98/vp5Z1C6qvTjh7bJaRV0Yq9j7qF1LHlx/4lPUIaJ3Lv94bajwNi++GYDcev2v8Skr1AuyhlSEgfRr44LxwW0t30xHpvaK89XjZGXESHcuWvDkHl93/qfSRE9EHG8XIS9OBpSvwnJaI2jYB3O6VFNDUp3fs8LHh9+xdHRkTtM862TZIT0fdwqxEhlHIvS+yGNmvPlcbKiyhbb8RQW1lE7NyjWRy4NfbSGNsZIrrCL3YVQaG89bI/c0TU43pQTlFNRHGtC4RnIdOk6z97dRGt4J/VugB9/r6YLz1XRBvH+vn/nS+iDq30XSoLRTQ8yVJDAKeLNjgrLxJR3WDaUhZsnDKxvBr+Dv/Jn70U3/fX/fEL2p53WmqtKyLT0Sv3/SH/5brIZrghNy9lUE9Eyd96/OYbiOhb0tTwYzAk1fm3j6GI7q264HoGXlu/QPk7PFTwMnXfKhGFheWZZcIes01FziQi3+AZPu/g7ZSdm01MRdSpIZj7F5pNDnntaSWimfZ3Tqtbi8hL4rVCEozS3XWqG7a+vXjVxkZEu74u62TDuggV68WbRHRcY6HtUWiTlylbBQWDNr3SDiIa8RqjmAaTnkk3ejginu71/jOdRDTbqdwqHLp0zHr8Fq4fvBlltkNEryPi91+BGrKn1+a74jmrvKIbodS66rmybqhHwrtua2ihXDyg7yGiI6ZpHwNhnirDRd5TRDu11JzXQ/nqRCc+3PStaW47zPxv27oNXiKqjozpqD8ioqa4rVkZviLizOqQn+6Hups7fLKDWr+vsjLgiOe+bdmBInLckv9AKwh5dfps4Q4XiBr2WwaLaIyUfurNCMTzwWTWskgRNR+031MAm85WjP0HlRU/N2ZwRfS+a2LJbL6I/mRUBzyCG1tqNz0+iT71uekwJVZEq8av+X0T1i4vcB17WkTGXT4FKxNE1C+UL/8I7z5mNjckimhNfDR/VpKIfgQLn328JKKfV68P+KWIKHFyuOcbKNeokhN5WURG19+43IVTa59GBKSK6Ixb+8cfcBt33AOHNBHFXzWfvyBdRLlBhld0c0T0SPJTkAe0PnvJahT6h021NSwQUaHqC/N38O7ZWQXzC0WkcPXq/iMw58C0YioSUXrWw9KdxSIKaly9iA8fH7wRMAJNDU/E2TwW0Uf/2MVM2Juc36ZcIiLZERLshv73DX7LPkGc1yYo/qpAP0yR6NtTifPfN7vdhesjhkykq0TUIPZk0AH+0Duvz4WDG+u1dz8T0cRGOZPTNSI66H5katZr5GXKi6SjdSKaxb06I71eRMt6+pR/QKUFLTyrBtxj4r8+y2bEXX1OZWML7iF3zu8UVCt6w/oFb0T83VfTKiK98qE8ZoeIRBbewbnQX6y/cdxXEQWkPCsvhiMNY/ZM6cSe6Ob3BUJdfycHkx4R3Rc7Ip0MlcRS5nr9EtHDVSduBfxGXpa9FFbARa+M93XBsQ9kzOYPYa7merHPwihGiUI7PDPNbmrVsIjervGISv2H+FbGyvaJRdObE8XTnMWj6eqS7tRX8NOeNSnXJKIpyfLyq2VS0XRpzp+HYfBFqOfxidLR9OXgsm9mcNJowNwmKNa7NUlCJprudqz8j2DqqrOVF2GhrKr+rSnRdHmf+jQxuWiqK4/HfwSjqVmYubkRBhv5rlOQj6ZdfTPtLOGUwnaXNLh7xeukLih342NrsnI0dTy0nz5lRjS5CyoebIdNU5d+CZwdTV023qEOavjcRomFWXDDEh22kno0Lbq4KEdhYTTlJHuWhcPVqi1Zb6C7rOnCP9AiTJI3sDSaHE1ci9bqRtNyDvvPCahyJf76Kr1oUo698HGSQTRVf9aeLG8YTV7fPuXvgcXuJc3X4YYzkbl98H1is5z8qmgaTZPTmW0aTba9FzIOwmVvjivNMIumfX9VP/nB8vG5KW+hX/q8DZusosmpevuN/dbRJCsdrpQNq9qGxlnbRNO3M6puIdD2u+88+U3RdO1j9bEeWDT+sw7bMZoqBjzjG5yiKYr3bYvcjmg6pHVhYCPM2/395jjXaGp7WDjxEuwwX75NzS2aptqfHzzoGU0Oj1vru6Dp9zkLpL2iqVs4rs0aFor5zp98EHVdl9kzH+6KHNn6/Ug0bTXfaG3sG02t0T2Kof83wiuvB6ZWdz438oummbr2gqbAaPr1edL5yKBoevJtjeZzeF/rXGk3VPexfqoQHE0FHq1X38JmL2m/gvBo8peUq/4bEU2lelYesZHRdPCLYXoTnHaq+K9MFPK9V+q7JWw+MvzwHHQeCc48x4smc8XXXyz40fTQdLuVz6locluu8t01FnHrVPq9SIimv7V3C8wTca+lX8++So6m2y/iLRekRNP6ja6S5nC3lK11LfQK9WvafRn9GjJppBAeWtBuJ3YF9dlde3wRtMt1aNyZGk3vwtx9UuDaNVJe32Fu/h57Rlo07TfuZpZD+hM2YpYeTaqFezMKYa1txcVtObjvwJLKenhSeu6wZG40/WY32sYX/v/8NnH9omhaUbDsdEFxNGUFXGy6VhJNEx11NDiV6BfDWU7rq/D5BL2qq1BM5jd//LNoEkaMvjKpwZxMfMb+X8X1HY/V38YBXEWpZEURJUVoUEgkuRBlRkYpCalQfnaolJRkde+7iKIoyUiRmSiKpCVFRppkpiIq9Xyev94v3Oec7zXPbdOLM3RS6FteOrQ9plIx1nyGvt/0Ne16fYZy1pyqftlyhtYdaChc0HqG3pou2hIJN55I+tMH7b5LWpi9wZwPjstchkKeen+l2zAHrcrHYruQb3ud5gdw9Y+PFkveoQ6Ni3VV3mNePB1/M6FBV0zugu4zdI7ZlHeiB/1450pGPvQUaLo8CMtTzr5L+IL+XFPv1gfVjU94LOtF/gcEl9yBOcOtYuyvZ+japT+aS4YRf0euRBBcdvr3pWdwh/PIsMo3xFd87sF+SDoF22+MnaHjty27zMfPUOglnwuJUEzuzsYP0G2hUqLhrzMkOPXjohxYyRV2TRZgUEnG1sbQSQxiz9E2y4J/5n9b9x4mBTRLXRJmUMKa3Z3tMO5XYuTC6QxibTdKPw2jt3to5kOFB6+7vGYwaNP+ARmVmQzK1E4sThBn0LUTwbfmSzDI3C+i9Qi0n3443EGSQS3+U6eVwcXzpi5Kk2HQx/2vt7+Dr48H/VwmyyCx7Li7fjDV5NuLzfMY9Mm2Kq5yIYNkP27zPqHIoPVlTgVLFkGZgewQuHVPUkEmtO1q2PFTlUGTH5Qmz1dj0LIpzyt9ILfGsCQfDhQbZEouZVCN7JwmxioG9V77xnsDUyskditoMigk9lvqBihftES7Gu4yYo+90WVQxVrFvFQ9Bq26nMeTWsugL2r1zDAjBt3t0aopgtvEx0oHYb3SO48p5gzKe7T0lLYFg5aWi7ycYYl8bE5YtMgG+RCRqZlhh+tD1xcYQ9avopxUqCMzJ/LZNgatvfTG0doZcW0J5LNhXPngSD/kBBr2b93OIFezFx6/3HDOT8G2e90ZJGUm1zgGt/o0TfP1YNBKQUmdU/BI5qiEvReDGFpNsxd6M/D/u0Z1Fqxa8FZxug+DgkXHBU5DN376jXo4Zfj24lX+DIpVic69C4/cW5rqHoDnfdj36Tq06sz+NgYvBB79FRLIoH6F9W6rw5DfrEymWDiDHMOued6GGYsGlnyDbr43JDQPMUhE7H1HNDxm/pnxIZJBnkeu/tQ8zqDH6XOE98KDrml1d/7vm7hW6Sj0h1hSe8T/bR6zXh3LIAtBx8KDcFaI/5LHUOoXU2BWHOoc/T4/Hhpv+6jwFY7nO930ZiGfsvRHkI3+2fzGcTqHQe/95vQtT2JQo05jSC60+h0s/w2uVfb9mZ/MoI2Wvs9c0xnkoH9g9Cosq3WY+QU25OiV2F1CnvLjN96E33vjBHrgfrNvqQFZDIq48o+leo1BZy7HH70I5T2cj0/PZtCYpM7WS/CoiCH3vxsM8rP6st+1gEF7trQEceCHS5uOVsEbepU3ZW4yKC1YT80Vso+FPGmCVZVnZzqVMij8zL/aMmg7VHP9G/x9tjBPoYxBTR9n7kmELYNZarqVDLp//plWSDWDrixZmqJ4j0HZOiXZjvD5Cg3huzBoKt+ssQ71euZ49Hw9g5r1ZC61QPk40YOKj9BH3Zp3DkK9B7s/FsLrjqLvLJ4zqEjEMpYPm/Lv8Z7A7qijwateMOhU6TLKg5K8qCvqTZgHnvAy0RYG/dzcNCL2hkG6x1LlB99hLp7oXuP1YN50evb3wbO9nxKivmA/fLRJeQK/Ptp5ue4rg+QCzK4JD+O8vTZVU74xSPpXXkzeGPK8ZTxNchx9lVS//zZ0HvwgKv0LfX7rYMkuWPZgJe+YAJP6VijnCk5i0oODMl814XPvhIU+cFLOqaBXgkxasEZTSF+ISW253294w5ebSz1mCzOp5drtspXQSrfziS8UXRUcVQynvlXJewc9ShfIS0xn0rsln63VoF6O5tqN8IrUk2C+CJPSv3x9fQu6R4bWrZjFpH+ln+a5wy3bZlUmizMpt7/QtgnO3rb78C/ov3hQK1yCSeK5JR7FUkzaFPHwdCdcsHDq1L3STCr3MD94XIZJiazWhGJ4KlAnQFyWSSOfFhrvk2fS4HPnERZ0KJpemQ+1JvIceiDbz3na0vlM+kHml7dB4xM81sGFTLLU2vD3NkxuNe79DZe8lhwUU2TSlxm9R7SVmCRVoKoZBH8++OJVCJ1LSt9PwO/S/gmLlZn0pGHaHyNVJtWVZm3IgWH7+w+9gYqsqiW6akxS19pz3XM5kz6InrnFh1UrLfz64CbbkxJCK5hkq9ZgpwEX/lTa7ADXz5NjR69kks6VzdZn4aGhIIf78EKz+dtemJ54P2aDNpPmGx35zYJ+Vo6S92A6V0zjA8zmi1nPWM0kVcsWpVVQpLhrbu4a1HlQwN5Gl0lOMZdfJcKJH5f33If3OevNJuCbgffMeXpMku+e/n79OtTPvNnOEfomnFNNg099NUXz4Me8JZp/oUMYJynMAP00FCqwgZgkFFUrcQhaJu28VQCD7OrzJYyY9Ccy9vkCmHTCMCVtA5POWeS6PYCFBuuUpUyZVDHaMrFjE5Me1T+4Ew1nTG8PqIWLmYNpwuZMEjjh+mcd7DTebbQPymRtn3C2YlKI5iOrQLhWtHJlCWxcXLG3EzYZNmyXs2ZSwNQDRwzgj9fcKRm2TNJNnCtRDe/XF2YutmNS95+MOILlDjNKIuCUpQKZBx0QZ1vaogo4byLxl7YjkzbHOL09AHMYsvYKW5nkXfH0gvc2Jn2Okdc5Aqfn8cqLoLzAU315ZyY1FLxosXHBz+dMNsRDlouT5y34ueoB6zeUKWaIy+1kkmDlbAWd/6tcdpDjxiR9IdbbEahjrlw/xZ1Jqz8beMyDsm8lzq2F32Q6dyVA+cr5bi88kff1WYFT9jDp4daN21UgT+B5gbwXk9bpHFF5BGvOur0V8GYSt6S+pvAAk1KObPZuhZUp67OFfXHf+wsP+cDuTaWGP/2ZdPoPf/W8ACZ5/bOy9IE5szfcvAsfzuVoNwUxSS4xvuR8MJO0BdMj6+B/S0w4XdDgQsOYVAjqFM0jrzAmSTd++lQF97y/4tMNN706aqgXzqSx38HrF0UwaSC4vMMtkkkrfzrvTYYVq1u5dVAxVYlNx7FPyhpF3CA3d8+Y60kmbZzxWuYt1DK6qaEZzSTmvYaq0lNMyjgjPaX5NJMicgT9psYyqefhXTF9+Nia37UNxhQ4VZUlMOlv/kC4RCL6y1dtnS78eDbq+U7I33hUez6TSQfP2ZI/nBMjm1QEV3l8MJvBYtKifU4jGjBQecx1B9xYvPPVVw6T4kS+rR3nMknyyhUfTR76L2VV0NNzTFIrnXXsN4w7p+uzK4lJh83e/YpLwRy5FxyvhnLnDSMlUxFnzdnHPtD6z7bq7DTUa15tVjvsnuwaPgFX1mn/WpSOPamy/r03/NMwL0zvMpNGjaqUbDKQh30x7ilw3+Dn7OtQ9MeE+TeoaMhWsMpEPx/zeOMBn+hJbT0Ow440XdK/iv4PFqh1zmKSnaiYcyQ8Ey92rhwaHPNMaYS6heLK/2D25eXc5deYNHcg3dcVdrOt5m/MQb2Xq4zvgwv+mAxdgPcOe+W+hY9J0G52LuLx+7poBYw/bjFp9g30p2+zriNM8jqtXwNrezszBAqwT2VXfD4IzcPtJ88uZNJxbsbGA5B/Qu1DA7SKPa2uWIQ87rG74Abz7c4lt5fgfRPkLzkATx5ZEypZivOxU80WlSOe6BlTgyuYFCVZu6UNbur966N6B30re7/RBAZ2N5ker2LS0JrtM2dVM4mTFpJHUOlucWdQDZOO5sR4voL7Db9rLavF55/dYjtCkxkJ9U4PmVR0LM6vqo5J4/u686TqsVfD9ObqwQq/Evdg2DV9nbndYyZNC38fkgy1pEJKxRvx/jjjbOPwDPvhh8muVLjlCm9FEfyatMS0DoY+C+ubgOofBt/Pe473wMaH/ubw79kyyw8vca4rWQYLm5Hf+nvappD3PeB5WAv24tG08Sfw/PeS5e3w1OfVMVKtTLL48WqXAfR0S2I3t+O8hjNif8M6yYkJsQ4mrdD3NnSDImGfF8R0YR/9vjP5KuwRKFn6GFY8PhE1BssyV7unfcTeFxBcLfuJSamzntsf6EY8yq5DMT1M2rB8mFUKDyUlzB+GRV/dPN2/oF5zXxie7GdSiU/A/mcw+upe3x54SWp9sckAk5o/bW+79xX78cSFmTuG8T4t2qJeCPE6s7z9A3vPKzD3DTS9rsH5Af87tU9m9QjqdqFRMQBuzfmT1zCGOUpd7T15HHkd/Fi7HK448W5sDzTR/E+l+Q/e31Kf5r2HWyTUbQQm8LyBEBVNaGar7vIf1DA+0lIgwCKrwIqwqZNYZOPXxXGB0sIDgdFQV8KXSgRZdOJ2sk0b7HMqzP4HLeokpbcKs8j291TTj/DV2zNnl09nkT2rYM8JmP2P0VYiwiLfOcF98rNYJDLKuJUrzqJnD/4LfA9Dn/JvyUmwKPm98dcwKC3XV+whxaKK6k6XEmh7XVrqI5y0s3ryImkWnSlNKTGCqVen5++AEnmv4vbJsCjh1ZGgJHhDOiA5D/7offhnvizOE8DV65NnUXuq8Xed+Swq1P+juXMh4ig7UZUJC65vd22BV2csr1qgyKLHv+7YpCux6J9227RHsKLvWmEPdDHyWiqhzKKbHfa+dnBvRuGMN6osEp4ZVSanxqLBVmZaAswIaX+zeBmL5tj05QQvZ1F65eKOHDiuMXj6HXR+YZsgvIJFw6/2zVuvwaKeXt0VnJUs2hJ3tPoJfKyaPN4P547dXbJyFYsWq1QscoPGBct3LF/NoqeNe92SdVm05FnH0Du4uWDlJWE9xBMzdnsZvFjrY2IJ71x3OH8IlmvkzJfXZxG387nH13XIY9HC3xoGLOqP83m2Hp4rmPvZGwaF223yJhatE6h9kwwHNCq6Nxqx6PkLbpT7BhZFtCberIVhDiYXVpuyKM77qNhWeGWT/alEeL5py9pLMNQkbIu8Ofrlt2KOjyXup3TpTrQViw7M0HAugH9NpVUXWiOPLM0N6VDC6/zUUVv0W3uA2C47FpUuDq0e2sIiLd/K3Ur2LApssY53g2rVcS63HVj0/Vj00GRH5Pv4Bk8TmKpxTtcdlkZ/tf7rxKJLqc3vOrehbr5XhpWd0c+9nIW74e0ZHw6v3YF63Lkkoe+CvHy6/CUNWifal7yHfr9H30/AN7pf8hV2sih6rWNiGPSXy9e8sAvnFU59XuyGuBbqVxq4o145D14GQdeRcGMbTxYVqR/eLrIH/VvnnO0HvS79ta/ywvmqHpzshDe8DooKerOwV3VmOMC6XVONkg6wyInOfZjry6KOrt9PzeACLSHtUJhzNNmzEDa3CrD0/VhkMqDNN/NnUdpb03YX+GCHUmw2nFYheuEnLP34aLdMAIvWRI88DA5m0ayJzWuroPij3Jnt8GcG2/wrPD14pMQy5P/9Ol+zEGpuMLvTEcaiw1td3f5BKYZP9bJwFhk0eOhZQwfm7X2JcHV91xf3Iyy6VfbfrHIoLpt6qwFOK9N2V4hgUeundVs3QZU7z9p2QO7cUyu4sEu3JelxJM6bPfncTzhzvctljeMsiukUiQ86iTkNYow+gfPvLLQcgDmmkT/XR6Mfp8gE8ODxJSs8r55m0c5FSjdrYYvAP1HJWBYpWTRk68L8VWvGY6DYm+Zs/3gWbTtdKfoqAfmV5Sn8gddmhDqsSmTR3Zgtr7fD5xn67FIm+k56OtYg+ktRUmUxC3OccUvWGnLncby8YdocvSVnYP/XlrNnucjf1IlfN+G0ifNDHVC6b4uvDg91jpepi4D5mZG1KdB4x8TOgXMsuqyWZ6CThL3Se+lFdgrmRvLl1RbYrfs3cWkqi9x+BjdfS8NcZS8Jk05n0a636qeWQMkHapI5UCLt3p5zGdgDE8amD6D/mEvpV7htZVuyQiaLpkgHehnBb1NtFbuycP+jpRv/wn/qjudlr7Ho9ZpoTyN40sjScSgH/b56t5B2Ln4v4PQk8AaLKmdYPnsFh2XahuULWFTccX7pWvjRJ7fVDYqLD0i5F7JIP+mp7QfolL7Y3akI85IgfsykGHHO3Fm2rYRFZoLtFk/hk454ucmlLCoZ2ZkmDl+dVtWwhxe8sqWCKli04pSzTCG0d9+7dPsd7P/4SGW9KhbNtssfkK1m0VabK53WsEN5tnIINF3gFGRWwyKPmGiHg/Azt3v1NXhkfL39F6jnfPOvWC32d3FSsB1c3DH/t1Q9izY9+ebUCp+OPJEaeYz91tnzSrwR+/dp2rWVMKg01FHlKeZA0F6w4RmLXky9e3z+cxYtFa5j+8LzgnUecTDpje/Q0iYWeRr+ZTq9RH8+2jiaAI3SMtfeg4aC/wmvbUYdboovOgLNLxxXc3zNoprSNcKlLegX7ftOk1pR51yN+zqwPcU0IgE6txwOLGxn0bHQW0+aoHPt99JvcPW82a0LOtB/B+f/3AXb+f+Uo+A6IUvntC4W/Smd7/ICeqtb9816xyJmm7X6Oig0vUQ8Fn7dZ7V78D2Llu39dLH8I+JxuZou+Qmfy22ttYQygW0XnLqxh0Wo5XIPi/aJtg1M+cKi98frFhGMFzU48R/8lPXyOheW1Q9t0OxDnZpzc1r7WbRcf9UHwQH0y5EWFwvYbriEnfqVRSt/vPoyAPk9pw9qDGPOTQQ7raDd+Pb8eFg6tzGX+wPvwzaXnCb4jn0ruhcO9//3SGqERdrLd3gxx/D8K7zgQqiRmFM6dZxFZ+etc1kJ+Xon06NgeWxr0d0/mNcqO9/v0LCr3Et/gkX7p035Sv/Q56fdvr8TYNOpC5fPsCaxiS2pVWAhyKZFAlfmaAmxKS2PllkJs8ni3drau9BasaUuR4RN5tffqbfBrAb9dTKz2DT1qYiWKRwcfnQ9Caaajj1xEWdTx+jBjjKYsbVT6C08rtNaPQY3eqzynCfBppndGmu3wsHTbxXDZrNpbODH8a9SbDIzf1lvJ82mNX897UKhuOvZGLYMm/6b+2puOkzT+XXxIVw2U9XiO9y/PZi3WJZNfZOve5nAsNqOG3fl2fT4dc+mXuiePrB+43w2vVgVHLoX7rPTWnUGuisbF8UsZFN7veiaW3B3dEvxMkU2FQ7KWdlBmRKN5cFwW+nZ7yn4l1Jl8sO4+/Bm5NsAIWU2fT/6fNJKWGMXOOIIj2RPTouAn60UCteosWmE9VIqFBbc58YoLmdT7p03flthe3tWYS2sn5GxVXgFm7yDy29ow6RtbI1gWJHnkii+ik0Nj7MFlWGjVNIGf5iT17uqUJtNk4b2sCevZpN05Z+9gdDN2l6Up8sm5+h+bh2cUj4trBsm7R37LanHpgW2vY07oMyub5nR8MIeU+XT69gktK1jeS/MXv/tr4QBmwbes1u04K7RlsPusGVl6u1EaKZwYMVj+NYvzq+N2LSp2EFuphGbXDkv0xLgiyeCLU0b2ORnbT9jgSmbui+ca9sDbx/4VWa4iU0iO0bEd0HhUYHCHvjmcRmJm7Pp4OEwJw04p3Nn5Wb4ftn9eglLxD99ZIuTFe7fUDbrFFx6eM/5F/Ck0lIHFWucP7ZSxwr6TdYODYS24dmcPHineqlNsy3qv+vHwuV2OH/4mfSNUL7gxwcGDDW/ucjSHvlWeyF/ygHPkxk51AinFo7+W+rIpuKLG/7FbWOTmuIjH01n9OOqGX6B0GpFaPI7Fzzn07CXxk42ifWENwVDXavRotdubJLaLOI6DCeeqc+f586md5XZ9y3hPJWelnJPNtnsqz/cAPllT1f0wek22gWz9rBJaYX7aj/o3TbtPx0vxKPvw7gEPX+dnCHkzSbjyX6ZFjCjpUQuEOovkt+gcgC/L/mjcxBaLwuuPgdtQ08trYVCH5bLD0Gb8PIuDV82Lb9uKGIAD0nsrH7jzyYDkw/qE9D1cZOwagCbeO6eoQ6wJky2MR8mmGlcTAxmk6GTpVMdvPng4eAPKHko/sqsEDadLi+sOwB9VK8EfwnD/OZO91UIxxzWPsmPgB1zK2XnRWCuBmLKjsCRB/5mGbDmYJFpXCSbrs59crgNjqR32YgeZ9O1zxIBa05gjua3P0g5ifNrTr41BL2El2zwjUa/lwT/LD3NphmXH/vciEXcd4O5zHg2BQftC6hOQJ/e9AjxTGSTv73W5kQYb/svVYnBpt7u0WQek01fJw8ZDMNjN4ochFh43mB77CIonJccZAofZNwuS4AONxXvX4Y6Xg/iBHnYg+zatQfgMV3debGwxdJ5yCWJTSsu/bE3Pc+mi6dDVwqkog+vHf6oBhe/LeTEwlXmo+ur0lDX3W6igumYg6KPT1ZA6ymvFxyCiwKWHruRwSZHn0m7hmBDxLiaTCabXOTFMoOysL9qisdqYe+NcjPla5irBgejRKhAdycb57Ap796jOz6wd/Kev/3wSkXnLutcNj0Zq1sQAv3vb90SeoNNXUJpJXmwsV3y+3Po0rumphtWLr5xRbqATXNPJgTZwYBr7j+KCxGXdH2kbBGbTmxv3WUAy8MVfnpBUX2xaSVwwzR/3ZQSNsW5L77TAsVKDJNMStl0oOqBfxTkaE1PzYXah9/wzcoRv4dYX2oF5vr5lLNN8G0mZ9lf2FYgr77kDpv6M2uTzOH8b1JB+6GQh2jnYBX+3ho6triaTSbMq5MjatAHZllP6uGxP3PiRuErmUuf1WrZ5ORqYkvwkd6/wh1wt0JVx2Ad3mOLv/ynWo88dSjxT8PBdpWn4Y+Rpy/NwQx4Ziz7xjNo/u2Zvksj5pr/bGcM7C96L858in0qHLzo7Evs5d7nScMwZr2Go1oz9rmOuYE93GFukRkBH947OnYZPrgqrW3Wiv1xVCFqQQebNPtXRe+BBxi9NmffYi9UCymNd7EpKjkgXu4d+rfrfOsGWKu18GLrR8xzo9egwCc2Pb+cfGYjbHV+b5HcjTg8Rws/97Ap8N+tVRpfsFeOTr/hDNtm+btJDbBJtXm+SST8Mfis5cQQm9byZJUbvmK/jzqJTB5m061D0u9t4G/VT1v8oCe/R+XAd8xTod/tbMh+eDt/ywib7j9vMHs4hnngPTBSG2cTY+tbli0MGn7w4Si8HOjBmDSB/r7oHbMdupdaeEUJcKh9tZXlL/gqXjnGfBIcvnzTbwqH3Jf52SRDpY9lTR6CHDo63nUxTohD/ZdMl6fAqV/t9/RDhqCJsdV0Dk2Z1nXhGPzVebf3oQiH2PNSzFfN4pCD8eisPbCxukmZC/vm/6aX4hxaV6YitkiCQ6kfhMfPwMY0f6VYKQ6pnrIQ7YTDtDtwnTSHbDYcYMTClxVybToyHKp8VbXMW5ZDn9LVhJPgkgsMd0N5DgWO3b9bCe0ydeS2zefQ670xK3ygQaLk+mvwe7OEi/VCDr1Z9uHHbEUOmfcdv7kElgwKWWbA7q/8pt9KHHJbJv5XTZlDIYGOwTvhpzWuLvYqHGrTddryTJVD590nxY7Bo0YBg8pqHPq91Huj2XIOrfd52nEPXrRZOSq0gkPPE7YdUIPpDzbz92pw6L/05tyZKxGvyyShKMg/r+NTCn+yBU4uXsWhZIdidSv45OWynFx4UKL1wLg2h1rPu7/TXM2hxDi9Wzd0OVTKmTx1th7y4erK2QGVL5z7HgFHG3gGogYcmlx+XeUCVGyoLT1kyKFZJltEThGHNH6XznwATwxuKVI04lCRhEvMtQ0c2rgibck0Uw7lnXVpNYLP3juKRMOye2tvFGzikBSV71phzqFvYd/X2cOXbVZ7x61wnrUWQ/rWHBKcMtIRD1VYxz9XQa+evKsWdhx6uvXUPyl7Dm1tiTc0hTZXZDt5///ZWj1xwIFDmz/uapvuiHwul55pAUcpJzkAei0b+Re2jUO1q6u+vYa7q9efNXHm0KLQq8b7oMB5pX19cPnApqUvXTi0fTi3QXIn+mpmsos+tGkfMuVArdpSzRduHPrYdV1ugTv6+diggjlMmWWxIQTeuNFWb7ob545y0M715FDsyGCVwB4OVX+/6LAKXpzY6RcLw71e5Fd44frr1RJi3ugTe6+3WjBhieNBP5jhfdLq+QEOLb4vuGOmL+ZBTd1PBcbzBJdvhfcuT7Hhwy+TrP/U+XPo8Eb5GWPwmU7Zb7kADhUXNPc5QnHOvMchwRz67Gpg0Ar/HZpWpxLCoaoxFdFdcObE1+rLoRxqmLnl1dRwDg1J1VrpQa1i3/274Tw9j/1n4Qm6vuXLEfSdYoGacATmIeFM4GqYph7h5wR512w1r0dySH+fkuYAHIqaKW57nEPCK/zWFcORis+Lgk5wKK53mvV9KJ0YqV99kkPjt/MYozDB48NZ42gOHesvW+4KD1WxJ4md5tDdO3a6FyGv/6L6KDxbZfZdLBZ1mvSyxRZGbEjzc4znELf3ilVlAodk07ctk0zk0Av/H3Y28FxnoU48/EsLq/KhaKJ+430m9o1J+Ncv8MTLuKvE4tCRjEeb/GDO5oK1o1wODUr231nEw7w9Hs7f9X+zZp9JgUqHPnrtOYf+N4yJbISfpkXc74exWYoP5ZI4tIr3bp4nLKj+c/skjGn9eDoghUMHQg6M1cBHPb1OK1Jxjifffp+GKv3/Ys7Cjn2NmpUXMQdeDqV1aRzyUNRVXZiOfLQuE7SC3rerj5dD/2gJI95lzImOx+K9GRzasyXINhvq/N1ob5bJoZsiLuZnYXj22l/FWYhnS+6TX9BxofjdNddx/uQfCsfgc8tatRM52FMu9+035HJIT/bZwij4pLquPb0Qed2/VOI5FJSrLBcuwr4z/LZ7sARzM+eHmVUp9tPtq75JcI9w8qf6Cg7ll68XELjDIdeYcvZs6Nymu9br/0rVNAhVc2jNXV1JA2jVfqgoDYbdYpRurUGc+ScYT2DTw7QfK2txveZR3rU6DtV7R3qWQFN961MG9cjzfy8cwmDPSofWZFicZXZ9SwPq9mx2lEUjh6ZHND6MgrVzygNTnnFoS2zhHMXn2GsVmp5WcL2wlmMIvDNpUuzNlxx68KOrObsZ74PC5+22rznUtaRKrbnl//vgdJxpK/Jum3P5PKxZKDDPoI1DE7pOj0fb0U8CoVEaHRzadr7ky27oauEudKkL+Sz/5dYHa/R+iM9+h/eQXJUVwZ/5TSLnYN3eOeNJHzFPhkpNXXCf4zVd5U94r+2IWeUBb4gNXyyCSpsNZtzr4ZDTKl+5CShyakTL7QuHoj5ToUQf6h4ayS3v51AhL0p1HDpl+f4VG+DQ2hD186vgqr9ZM1zg4qP22nVf0Q/7H/5bMMwhuefC2Zsh2cSVx8KwnWvuVUJNpva46nfUW8boy78f6JOPbxdsHkE87iZR3j85xPLLU7wwhvm6uSRy6jjqmeuhuBZ2FTVP5MMdTPkfon84dOHP1Q+fYKSbpsKcCfRda9YMPbgpwG22PXz4KNE+HR41HLqoOolLt2UEVRzhMb+FQm9g+K/rmjsEufT3YohIFmw/rfm2Hd7d6XZORohLXzpOpARCM/vZazqEuVRVxPh8YjqXrl7N2nJkFpeMwgsfqUpwaZF1ZYIz1M6TunwYNgwNXo6czaVX50PyPkhxadZ0maA50ly65SduaQgVAtyUI+HygpOOpTJcOicU57pRlktHg9+/TIIt/6wSq+S5dK234fsgfMrNnjp3Ppf2jw4masPVC+5v8IX+xQXTSuAP+V29rQu5xK/eFK+gyKUC9ciZIdBsvbqlijKXjlguKRiBK/3mSmeocsltY+V5bTUuuZPSzc9QnFGlLL2CSx7dCsW2sKHz8t4AmFj2RTsRvpp7dkXWSi6t5SctFl7FpQEBKd15UOFtRGsobLXsT8yGB0f1Z73S5pJLzLDStNVcmiJ6785G+Dbz5LwQuM/Bunn3Gi7p/8sv79HlUmT2+E4LPS5xB093HII75T+f91rHpW0Fo4nGBlxStq4XiYb976RpoSGXnF6RA4+49CLo1d6/UC1AXnujEZfUb+9TD4JXYgo0nmxA/tyV/i005VLATeX73tBms8P+8/CdrIOjgDmX7Bxmn9sLi1ZYVZTBWzUn9i615NLcWea+sVZcyivRXbDCGp/LKlCwgBkW4ZIB8GKJ4b546HUmU7Eeru/aFrjclkub9obN74MmfFailx2XQg69PJsJ9977W1cHafF1trc9+m5tPafCgUtyfeJxn+FQ32ah5K2o+25Z5qltqKNc4933cN2s3U9XOHOp8bTdgXAoMHuTwg1YtOcdvieg7t+8nq7eiX5dYGe6BYYZsYzioPHCvKZhNy7Jv5RpV3bn0uv8jhmh8JtK0NLHnlxS+mns0Q9LUs2vaO3h0mCvz7YULy55Vt3Nb4dbli7hy3lzaVRec8AKXtabpam6n4v5Dv1o5ov7Sh/bWwo3lWlF7vbjUl/x67s3/XF/a7GGYXhjmuYN5QBc9/CObhgsedq0JTyISwy9QM07wbjuP5uKLvjR+aeJUQiXeqYVaiuEc0nvkFr1ZmhWO7boKByhi7pX4Nsx/bith7nU298sZBeB/rkV1nkAbuadUjh7DHWbU3nxbSSXKjQ2rD19HPMYUbHkv5Ncel/+VqQIfnCZPrUDqrUaGZtFo78lGdou8Klex67Xp7mUvubmIfdYLpX+qX4klog45S9pLYPDNUPyPlA850aaOYNLbe97O3qZ2BfBw8Y6LC69EaheEwi3DdUvyIaaC3qrv3C5dKFk5GMgD3kS9NwZBx/eL55ZcY5Lj8YOzZyWxCV7Wcv/1KGVcLjJVlgrdDzjewr6KCgpxjWVS9Gn9KdcgC+SdNytLnKpu9BJ7FMa+vuBS6FVOvaOYspjbyjRmXcoA6Z8iGO9zkB/3IqI25rJJcvKkN7TUNolQLLx/z9PPnZINQt7g51huPYal07Ot812hxuK8xd5XMd8MVnuozmIV0X5jVIu8hu2IL4RzlK/Zzx2A32gcEpdr4BLwrHXm7mwfcOVX7a3/v88O/eHhVzSKl2soVnEJeZX4fbDUD1GjJELzzNbjPvg9PNeqmdLcN25pn2V0M0x7rl1KZemfj/WWAH1SpIFkyqwh15k7lxyh0s3Rf8GekHlpHOSDJh5rMCcXcWl7edSdmTBWu9vIUPQokbzk2c1l6rvW3w4Dw+HPzptdB9xP2t6mFjDpd0Ds/YsqOVSkqaNexJ8P2XvIr867BsP/W2FMHPadlYH7HdNvq1WzyVVvVojy/r/12v1nYTHXGLfEalXasS+FDCw3wvnuF+yknuOeFTaDt6B6vnTlIObuLTgsvxvvWZcd3V3lDtUl9KYkGhFHkf8albCBtbf2QHw75Ixh3fQLyPk4Jl29N+Hyx+q4bKTTUsnYObnNYsSO7hUfy9p7c0uLt0fdRXpg2duJ09zfceliNElw80fuVSz6e77S5/wfmL96djbjb0mdTb8Pgy4tF/JpodLkk3siRSYs63n4fwviOv7tiEt+KWqb8thWNr8JiijD/V+vdCJ3489N2ZVpjPAJZbKf8tcYaZwUUo0lPabyTQe4pIQ49vRX18xj8OROUrD6APz9dqh8JcNZ/9naCcaPlT0g0uTlgqUt8HunCM9k0e45PDFrmI9TBJ7/txpHPvvm8bHiT9cEvv2s817gktSLq3GSVBJQ37Dt79cWrhO7F71Py6pHGA5dgnw6GDazjDrSTyyWKyTlgbLX49wCuBiZe3vrYI8ulQy4DoEw2f89F8lxKNVzPtd5vBvxdKZ8fCntNfDdGEexd/Yzl4+i0czjYVYibCnZ2P0IzEeTXvUvHKLBK5791spAyYcvO4TNpuHt+HjXxeleLSstrNoHKpujvfWkebRn5mTs/2gy0w7ZSVZHp16l7XbBvY+W+0TCu/qnT1UK8cjnT1enEZ5Ht1z8ZD6Di8d3nzbbT6PgpzcphyG0tyjok3wvsnM5ZMVeWRjd+W+MZRpnDqmuphHjv5ZHg+UoIJh/1RlHsXKKkwYw8HvbY/+wcnVqr8yVHlkHjKHa6jGo7qsH28Pw92dxQkp8OZmcenZK3j09PFq03Boo2+jdRWOy02rmFjJoy9X/A6pruKRWTLP+ij0HvdUvQFfhVdYdGvySPHlofd22jwSMvO4VQd9ksMWCK3mkYFufspuKKKu35UAH67s512Gxku5+h+h66Z47lE9Hp31GfS9AqPDLtrMNeDRc4kQLRV4aeGiLeFwTz37n7QRjzSvXl20Gn7yKrp5CB7tK6af8FqRec1ZEx5dtD7f9m8Dj55ZWhfPNUUcFq02tlCj49NmLpytOu1PA/yySUlbzJxHgXs7zNxgM/Hmx8Fa2Z6iLtjn2m4tac0jZw0rP0NoU5reehReHFVdenwzj0r/xZ8TtEN9h6Z6O8LeR8LJTdBktPJiKr5pPIzpSVZw5FHYmXztdhgfkZY64cTD96XCxb5bkSfFlgPWzrjvXTeDl9t59OaXb+DFHchnzHvVJBce7Y9IMViwk0duyzNf8N149Gto/dJQdx5NcfCJvAgj+qK8yj159HKxTrXyHh61fA2x2wSTwrK2H4Hfaz6KpkFLOcOKDi/0WbAca743j0YUB9YZwWRxJae9cKfDuYYzcHbA0cumvjxaVPXX9RjkJF8fuQf3Pz0Y5unHI1rwXqHUH3FsEvHZEIB8KZzP9oPkKXE6C2qc7IyWCkE8/po//GHw91mTGJDRI/LgLbQWORcxehCfc43aaxuO+kjV/IiBbUm5x18fwXMrB3RnR/BIwMHKdh1cZfS2/81xHtm5PpradJJHX7VTR/7CV4EmqwOiebSc2xr7BJ6xy7qYdxrzGeXzzyQW3/A6aWUddP2nn/kdVpXdmvMrgUehn5iP4hPRX8xB7iM4V3/xOXEWj7LO7hT1gjLHzY43Q//ypKo6Do9aX206v4PLI6sN2/dVwh8X+kMH4bdeozWsczzK6JcbmZ2Evk+8EXsSlshdNrkLM7orFIzO8+jQWj3J0BScJ8CwKR1WRJ+kpyn/n3frvlWpPJq/e44DG563Ovb1Bvy7dnPVkYuYP/H9ik1pPJrjelNWJZ1H55Jm/7CAex8WyN+EtsZ/d3RkoH82akmIZfKoW2FJqDW8wngq35eFPMlMubbwGo9OpJmp20DX7krDVOjWKPHs4HUevh+2Fr7JQf4nV4bfyuXRDpdH2bdu8Mjv0QzTcSiaqXZsWQGPblT/6EyGv8O82fq3sNeiRjVfQk+DeQvaC7GPQt1PryzCHCfLOZ+A6cXMgiaYr9PcfaUEc/NT5aZpKfqyZ+6mAPj66ly3VGj08Knyjwoe6Xp0ahje4ZGkhKV1bRXOtyqQK13NIxWtEJOtcL3rxvcJUFi6dPnLGvRBqsvQBHxYP/RNsZZH7UcaQrIga/6p9ZsfYn+8H9/VVMejhaV/DonX82hUZntvFRRa9uXk8wbsrXU3Xaoe84gpKhA1s5FHp02j+yxhybTpGnvhT4H793PgJLMZbkPPeFQ4oVGj9Rz73a54jyOcvWOdTDxs+Zcqt+k1j45vfL3yVgvq624uPrUVe6jpcIs2bIo/NeIJhaOiVl+E29+NS27uQH83J6lYv+WRw/SwgRcwbX+ykc47HplGez32gQreZf758LWi35oLH9DXeh9vvIIWzhd33P/Io10Z715of4LXuKnWsNb24tcjsDs6okThC+p+U85mJ1TT1LqeARs8OviyfTzqd4r5LTWA/ugU9DsL/5zUz/kKO5ZqJfUOou+tdJwzhnh0fXXe/u6v2KNDcVcXDWO/iES8qISikR2Smd95VPBm+hPnEeyzvuj2Q7BqTcHPiJ+YiyP7G0XHeTQs+eaOAVyR8cI/EZ55NUmv6DePtN4wXCdN4P03VOwQAD22fC4qg/5jkeWn/mFuLwy9UJrEp64ylzw7OFHDrUuAQ/VjsZOF+PQgx19dH35SlzEPgkMGcYlcGPgksmtMmE9/92y9YDedTx+F7+ZXi/ApSmjpuPgsPvkIvgvUhT9rBRcmwOW/1w9rifFJab6sr7EEn2y7J1dch+/79moum80n1cyil5Ol+XRrMD32P7hagt9fBQ3FLol4z+XT0tDk8DsyfHozpXi+qSyfLIJcSqPgqpVmKQMw7EbwSqn5fIqWn52mDYOmdcYz4CD/0Lo6BfzdU1RhgyKf3KwTBFJgPENxVdBiPpmui30Zr8Sn6oyHT0vhVI8zzVXKfLqaeIXrqsYnzxcey8/AW0mzX5qt4FOzllbcCbi47HCClwafOGpGH1pXIt7Wl3ayqxCf17z6L9BmfrrSMy0+ff5pKf1LG/c7211gtBr5Kz8mL6zHJ+O5C6SDocdE1RuJtXzaYHzg6nd9Pi185vrH14BP1y6t/XQTZnWmxT8i/L1O9ouwEZ/M2nuuKMEM9R1X3aGAYVRUBMzvqpv6BBo3uBzgbeCT+9XcHilTPoUcW9K4EUrJtj6Phq4f1SoewPScE+7DG/m0Xn5d4e9NfHqldutbgjmfat7uUimz5NMBdSuTT1Z8KnvSXL7Imk8rtY/z3OFupyTP+M2o67Zfz7zt8Jwwt7M34dr1rwvuOPAp+Y9v3wxHPpncf1LqAf9SqxkL1kh8di3chvzbLLD9CYVMDbolnJFXkyvDxrBLQvfngh18mnVsYqk1zFBdn9Xhwqc51i81du3kU8CjY8G3oORD/ucF7rje3e7GRig6cNg1Fnb/mRIZvRt1Tb830OnJpxGtqw7Se/ikNT4wOwgefHrl6wWY4i9o8wQar3CSddnHJ4cdB4tlvfkkFvnMfiPse3viAx8m/2dj834/n5p8eBFqB/h0ZomkPNOXT5VBbn6lfnz64LUnepc/n+YWueTKBKCOXXIpa+GmE8r+odAmriogD5ZsXV3THow6xiRIzgzhk/a2YwZh0E1w3hluKOohpJIhFsanfdP2Gc0K59Pz4Z1+YfD6L5nbLw7zKalROWFnBJ9Oibm8+g+Wvf0e4h6JuWmTFPQ7zqctja1cHlwWOqm1BsYsiVBoOYlz6BfmW0Tzqe125KnTcP0RGat9p9G3aWOx3XBPwbPkKbGIW+zgzmXQQtIn3wE6Vhpmbk7kU2SOXvFJ2FYkOv/RGT4NDCprG3P4VBqwY2M/l0+xs036fJP4VBeg//oSjNnhMXjtPM6l7LK8MAXztk2vcxh2hf3NOZDKJ93/uv9WX+STuF5TRW0a7ic7daV6Op/yerrdmfCJdYRVNVSZOyEyAK9deMZmZvJpelms4Ssom7s3c9EVPjX2u7/WuobPxwbapMLlCo8nR+by6avv7vg8aJPS/+wtTP+mFutZgOcuTthfCg06G7dsLES/bZOYu7WIT0dapgXy4OBeI4tbJXza4ba/Z1cp4mBpbzkHbTMP2zbB6AM++UJlfBpWdV2ZUI4+ENkuz7zDJ6Owd5cy7vJphWN5fC90Gpezf1rFJ658tad0NZ8mh/9scoS53x4nnoZlj+5ZTLnHJ2eXiy5q9/nE3mY8Jx9+r0y//bSGT1Uebl8u1WKPLFVKEK7nU0db1n49+K4rvCsCbn5V1bG9AftkB88nCnbp3B+d3sino/YDZ5Wf8OnHzkxu01M+/Q/VjEuR</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="32744">
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>eJwUmmc4kG8bxo2QFEIhRSolUVJm4jqvx2hIlFGkorQolZCKjKxkJJKsNK1oEmkXDVp/oaRUSkNDU6Je74fz03Mcz72u+zx/13HcA1R+YdbiWbjncYRrau7Tgp75bD1FXXiFNobREExdFUQuPy0x6Odn3HE4gm3v1+HC0zrWMnyFJ1qyQoibhOB+vZCWxzhD9ZYp6lKd6dDH0azn5MjWCw6yllIdhuU509H7QdA+vwKqzfnCrRBTIfK3DsXkRCF2wATMuu9M8SOzMNGFrQq9krFpfhOP0yqi1R8reZREivAuuAcVXY9ob2gY8pwnkH64CH4v8OOah5kcOdUF//ymccPsAHZ7WSLEZYmgcfJ6ltBrYWezcD5+SgQp9hc4L6eIRM6JINnqKE7dG8tfVKKx6egEar7kAqfBeaj0foBpD0YKafU3MWVCMFVuDsF2l8PQ6z6PhMYGNHwsIjlpVxKTEsWfSYbcvSaapUMv49KUKqxVLCYHJV0qjIrBO5ViYqVw3DLejcd3ruB0twzyogayTr0P/1CQ5IePg+FhHk6xRXqC4fF9HO5aTPaLwxH8uYMnvRjCF2J0YeVojJU7denAdU08i8znstdSHNouxdvuueK/p5rI2CGKM7tEofnRFXWPUjDuiys5jU/HRE0zYd+2Doh93cNlf4pYcX84jDPD0TtwARYFPeBpmZIcMr2JjkwcBYdGLat1fuv4pvcEDvy7jptOhPKmlz/53JaV+KJ7nCJX9udMhRU8vOo0p5dtYtvdCyiRj9PQq8T16U30vNMQCjZO+LxzOk/tFoW+mBjcTy8gh8oF+PW6VOg0kOfSwWcR5nQOWb8zcPhWI5Z8PAXV0REk+n4BOX9sorRvTWRcqge1Bjkefs6fVXwE/DmrR3c6b2Hrub6x2rfSDG9ztn+WwgsdIkixKgUPt/jjx5Qi7q8xmJeZJfET5X4cZL6NthySEuTKCnHgxR6aHC2GfQNK6GSCGMqMRsNGtYQsx5SQnM5mVMUW8EDTvdi+u4fW2WUJYxuLeZJuJ/+kEuJqMcTPleM/N8WgbqjLnr+lhJiDK/nR6K3C9bWThQCXG/i2KhVlLTvYz9+Cb41YzH5/xHDcQ5VdPQYJF3ydOXGEOMTi3Ch3pxvt3PWEBjRNpJOz6nnZA7ZaLzKIPdcWIEdLld0fhZB7xniu8XoEW6fRwotfq4Rjr56QuEg8FkpaI2FpBjbPLqXj3/sLr7eJo7nBkWfKSQnrf4G7XCfRyMhIrNghjtWXjbm4erzVf2XmmLNAhk2TJiHJM5f1c6oxabkbf8twR9UNccjnu6OjxB2XL5eSsnt/weqyNUJvltLL8k661jGMnx5ez2mf/1JQSyld+jGJTv0uJWM/VfZVbuHef6V05owMm/R7SmebH7D4solstdCCe/UXAeP64aLwFNnj+2GToRZ6BouzglU1tshW4LnlCbr4Anz/XCoM/Yy51aEfZNbq45ufPu4k+PKvxXL4EHCCVqvJCCbu/fBhywnyqY6F9vFcHqQ/B7H1T2lSWD+MlRrAc0fL4OuYLYKXoycaj2th5btFdHeYB6XZH4DI5VV8YMhtXv1gGISANTzjhz75DT1JYie92WbkSWpe7YGGSElhvdZJ2rJxqJDXpis0aQYKmcJJSKV70NmFk5GkPsBqludJ6h+UyKNv7UVqv7dC85Edwqw7B6C2eCu3VSax31g96EZf5aT9k7FG/BmdWPgC/pdz8HPpIkFx/Gr+dtZdMF8YhQb/PzzmPxU2rxiLjEsL+mp3MT11fEbzDmSiVtRYEC2w4F+Sa9j71WSaEbUYqjtE+N3YzbyuQ1T4G/EHsbt1hF/F4IGpUdT4IwujdQwwQO8U7W0cxmkjjsFywX2o/5YRnA8kQvPrBqEkMZ9/paST99vFpDhgONjFgIYsNMCoxxJQUX1ONs2NPPHoSF491YVi9t2yXjBhCW3dc4r+JL3nR80j+eQ2S6uP98ejcLArn28Qh4fkKN7YYkDvs/+g/6wydDv58Y66eOSnD4fW/XWC5d7ZGLdag4VnS1kfkrAVn4IN7pJ4tFgSVyHBrk8YwydOoYtfJVm+b24nRHZh+KdT7FSwGf3tr3NR1HKo0mkM9ZxCvnGSeDZDQrhguhobEiXhZmYnDCArntYwD56LM9jc/zSNPDCBKwsk0X/7UvySyxV8D04hh6WV+Keqw8HJS5HYEoO2K5XCJq1wZG7WRp12M+Stf2Hz7a+8ccMbNFi8ZLzeR3OUQnGyeSmJfJCEVJgTb6rThqPneeGo4lQ2WreF1ZcGoFP9Bbk2acOouwABC39z1L9cFKw5y1ekClA/ZyosK8RQ0zadV6cpc/6iaqQ4H+ARHVv59+bLnJGRyIsXS+E/XWV2/UhctUUQqudOw7WrNzix9Sa3DJkoiGyQws8AKWzNzkB1QgwWJVlhutxpdvhdA+OYzyirmYosSSnhSfkofiu+BwaTX0LUdT2f6Nvzqo/1PDlukFAlq8i7x94H7RknuKw5h/lzvPBF5BZfPF3MG8Ne0rFtztww2RWzNa7wv/RBPPbDeBineeF+aCsXn5phlXG4P1/xr4bxqDRWCH8L0htg9V3XUdig8Iq4yBDux8/SqnOG5CqfiIfHJ1rd3uMgKJjJsf5LQ3r7IRXPk17RoCp1vrthlLB+QyRv8pbDgf+cWPdSJO9v+4gci6W87ZUOooObYNYizYPHTEdvvQ1PKgPEP+rgfek9XmCzHSd35WLv5gH87tw+HAgxQmuXFh92DuOP2m1UUDKFnd8+xquLb/HoojJ/b9blL4oRPCKljF4M+w8rs41gvFkJgy5O5I6sI7gjH4d4+5XcaiLJ1jVGdDt4PW+/bUQ/VaRhO0oabXrS6P++jCRK2pBlFIfUlK1WyfGnIdM0ncN7ykih/Cq3Xl4Og+9tfR6sKUxoUmL3iCvIuivwSQ17iE1Owke7cjLxKie5S1uFQVbe+LG8FM8uWApjI0eisC5Q+GpjxybDriF0hCj7zhnAZ4eex7gse3jnl1PB4zB2d5wh6JaU8cQDOiyZLsUX0uqR9fguuraaC5dyYwT7DyN5R680VCJ18WD9cGxLj2Z9BzXWDSkQHqWs5lFab9ktdqAwaoQmKuxWkJzjG2oUTJA6Zy62mfXAgvLQsCIERu11fCR5ATrX34TZUGkOKh6Otc/OQMbpHIk7n6O9L85gEQ/A3U5dPLxixEUjSmC43QQPT/Wi8Wgj/rkfZYcjVnzcOIovKLykv7Hf4X/yHLX9WMfhKx8LnvE7kaHxh02CIzBOKhTuhnrsdPccST4yofi3JnQwMBn9PfQwPVieHxxvtzIuOcCLXf4i+e858nZux29NU6qekMDT9h8SpocFcsMmGRZbkY1/Rcl49WoARA79JdkKQxbWNbDejnZysTQl8eMrqeXUQcGcTgjqy00pYcMXnj3XnI2tJThssAzKFGTQO2cPr3NawNu2KMFn5W9cbutBqc8lPiY6mkdoBnH2EVOSOZTKo+tM6adbNn9rOgVa4MtJ9abkrXyUW1WOYmpMOTyXy+BNawX1D5XBou0ymLNJlYMj31KAWAdMnHT4qZQZ6QSM5Fd/bgstjduhnicDF5NK+lyziqxr39KIuibudlJmNyVpwWhgDN18vAoGbVHICDqDhd2rsLB6Iu5ojsbGDWaQLolE841ZXHs7h62sLYS6U7vZMMyMTF/IcEH/AmR+jYfCkUraUfAB2n0+Whp+Cm1rDXmRx2qq1hwsfJ6ayu+dd3HStUqyeFhJ7TfCOLKwgCv07nL70Gu4K3MAdGYop51r4tjBzfzmgA0kpg1E6D8z2vp4Naa0ZEPXeSCv37qGX8jm0hZZCy7sruWrh9SFHePP05KHh1DRdgjbxuyEqYkGopM1Ib7rNo7mBXHqxPcYeukS/81JZuvF56nJ6D29XHKeLlmo4KLkYUycnM4zjg7EEN/3lLsjBSOTMjjA/oWQsPcflLUO423ue/KpOE9u58+TzR4NuDgMELKcJ/Dy5cpsY/eDRz4ZiHVfzpOUcTjurB7BXkrEejP64/mH+YL1iyqhVdOcurNbeUFQOazXnEDo8WROHzdBGBx4AnlHHiNl3FP8CfLBPa8q0vjZzm0rzWnepUIkTjcSvPcVAAkfqMd0D4pCzGnykHj4e86Ai1odurWI799I4d8VaVDT1IXz41TeHOzPVeZRuF5XhVMVpsLi9fVk5/CSV86qxoFFCjxplyJPvyzFDlcHwVfiAqXP8IXF9lw8nL8D90pH4tJzJRybb8KPTu9B9TJZNt82it+Uj4TixOmwnSyNi/EdlF3Rik0p8fzUtRzpH5wQsPID/CsrEHRbFenZvnTz4BGMdZoOjXUXyKa2g2bd9cXPjRcoZ8cm/ic2hk/OG86G6okIv3YOnx4cgchbX6o3ksX6/Ol09t5kHHJKZjOH8zwo7z+20Kzj+69zOKhuOtqbp9P7JAXBf/kZGu+xls74yMInUoX9f5dzrPdHOjJzANuYjOZFxxYJnllrkZuah6Vl+RhjaoBirRTsOryW3vf8EaDiyj7H73GcjQXZDtsNecuJvLYhAg3vLvK8bcX8OuAdy+01xaurIwUPj4sktvgi/e67m966c2ETeZEqXT5D3Cqa2+IuUoreJ4oYqsvnZr7Es9lePHCnNj83/USSuRfp0bpV/GPVOtLa7oWsHRJc99AA+0aNwtOHYwTXRgPYBq2jNw436dqXoxD0hvCfq/sw4fNqXlm+jpSmJ/XxZAVi58phsVQjtTzt5eSZO/m3zBNurL3PS5fJIXtxGpbE3me/RHEE5I/isTWbYWbmy9lzXHEvPx9Pgo7h1O089pi9DB90ErDUxg/9Dsmh0UiLP28cxgqxjnywJIne7blE51Iv0YrLc/lS0RzBomwXR2EC390ymsdevwQF10TBT/Qs4mot4dSkwnPlZdhO14+P/vajYdsj2F+U8DxrOmY9BGdLER+TlMf8AZepRobQcu0IJArS+W/NEfzYncbjlo9G8H+yQp0lUXZNDPY5rUfBkqlIDl9PV+N6MDfmC5179wa96wgvtFS4VP8YpqSsR+G2mXxYIRXR/jP4avs+Nnl6hIWM1dxZIoPPLYFMp+J59snLpJ+2EyEF3TiWLY+366/D+hFhbVU+/Cra2XaPHuQCFDhg4V+snXWNzx3uO6/HMrj7mqh9zAaqlwBOh99D6R0R4dv6ZVym/5hOzN9AuXKZLKbVx/mTTITrN6RYQ+0KJUb4sK/lFdqW3EkfX43j0zuKIGwSQ+wTUVb4IQ/9WWO4gJYKq3+141vwY0h6gHT9rpBlaA1iHm6g2W+LYbgZKFIbjGd7MvBOIgpevZf444AK2J46gkzlxTwgHyRWAJoxdCP+KX+l68ev0O7RtsLjvjgIdlkER3NT9igH2UYUoHR3KUxvXoFq8xVsewYcGu6GqNoxSDxaAMVt6exeVICjVaVYuHIjTn8C3RRjqMcVc0VuOtIHOPCzLweF3KVPqNPSHo2iRjh4ejDWJkfBe60a95bvplt30lF6w0i4oiPOHvOZLu2XYEfXq1T/Kxy6C5n2Kftjtao/hG0Mmz+mbChP2DvkAfkXfGTVM6ZCTcF01PUfxBe3P4OC3jdy6VnGlolM0duN8PDkVRIkU/Bg+iRhXnkjD1WJwYRBCrC1v4yN3I556/1p3YZvtLSJ4WN5CTuHzsWplS4wG23FJ3ev5cqdXYh2SqC8ni2wPFmL2WJO2Okylb8rCdSyaRCWq1+jExZf4Csbhm3BCTRq7DW8TmhGifRvSB19BOeEkZybM49DYxTAngIJh1Iwpvsw/I4pICZeIMnXH1haYwL+SjzFyLRrNKxv079brYLDLQW8rrFh41oFFJ3ahLgdxWi9fo3sxRxQ4GcOjeAkPuV3EkuKpVnmrQKeTnZnxfpdaOrYRA8UEklf5jVf/7MJ7/cH8Lb0Newqdp2+6wTQp2kZ2DsxAC/GWtEPyYuQdTfjHS6PUPjkDG+xlhS+rxrIcydswZWoYTDGHlILvQ2rfX9QabsHLbIKXGvXhurcViiE5QprV18nzc6ZXOyoiM96Cmy3XRavFMZh+mx35hP9+GxqBlQzrGjh32Rkv8nmGo1x2BekyGXff5BgK4VRR46yzp8f9O+OFVSGdJKzmiNENujxtsbhbF+uiCbDQOzvsqLxxot56LSf9NNAkk0tA8nMwgVronVReVaCnYxb+NFPWQRfd+N5rm9ZfZcjNGJ/0vTZMrx7ujX0k3+S2aT9WHdWjmMlvqErZinfy6tGt+lvrGix5Ct57oiLsKaJKdZkMVEJU1JvkN64XtQVhsNh7xArq9qBbOiYyWuunMeMj92ou3kD7uMTsevHaEH67FxO8E3ig3ZBaPVSwqVma7rWYo3Wov0Q3xpE7U7T+WnrARYz1uKZEjaw84xDxcm7SKp7RpMHVZP1HiU8OKiE/FpTPL0QhACDaoo4mkpSG215kk1/QcPMhkYW1kHnuBLWPKnA0Ml/UVanhPWas3jpkyTKk6hE0IHjcLi6CJnSZnhxfjCHDN0ML+XMvr6omoI6U/G0ezW/NjDDl6m5vOZRPsIGzYe2mRk+fstgrfJ9+BuRgoaCajpSWk3fYzThceoJDC7+hXNcF1102shh4+VxWllFiE7dTD5FqyGT3kUP3lTTohJN1JVq4ue4Ahq6xwzXM8W4x0VNwIwhQu7CDbz3Z59nLvgJB9Wl2CH6m6yNbCn9uhkr9A8mI98hOGa6SRiYXciH75uhdu5SGHvbksLKGpxeY0s9qfKwOH8GE6TlBBn/GlS7y7HN+wWsbVqN2uHfMHjwYV41PoPnHq2hzJRg2nNpCESP21LcaVvUXqqh9IYCnHlQg0tNU3hX6zBub0vDoEe/ybMpmBre2GKKmA5yRquymo0+/9U24NaZmmzXocw5jmbsdc4JWzecxfzKubhqepNEZ3bTuvv9BNm53aQy05OxIQWDZs3A+QUz4LnqJjnMHYo1t+IQ5K4D03YxwWRJIUIHhLN6WQjLzHqNwetEeLD/ULTuv0ljIip5ybpmXH9wFh3ZAtrrotn67CAWGVuN8xc9MaZhC75NS8bXw834/HAGRWlmwLxWnDUbZ4CbZtDmxzfJzlib5/0uY6d5VUgSnUkFwlakWm9FkspAthtTjCSZmWRzdTAWNo7kGQMCuPprJPLq9tKTCHP4D52JdSdceWH8VpgYp/CfJR6YgZm0sd9i3jljJmWtnklnRUqFHdOLkNtqjkEdJzhU34BN3pjjTe4teiU5Ha/XnsCzjxZs+0Kb7eOjeQ8p447VNzz+uV/QvLwTzY7T2GdWDzV02vKCiZ6c8MiZCyeu5bGW0xG5twgHHhsKw8VnYXX0Nuq5ehPTVl7AvAcb+E9iDwX7JSBm8X3Eys3Ca/lZMJm+GwFSN8i60BFxq/vDvLqHRvWks/7CeqQd+ybse/YOFhPsWGZwPHa2vcNzt1k4dX06Ah+kY0nJAVzQi4dFgzK6f1dzkfZnBB7JRM0TZVYImYXDbcq4L3ENyQdmoeDgbTI684NLp4fx1Dv9MfaREkscP4wbC3JQ9XAWeFcvHesnxb1JIQi/fQNuz27T7c1HeO+fcgSedYX0TlW20loruOxy53n7Zbi9vhcnKl9jZPhyLBmcgvW67Rj78jmLHR7EaXfUuVbyA7wDbTnEYTaFLp9N+RwK7U35rGiUgrfb9lDIqUK+o6bPLoYlyP5STKpOf0lM+hSkoxQx/4wKevu0zCiNbSt8MSzAh70OK+KuQZEw54sFrK6pIL3iDileCoXYjyLYfPLlL3beePnfbDhv2sW3nfdCfstFDtGwhHHPHdr/7w6tdAvCOrHtsBPLQGR0NP+W+kcXt2Wz5UdFeCcpW5XIZEAlLhdv5CuwNHw3jN52IcG2n1ASno9R13egrHoUJ9rW0sVx09joaSY6N2jx1jV2FH0mF55XNyLNSAmbdx2Cg5oP7wzrxMjZoWzy5Dx8F0ZANN2O6jNqafpmaaasWiqdvAKXc+zIo3gL31o/k7XkT8NYZBE8Qx24TmsAsq/ZwUUxlF9sTaX2ZDEuuV9L7tvPYKBbKx+b78mkUUIKh1VR6n8U6RYS/OavHVmLzMEK0ToyHb6bV30L4qjkBaw4VoTnOmrx8gNduC1bR8Eee/ndYkLbg2Je/O0qTTKuw4fdU7h4z2not5xB9usVSKvyR+k3VVQvmYMbwiW2pXIOM5jFkurOfFDcArumDeLH749iUp0Kf/EqZefJ+2GTIC5oDE6jDcbDMOfAHByLCkNBdBiufI+GzqLvuP87ljfkv0J4bR0FnJvKvW59Hu59n6V+lNDnn3UUOb6MzxqPYsWAFnRGDMNHw09wvC4CzSdliHBpoiQde7wPTqPypyIYM3kyq/9bz/2OOfHGSxfx7KVIn8/exe8fYRgz7i3il9jD3fMuIsZKsp6zjfA3DPi2oApdnIcv4qJYu9Ge+iffpeph4ei4740gm0KhSyMcevvWQjPPHtVjw5Err4bNqWH8u2AEjJ+sEJ50noFXhXtf3SXj2te7dP50GCt8vyKcfKEmhPTaU/GkfAz9lcgmy0TxpX4o/6yXYW/NG2ypNo0Hd/lyyOyzqOo3C0N274RVuCgehodTZ2kPOl3u0Zq1Z5G1nGFQuZATPeaClsylMtG32Oe2l3KzD8M93oL3oBXzjoYjOeweaYctwt6kjbzAfjk6/juOtorJfON+JcfPSOEXl0TRXT6X2nV7keEcy6HmA1nVYhfPXDOBf7qmQaJZlnVe6rBSlT4Cv4dj6qNuDtM+jyE0Wxh3PRTmveH0pOcnHqo6YEOTAX/XcMCW9FjWGS0lzBsmhnVqYuySl4a3+hHwXrgGySFThR3nJ3PtxSHsk1bNYt0PUe8m4KjUGMHMczhSvTfi1fixPK1fMj88tYJ/xDuQTR/3/vnZhe1DEmGZXMDFng7C9FUnaY5/BEoqwNYBYmisciCLoVcQU/cH3y/fR+XV+3R05l1UfFjCV74n8bQHr/Fp72Q8uviOE/aKsfu+CDgUiSHt1Hy+nKDKYq8LMOHFHRQuE+XsAldOHNXHXP+M4DTmAVkPCeGXFcrorRVDvEwhbv0XztM6TIUt87/BcOdU1lTSgVHlUMHt5xF2eVnFk7+K4ZapJJ/O3Q/a/5ZbF6Rb1aim4try+1Dcfx055Y4IXOrGvu0p/OCZI2o+7RUsQ8FrI97hdlE5jviNwLwPjqS6Sp6neg8XLnzxE3w7MnmIWDpCTaVZzo0RvTMZs9ftoxcHB3BVtTVrjR/CJWq2vEt2KhuOs+at2m/QXJ+NLP95fGLTQ9JoGoG3feqR3sjX5cexxTsDds6LhOtBcUj/GoGjB+bRjfN3eOiyu7y3eB7JmB1Dx5DTGGnpjV13H1L/HDmeL3sJFXZF2D/DG/OT3iMHtfhXcRgHn6ngh5IUy98WR5r1O0hrq+Nan46ftYbot4eUeecGSk8a8LKHN2DmcRp1ivpc0X+j8PrQZr4SPY6bN3wkuTnqWG6nzYUiO6hupTryxNuxRDcNTianMPJ9Kdf9iYHO0bU8I6Kv/5KzwWGv+ZjW/w+urJhPSpo7kGI2WSCFkzDfo47hf4ew2PEciovT59HS6+B8Sh2PLPthlkMQ77J34MHe1QiXuYWrkORNwVvRdTYcOycN55W3/qMZz/fjnP8xnjnjE4LLT0Fj2Q60/TcfAadtsPTkVrwYehnbilWxRJXYaGsFxinLIXK6J27+m88XltxjH4l6GvDSBlfWjmLdUSMEzU9SPHKMBuw0R/NBpyQ0361gY2sNBKrUwG1pPfS86hFmtZ6946Ziq2+n8DWlliN7KlD225I/ilZiR/+pnJ/uRC/nrYRIkIiw/+xTWLxPhdikEh4YYAsJqXX8K9SSH7kF84OoD/CMe886ihJI8FJA3ZRAnpn4GZ/WirH4/IvYvioFxb9rsUD5Ed3VHczekUrsEi3LSpEjuX78WQjRw7Bh41foj31E/5lEQU7HGTezvbAsrxIuXUF8b+4jyuyZwBbz9fjVPxk2cX0EsQUFGFCiwr/99Tho/W5objbEuw1yws3xM7Bz1DDWC4zCr8Vf8Ou5GKd5rmH/1YHckBSFY7ujiFOiaPVlZ2T07OC11Ybo7tOn5bmsYL4Mjh3t7L/1HNpdwrht7UiYvXNGvd9IzK1bjzmZU1l0pBT/lXehC9vleaD5aK6tk8BA40zSDRvIQzoW8dNRF/HuQxzbX/+HwIXvMdvKhdbwfzwh7R5CZriQc/lIBM92wce7IyGzxoWWuezg7WM9OcvPBZ+XaAs4bMpD29oRJLWCA+IVYb9hA8aOjqYJ88awhmQBVmww4iHrp/LR0+PYYagm4hyBTjVpQe/EHsyfsIBjrKOpuaGBWtwlcXqaJnxj9sNRpJHEF4qx26tOTBU0cSZvLjvaaiK+fCZs1XcJPmvt2D7mBGe8lOGWJ1Jc6ODJo+8vx/BFjXRt2kwOLPzBNztmQmW5K1V+k+BXv6X4wZxPUFqSgIFrGykx1pUSDSWFxopjvHHhNdRpy7PK+WiaUZKH4ZblqNi8i/dkNFLufleyW/sEjdsk2OBiIx2TLuOl78azbKAox9VV4eTdKnx5JslWL6OR395Icooz2SOunEacTcBbozBM/Dua8382klSXK33udqVlvZLY0etKofX5mP9dmY0VY6hsbX9uP3GPBx99jTnKMbg0fBSeO3yD6awFUA034ryHWXTQXo6Puvuj/51wdD21Z7muBCgELYCc+ygsNQoVer3us8R9Xw6Ma6Jilxh8WBVDB3WC+YhPH3POvMTGk0xgbNzNhWebyGBjDO1TH4FRD2fyU38peDU2Ufus2RCriBTSPo8Xoi0MWLlahG3HOjHuzuOIwzH0awYJs0Yb89Mv6SxhnsYl8tux4Px1HI7sRFhpDH5cjcG+Kz+5uWMUijpv0oP6nXyn6BzlCQtx1eoxLbF5TGy7kLJ/juKhW47xsBcqPDJ9v7D3lx6yAh+Ty+RDdMNbhlNFCmF4fQQm3pjI3+/rY87s93y4uA0RT3yRsKoMg04tx6V5XsKS/x4T7c5Ck9c6HqsqxvMW2iGswYt9HNVYVF1TmLe3DF3L7eBs9f/3F+P5Sk8ajjXn8PTRWdzycBAPMpDjS0nhfWfkBs+XGxEgY8kBh0W5zm0km35OwLs327lxXg7Fzg/nTmd1qH1xwo97o9Gydy5XzbkG8a9a3FqvwLbXRDlzzRdhxI6RfLk0FgW9s3hB+hd4yIzBE0GDu5QCMX/yFsG1MhZl15+Qp+EcTG9awMtM60Dv3GjNxvN4+MC8b20VLHnKkp0dxmCi4xjsUHGnQ9IiPLozFtcTdIVWKWl4cjOZSfpw6EMRfmbbjNzBXVDaPAYdfpMwba0t/5knCbX9c7AjZQwG+zXTwtkvYXJKm7cNkOBN/hNYf7gGaJ4BRyhe4dqcw8jdXYTG8jEY8SWVw0YnI633K1srZXDB8WZoNR3G0+2DhF8x2yE534XbDFZxzrwRPHnENRzMl8SEEXfx3FsD/dfE0VapHBh1u9OcpnQh8IEPX1pWg6PicpwhtYhSC57gjswieq/9lNT35fCFUVr4NloLgTlx9PHJNP5zIA50OQILNtmj4LA03pVJY/jrIPhZHcES0TdYn5sMoeEykiYXo/f4cgRdi8PqR3G0clApYqQOI1ovh2W3nIfGl0Jcc+3HM92N2XCdKe/IeErhF6IQzdJcKUjzvfOLEHjxKbZcXkSDbijz6lmBnCZiwFpvntIhHyVW9wjhjo6nlD5yCNwiTuPOl6c0YNpNvFUegNr2M3AfOxe2rlKsodRCvzJu8Em7A5Rs0cshGWLc0ti3ppEepPbNiuvUPuBgZxd1jlJh3/Uj0eGvzHFna+FwRoZd/2rhyQYPTJ03GivNojj35V5OGynW16PsJDOPQ5ipNxYpwT6wOuxB0R+UOHjzIZyTMGCVn4DccQ+Y5+2Ed4gcxywei6ZEc6ycexyffRMQtcJc6Gj2oC8tLSS5MYBTVo2F78W+f85JhqLYMzKqGo2xN4JhHeotrBj4jNKXHuxjAin+tvQh/yBXtpz6jG6qasL79RvOrzBhozfmXC6xAwc8FtPiObX49GcnWZhqYrP3EaSkX0V/tbHCgOhnlKYkg51D4klMRQbqqjLsuKwb+w8YC5XjrFhWZBzGly+msSde47jlDuRqiAqDt2viSNtBjtFPgWL7YpryXISDKmbxE/VEfJh6DA2G4/DzcB5Mfz+jmMP9+fC1At5WIirMEd2KGV3zeeCCpxhRk4cFWksoiJfATVhCBTbPSfL2Bdr1QhM3/tvImmen8bTXebQmyR5BmZfhg+9YPv4MQuZV45p+Og+Z+hfKW59T7rYl9KzSnv1LZfAqtQrndzpCPvMj5pR9ZruaePLo6Q+9wGYU3Zbh2IE7Wbr0OW42xuPNkxL0u6bLP4wDheY38cTt8STFTzC35zl2hfZl6b/npC7WSq8PewmN54bxqnEXUD9aG90dskLUOG3IG7XSEZNWipygjbTZRryjcqkgdc2Ooy/156tRS7E+sR1hu0x45Bpt/Lqez9h6AePKWslk9R9oZg3nksZoVg4aiOwJM1i1eRvuHXLmk7FR2C87GrtWBvHylI9o6milQNkyVpR9Qd/uaOOB/AvKLRqI6YovaPiZo1w0/jOUcq7ziGVFHFq9C7I3ByJj1l7W/VeKkfZXceHNZaSPuoF/Podons8LKhuhz+EL/8NZoQ2qtEdYpHUCVfrjEZ31gnZ/GgG37Z38KKAN7TNO4MNlP7w55knT55zAE6cC3IscC5M7noi8YsSm9jux65saJypFo+ffT0g3eNKQcQmYa5RAk/u9wz+zQXjZ5UlZ5glY/VOLX/kdRBT+Ql7iJYk7J6Biw1qYuSYg8aU11H+Nxt9vAVh5pRUy3YewrTsAYzcmYJGuE4Yd2IkR3IyLx06jx/UlZR7+S5ZmcVi53FgQ0RiD8yEvaVdyAuXvTqBx1hp8fE8CbVEfzJ+Nq/Ht/mmY9dflK7/FuEJEB+eLE5C54DD1iusgYn0dtp16SVEDtiNqxEn8PjkIcl9F+FNoGn87k4BRNV6YF67Bh3VrcamBUCR/CI4vvUj2bgJ9mFBIg/UKYST5Chmj3mN1/2SeO+gVnQg8xpvzDtMq40PwWlkIf6NXZGqyDG2+OjixcQOa/XRwtckGJ6UTkTAgkZy8XlHOsmUY+HA7tD99wOvtqtiW24lIcWb9qnRWE6tB6IZXZDJZFuXFhTAr0cF9c1kMklFjt/Io/lv+ikbnB2HGxVfUm7eIj0WZCBPm2uK/9mWk4X8Bm4qcMajrEyddvEIfIl9yiONuVP7WQdGLGCFnQxEb+2Riap4tTgtttNdqOS1PshO8FulxXoIUa88MYYpX4/01iSTsrOX624kovSMLlTADnmkuCe27+7B/SRHtCGujY5198/SPxPWc5eTr6sh4k0jtC0xY8VoEa20V5zzbVL4XMQFxt9uQ9U8W/UTkEL1/AixyzmJtZAMmiyfR94dtpNuwmj+sWYvGt0dIVyoJi94fodfScsj9tpyUf7XRlnyXPo5fjp37JwpFcpXw+pjGs4LGsXV/b2r9mw+dcd6Qtz/OqwIm8eDmPCSMceFlU0V4blo2msxe06qeCXgou4LtE8/x7ZUz2a0+hj9MmcLrPJJIPdQb58JfI2pUMU1e+YRFVQUMWvEWFkrWwucPRhwZnATJZG/YH/cmaVEDror9h94V42HmP5f3nFIU1FLlOPhVOWTiyrle0hDnm+UEsZ5CnPDVxU3DFI4VX4E7hxRYIyAer6rH4s6ANzR7miW3vtvFVonFmH/GFXfuumJYaxK1KKRj3z0JPuRYi3UPohDQdpszY1X43Rs5RKVXQ2fJGzJZtosf3tZF7L4jWJjxEUW/lrPdg034tXMFLel9xqsa5Kymd+pi+A9dvvhTF0vPvaF9VSd5uFEy/Ts6Ttjndge3TeXho6iHjmnJiPQo5uUze4T4EAVhTMM9zO98QzMmeeLP7OMY6txPSOxV4zt9/c/+f+E44XIc482HcrKbHraf0+WYRB2s3FKPnh433iimwa5Jydj8cwH017VTyJ7jkHupzJf1++5guh5G2V0T+j84RnW9UlyadRz7QlZSWp4e2tJX0qYD0/nzqIVo7TrBv19cpzGjvnLUJXF+fXQlTftxDLdutJPp02S8rGmnykkG/MhyEFtNXM53380R3FuO07dfyTh5n9i6Oxk3TM/iUGoFLh4ayNrZ9nx9dn/++m8lDe2M4aichXDUbUL9sBLkpN/k55td2XB+PjXqvaXsSavw1WQiNt98jEvJzFpTd6Ne6jryXd7SL6PdaFxDfGDKC2y9LsbbPCbCKTEfXSVe7Hb/EtrC35Jt5FvMatZAufdERKzYDdo9n6tW76aKvQIP8x2Md316PW6YMK2vL/GKngjh+Vmsv7uKXLNKoPj3ITR8RIRDitpc2LCKYkWm8f2Pj1BwaCLmLVLmwb1i6Ff/FxId+bx3UzpUs8PBEu8QqGCDqcNVBceMSfxBPAMvu6fwqsu/sEqvDB/3pGNFZi/492hWNnpH+YNrEVtghpPDpvJnEoeZlzw/3vGKRDfP5qU2kTzMVhzTZCbhoF4VLAY7c6njZA4IGI22Djd03VbmAd0hCA4w4hMJ7yi1LxMkB6WgaGstDKIVecMIKT5p5M9e9pNw1iAUK56spi4dBfS8nc0PXqymn88GcEjtIA6vKsPcF4OEe3PPsaR6PcbOUcDhKRLs4KkAVrKF285CLh6Wg93e0Wx6s5Qm3uovzIldjg9n4tBkbovWS+5wfSLOwf2H8/37k3B6bDkcEp34W2QR1k9bwFEfx3CZ9VAOKluOs279uey7LMtdH8amA/Tx3C6Sm+72QtpThscFTeW4v1mQX1CJTa/W0AxdfdgOX8tx+4LhWFJDtLmRv+0sx4Jva7DTRh/lCSLc/iEFloe+81PPVxyp5gOZG69Q01fLnZ9/o1hSEWMMB3Dt7XLY3h4ovLL6gIcn4yHfOp/9Rm+B9qJHfOvfINba6IOG4hPQLBwnTJXQYDPZc7BWE+EWg8f8wWcf9/c7wSU273n/wj1ojRjLw91LoTpWj4PHHeWXfnsw2PoZb24w4o+d+kj5rMRWnR/INPEmml5K87vSIXwuy5g3PerG6fRJvE90LK9MVsS9GfP4k3sLis1s+ajLKG5a6oFla0axTKwbm0j/gYeNLyXXF6C9ZA+d26PDa07soaFnziH0uiL35nsgzytMSAjoIFnV5D7fPIeC+x58K7OD1n4o4nvDJNAqew/7r3fQiqYTvEZ1mNDyYxr/ehvE9VmT+zKtASu6+7NBpy+SlFPxyVeT389ewRa7VHjscCX+sugefGYvhtiTx3B9bM06mx5idb4Pj9NaS8Vd2myYfw1HzVLJYsZH8v81GT6ug3FsiwSHnJ3JeQ4faYVjEec6KyF1iAF+FRaitnoupv5MwvI1Sjh0ay5efXflM1s/ktgfObY0MsDsvI+kpHQFlUXvEb5CTXh7bC3mWRrgUJA0/8Y0KKhM4exbFfDs8ETX3mM8KScdrtrDeXtlKrXdvomDbzwFmfs3oV2fiu9fJfCpIZXss06h9uwKtq03Zq/f1mzcrAT9AgOkvJ7O6Vd/4PvnFs6aY88vjoAD3NchK2gdpQQexHmtaDzZ9onWGNbicUk4nKs0+XZUFiqbbtMfmybEdRvyyLmP4Cx6Gt3H19EWySnYVfuJUu9/os9WaQgZOQWl9xJwc2E05GakwdpuDHt5DMHM6VMQ/e8TvacpWNzsyjVeaUhedBruI0IxafdBXqX/GdrB8RxvZsw/Fi/lrtl/4R+rw66RU1C8bwh+ufvBLMgPod4HeXxoB4pOpMG54wCrpj1AwvZQ5MT5oe1GGrnWSfKam2k0tN8YfjxTma9cPY4l47tReP04+TyMhm/VbDREGnPxg1ZI/PeZzFsYcY+XIuh2BNe8TaPk4gDB84UfnHumYHvvEHT91YNkWF9vKloCF9ZnA/G9uNYWzxMkh2K8zBcaoDKUxffJssSrayynKoUmvS84PKoEq8pCOGjOFwowHAofl/VU7egJV/cv1OGxHqs2ecIk5At1Lp6KMX6p7LZagJrXGYweP43nPxnBzvHraVP+esxJewirMct4WuZDVK7x5rIzX2h32Xq6kTUVjx6sp+ZiAVEHpmJFzTM8bliLCdauHNPyhWaFxOBD/F5MnDeDoyomIu7AUMR/9cSKigl86vpUvEyNwVHpDZQzYANVK7/EnIIYHOdMaF7cS+F/BCx36ES7Rh3q9PL5re5/0NEqY51Uc57bIMXqq73wK2IDhcgHs1JMJ9aOM8QObUNs/RyD8q0uHHjIB/lBJVx0spNcNVeyn1MprXrbjWRPQyxr6qSPDh/R/rSTbG2teU+IIRoslGEXdhaPKibzulNJsBaUsaTDm2eP2MoPBm7Ei0kXsDKUec91K8yKKUCs3xph6TFDriroY5oqQ2x+kQSVzKNov2qIJ+cnCA3VZ/uy0hDbb51FvvMymP1JwpCwjXTtfilNW7OaTb+8x3n/X9zr2x8dcRvpcuFXOmlxB/JO51n3ZDrK+xthyN2vJJP4hH/e6KCYM28QsKCPMUuWweqewPmP9mP/i6/0r/crRbamk9j+ITzwdisstg/k0GP1WNB5AS13TyLlmhPGz9aHZWUQ3/v9CpOWG+FxgA2Lt8ZCZOg+BDydwPOzjGBfEcc6+vvgHe5PlZNVcKI7FhvfHIHdAw2u9HLkA8f8ad0ydc40eQRHdEHE3BntLUa4RXNxotUIiybcgs/KfWSbvxLzRtvwk5B9UBLdxLYRzlhyvx3HxI3RKLGJBkl9J7uP+nxdexOOvLPlEf+C+K/+JrzVKseEPWm4aPedLm1w4Iva9lxnXQ/9U/cQ6S+NwEXGSPAwxpmQTdTf5DUy9rZg+o7vtO8/FQ6qV8Hw2O/04qYNHOdN4xrPBqH+ng1iRTMwdYAbX4v2RmbxARhfMBWUoibDrdIYM3zzkTxCFfcaDuFXEPNsg7/MRwfx734/yPplHKqfGWO81GyW8DvDjvPbIBagJPQ7thsy8zLoh8MP+mybzyM2l0FizDh2cPtB+Qn3SefEJVRsDqBA3wzs2PaDYvxUuUA4yAUbVaHY0YBv/5TZo+AHJe1UxeiiHxRstZD3evTiSc0PCvqTj1/HJNh74wqMvx9ADU9d+aapAeYdyBKSJPP4394V8Lqtz1Iup2iJhBU33uiACD/kO/EmSJr6AGGLPTnvWgSkx/3EkJqpQo5yOWrNAskm+RTZTU+B9tcMaF8wwcvVKmy7+AInvRjBduP/YknmJF7mbcZb1eJQ+DUCVVXVsB6zH0oyCUzB4DP/TPBexBQ7zPfj+Oow3nb1JRxPyvJcd0O2lW1jX/f9NLD7J+Z6xeHu30Da5VwB9dydnKIZhM5xQeSqcgVptIuF/0R58ikTXrw5H5rd+ozmlXikEguriBokfkyB3Qvmmlkt+HPaFHb2w3mN8ye4xUyBy7aHkFhVznf/M8WG6l90/ul+tNz8Rd63g2jbBUnuah2GXc2mcHq5n1xrj+BTpynkz/Th0s8mfP8RRPGOpyAqnwlZtc10U62LTlRd5H3z9mCYdibej8+kmz+ugPOK2VQ0Bm/01PBZdyfkWQ2mPpthN30896iI8I3Hibgh68prNnbRhYNyfZzQV79bA/jexngeGmAGnewuKvVpw9+aU4Dff7SWhnCD61W8vLYZvpIVfKWmi8Rvd6EsORNLUjLJ74QZZriPZgXLfjy7czNVbTsDkwG/KdFkBE+oM0O+YjD9Lc6k4iG/6YWcC79RCUaG+i4oqQUTZ57BvhuZ8Es+hJlbSvBjrQzXfjVD2tNMUnmWifJ7Z2itUpSgvr+Ws1quoiQ6mJrig8k44TcVG4sLRYujuFd/GuYrZNEY61TU1dSw1pAsetIn0dE6fPdK3zxWTsPi8YawudGC7tXTkDI4jP+zz8WwN79p970JvHvPLuStn4ZNGS9RGzcNZe6xLJpwHof0u4k/PkHpsfM0S/souywbDnOzLZTtPoRbpm/BSNFEVl3STYvHxEI0+xp2qomyV+tH9A48g8sR3WSxagwXxWyhrRt9hdfvp2F97xpoFXTTtqItJF2chZDGVDh5WPDbyP7Cuf7mUFiqz0cexQtqz7dQWO1wdL/cQmquEjyKzCHxIouUVYK4doii4G1rDs23w5GzN4vhVUXld6Q43EySfTre4dbhM2gJM0e55yCeGVlFOu5byXjRVmSGbMW1K3swMK/v2wN79j36hyRnjoDXrGwqv1JFTiVbEbFkBOK0FLlVYjbf8sqmv/EHMLliEOdOaIBJtzl6rdV523//cey8JMTeC0DenAbsS80mtZKvWPfdlPPGzOAmb1/IrvSF2sMymm94AaePZ1PluwTYnszGlgHR0BAPROK8Htrn10MuG3vI9FY2nQzsodvvJHn2yGjEbt0GrZAeSvWfjndRhRB9PQJVj10484oI70m7QJm92Vh2p4fyRNSxY3AO1Z6YjuctpUxfttHToTnILJsOmVmy3PJzG7m4y+KQvwdvDDXGpJtgvefpMNLspUdzpIV3+8M4yS6eE35egLrmLXQ8Xs49geP5uGcO3V3dS44r4rineQKPWJFDKutG8fvNOQg2kufPW3KQ7lyCn5MsIN3Wx9n7QmhleQgCb0ty5a0zqHyzG38TKiDhZIHWwhxaX5yDmEXV0JQMRbtbDFdUyPAUiztsqxhKNi2RmFRixtEvcujziGFsYZfNiWWZODEtFPXH7sLomgVsR0px1s4xnFaayOIqczjwbw6iMtbh+9RCeGetg1pMKDXonuI/O0MpctdfPEwKpbKCv3RAJ5eGu9RBtN8ldM2JQeGkXFi8cuPHD/9SfH0oySnXwM0ml8xUhrPb8BpM+rIOFr9DIdmQANWLTchaooGL6+VwbtRzSGk9h3egBjatLkVj8BNWn5WFWfsquXZbLj29UMgqPdl4vO4fjfWbJDg8qMT6fTUYcLQU25OeIy6+H7+5lIvB2dvJVySGz3XlsN3fFBS6VsDvwiUsv2iJzsLttMSykCueyyFl9WOKb8nFlVvb+3IrCfTYEoXN5bj9yRL7O7aTz1dLxPwS55/fLZHx/Tk+6DQjocsPndJheLUhGqGyB7BKpQvvFfRZTU4EZ+XC6LHSAbo6+TJ8dqsL9hNH8v4pYRRmGIZNZ4x4wZZDWGwbRorauXzqtxYnnnbnutlhdP3oW4TvuoxHCZchEnQAHT7yeLb5ABJSLsNTu5K6jl2Go1wXT41T4ee7D5DdHnm82yvPQVlKbLNelb+Kb8D2SyOR0E5IHL0BJlobMKI4jGaVhFHIDXk4Sw4TxmofRtJlEXiOBlaPAV5slOU50pp4XB9G1Y9EoJS2lwMX3eNF7SJs976S3i8C8t+F0fNdC/mlqz/f0/7/+x11rjqvwPpffiP1uTQvP/MY3xzzKGw/UNo9iOcpirLaw8cocsuDxkHg0NhwkjCL41nFCYLK5l3wmr0RzjE/aMb2Efw1UJUtHigKjQl5dHN2OOxvXufKH8Cen8DiQ5pwN/BhTUVG1eY4jP9vPO9cWMN6G0Wh9KAbnUURLFqvyQc6CqBZuwuTGzUxN1iUE5rycH2sEW+vuYk7aRKsuuo21HeJ8vFd4VRlVolyp6t4dW0wrzorzR+NTyHel3E6tBEaS9dycyxjb/AiFBbIsnAqnMIixDjJQ+DPBv6Y9lCCEzQSIHdsDBsXMZRc/RF1exa73g7HhZbb6Nn9B5vtR0F6nQ7PufIUiNHh0NUHQXMSYGyfAGHEHZxQjuUdG315lWEgL7rpj7MSYoiVvgZVRTG+uW8U3qkLvLXFADpDxaCmLMYXOo24JucgElQj4D4sAuYm1yA/LoICKqqou30iD/34AQplB2EVOx+FLgKMbzTjgLsATcubnLamhWz/13B5RwP5RnFcWZmZJdkyIhUloXi+VymSVKSkSdFSyoxflL1n2US2UjIqSSGEkCSpJNKOFO3188c95znv+7z3PM8577338+nMQfDOBvinxENw/WROzkycTRcjno2nWIzDKVZi8he/FljStlgLanOaihyPU1ha2YAAK0tSy5+A9XUT3Ao7Ba8Fu+iAbiqVvviIyh4TXI2Zipvpp9jJPZP90VQZ0h/cYDXiBmmZuziU4Ugma89Bj38FuLnTSUdGgXx3n8O1dF7qcDzHXjSeYmoTO6iusAS3fJXxUCWBvslOp4tTXsL4TBy8nNIwb2AqboxOhexvIRPj1GfImMKJnod/cM5oKV2XCECIjwwtL/pOKTL3YPJsOwpmcaJlVBk3q1dASD2ApX1wx/brI6iZUMbuEjNa8OcZq9APIvPYXaTmb0oiVnK01qoWFprqVPh9BZ36uQK+HPNJciMndLafR/B0Bbq6ph2aQUbQluUw8QzrwaF9AdC2zYX3t1ZKKDxFb/RX4pJLLqo2rISAdSMTCF1CGdEBk/2QE5H7V2JZUTu0z4ubCA3UMulznOjLmEOfsnKRVxHAYhf8w64qTiqpzEVxYwD718QJfZdIun89FydvN6JzRiRUE9PpSEco/JPSscOJh2rmXsB/Hznx7n0uyxwLANe/AFZVzkHh9TeQI1KHek4VeHKpoJyLC5myTWylBBdokyBdlQyENztDS1xbMM/AFP0nOlCdc5ONvxamMltTuNdLYO+yQCaSK0K/16nQ/l5jnLHkwqpeW5Lbm8dWOalgz748bPfKg3OcKU7uCmTDEzch7sAFBcdAWC/NwKs9XDB/3gHdNFOMxKlggXsgy61fRvWn89DVcxmPv2VCSX8eNYcEou+8CioDvSA/Wc8PLuUxsx5T2N7OA1ncwnn3XXhn2Im93jkYn7YKNuWBaKngQlldILLqA9mu6VH4NjGOvC8q4GgMxNjn7+BigtTyMJD9PXoaDY8CMf3RILNa/ATvRfLZZ8m/+Ln4OVIudML35RcEf+DCOMdmJL7lIw+xFRjYswp3qt+A3ygf7cb5LFFKiY4OLSHenQfofVY9dkgEYbW4HiWI1DFD55NUW7MKTvdXQW6hFl080Y3y0HzWYRDEGp6Vosz0CqTHdtKj1W24cVaX6tfsow8/Y1HjUMc+7spEuNMactGbQloO3Bice4fxduajZulxTHSpIlPLiPx+zqAxD26c+jPEHmnzkt/fR6h6n89mRwTBxPcnah3voDyay+Sl7nMaTedG95GLiPGooL7OK+CIFKGZYXfQdTOIGSxUQ5jJMYqq40afjhoe1XMjvJsb24uDKWJ2JHGuLcCLhcrUtW4PJb3hnmR2whsPNfz9shoffwRBUGEOfm3ugu5fbngv90HfZh+svDeD7EV40C4SzN7KBmPtwasYFdOFuyIPLGcJm+T/OIOBuoJJ388n24cF7Eu5OImq7qdtqxzx0MSc5riYgXPwK2TVkmD4qQt7vhSgfESIzuSawdWFh6oKW7D6KA+468ywrzQVxxze45qyOrqv8NO/wGAcF9QnuYzZ9KjKDhf33IdzYTDeRu8x4ZlijqvirZPzspKGE19TpJw5trUGQ/CWL7a080BI1xxz3JTp5LtJvs5IJdOGp/jTFcxeD/CA9/xyer6hFaqZl+iqjTk+Zhai8xMPLn/mgdcEDwxtDtDC1uW01dCUXoWaoyPCHKpthQiJbsXbu+oYnMmLzo1/sF6GF4UBeaj6VsigxUvLfhayC1+mkjH3CtjJ1JJZTBAliBbBuVGDyn624luJLa1Pa4aasRSVjF2krvlFkG1RoJ82UmgxmYuELbdxU2ENOg+EsLeeIWxY2R67r8ygjHV7sZRxkrzhGiiHh7CqCF4YHZ6LeXaDCLygRS7+yXCscKfr6SF4fngNDALlaEOHKMW6r8GuzCJW/WcY71Lk6FlOEX5W8mJ5PS+JSV9AYlURdhpmk2VfD2LUH0AtR5iILx7Zq03o370itujOGjQ+CWEYLmKvG3qx9U0yau5M8uXruTg9tpJePz2B+FdrUPFfLJ3fzEHXTu6hbZwW0JHQoL7Z/VgdbUahMhb4Lt+PTb37ESOcCMdmVRSrTkPPDWt6tUIDvT/2o8G0GEMiA+A87YSIzRbIPmiBv2bT8ExrB311jqIaNwuYjWZjRqQF9kTfhd/OULQnhtBxmk7jEuUoKbGY9OXbEDo1DTUNd9F9rphlNt6FvmwOpgSHYklhMYx8z+KNjhI9LttC47XF0Ksrhm5hKPZ3F0P/QTHT1jTFcx9J+lgzjT6OFOPBxiC4ZEuZ3L8XynbzaMLufigLW98O+aFpuP62icz8TOH7zYm+7HlPR79Ow9tja3HoaQEWXk+nIgtNSP56iqCZfDC8yWEScp+L9t5rYnpGD1Eux4doDT4STpejf6kcZLWAD/t1G2H/XwkWP10L26nNbMPztahxlobYYR0yfrUWLrklLO3HWtQXlOBgrT+6LgmYWPtLT86kMSTWaEJxpiV6LvDSWF88nc6TJkMvPvjzm5C71UlSSDoCpm+JoRFN1EXwwUNPg+ZGheHsF38o7rdE1EFLqEqnIKpuM7meDWPm2WHwnMiHwWU+9Iop0JriZqZWF4a7k6HZEAYPtZNYqTsPu3fF408jH/4mvcH1PztQYnASco2WeLjuPPyfdLDp5lNowmEeefv14si3DnBKV4LD9zwLuMBNdif16YeOG70U5cfXgvP4rsRPaUvWoUtvHcLWroO+Lj9Wb1yHwsST4Hkw+Y1iLdi5k1DXy8WNb9y06pwLjoyeZyP3dpLeVn4kHeDHM6lgMshdh4prnciT0aI5J8Lxb9tnJP40wPtofpgvTcDYu9WQSdega9ki1Kqnhf7yGbTN4AL+ZBnR6LlwZvfKjE7m8UMmP5xttrqA+MJw2BhepaRr4eBuDmdN8+/hWCs/ktv5odsXDj69dOyZfwrZPx5BTvsUTskeg5qDFZosHlDWcx1y/jqThsbCWQZHBAsd2kVpvib0KOIAJT/UQudoFp7JcdGtIQO6LBHBHJ9egKCSAL4Z5mH5tXtIc5tKItEyNPbYDDlXllC3XgS2LI1gr4KmUoTGERBfKes59RwWo1ZolJmPloZxrLSIgPK4FaIUStkMSwGsVyrF0u0CqC/ZSH3Gaji8LwK2fgYkff0mTr6/RH9pPWQXrqC0gAgmwKdBkuHvUf7hJm7HGhI3fwZeeqzHWH4Ekxk5hUVOURCXy0ClnCzJvVxE3xfPIMM4RdqV2YrUKQFQaY1AWKU5em/NJxk/PVp9zRwydhlY8UeKLF6vR33xYzz+WMq8Rtajius+qnldMHrnMeLSNGmj7EUW/bwWXlKCiNscgKlbOCnbcAN4Dibj4Sp3jA9upXsakeAxEAR+8NCZnJeoXHORjSwTRMnxAJS5bMC5gqmUHziKOktBiEhIUrDnBjhbRbIemWHYKOqbyMQswMZlX2nT90u0aMKQuk5HwnluJp6dEYSEWyXFzJvsma834EaqIL6ttaXxewvQuLcOoYWRUJjrgWmmjxCs/BGx5wVRfV0QC8PDae/Hi8jriGTvOS+BcyASpRedTd4a2lOZ9iXctW2kJ64bsahHklR5hSByhMskc5JhfogL4dc6aeJ+/JFpmAYiX0oI7rOEcHrZdrKaLYSi6xvR86Mcde2T/7BMLgI9F6JrSRSm9m5Ev/01dIVdwsgLObxOTsHcGyvpS/QlNFaJUtLERuyzjGImk/XGYxXFsq2EcLHqElu1UwjTHoVRx4Q1cb8sQPj7p6ji6Ecd8VIthxv+HYuCe1wyjQZEQeTGPXR39cJHsR/2IVFMKCyK1YntRd4ZIZxIEiL9Eyrk7WSNaB9rOAqlYo14GfaeeICymmQqtNyLebVteDKvDFVa2lgxv4wN341iY+XW+NkuBNfQLGjt4qPc0n7E6lWjhDMIC4ai2KWadnbmJB9FHdZGtak4lXAJw+DwJ3aFWxiUVsZ+l1uRs3Q0U9KxwVe1aBjaWZD13GhWpC+MKoNoiL6aRhWvOEhxuTA0B8oQ/lOBjPm8sfaFNmr3B6HHXhh526PZnZgelnU8CNN2OOHs6iRo8l+e9LiZtMFVGK1zv1Ljam/EucfT1eQgyN62QXZxNpVMhKNA9TIKTbTJOVEYWYqOFOYWgpJjC+nIHS0adf7MpNfroEXCA3zjuRS/8TIzfPcMrRyb0HNNGNVzBWhi9kPsaotmHYV2hOdBGB3kpm2ndRD2TBhPdrbj07HbkErRgf2gMJ6OCMP7YzRanB/CeEzZ5PhFHbz4F836RYNREbAJuQ062GF6nO4Pn8VYyCY0iU8n86xNOOG1Di9+/EfiOZvwWy4Gbz7q0MfrU2jj58tQmzIKyyQVsrbJgsymLFxKHMSR/OPYbhhDe18MwD35GB4aJ+OJfTeyxjdh/ZdNmL8lhpVvi2FXvYIparkt7uTEU8jORZA9GYOezb2w6pOk1nY1isiZDsfIckhHL8KlvBhEefciOKYXm3bOoYhEW/w7bQue6+WTXOFDq9qmg7t9EdIbbHGiqxihLZa05GE2pJKtJnuHLbKeTofH++mYNvgcux32EOfH6Sj7M53c/8YwlX8xsJ8Sy56eL0WaRAU+i02uFURwQT4E9sqx6MMNyC4SoYxFsaz6nj3FWW3GpR2/0eXpi2Lt9Ug3FaHvmxfDtV+WLDbFMrNDFWxFmi+09pdgvVMsq8/YjO+Zm3HfrwSatYM4FOhBld0t9D2tgp1Pr2A+GRVMd5YcFUfGMoH5dzEtOhbKXEX0n4MTKWfFMq4jY/i1wQbpnzbDsrcCb0pjIf1NgQTKYpnVswrYFoSgTWELZvYpYefnCjQ9zoGHihDdaxQhQd5KdrQ7FjsLryJUQBfmgpXo2rwFvgX69Grr5M1ct2Dpt1imfEnc5MiPWEzVr8S9yVgeuQVJFhswpes/0l9bybIE4uAoKErbqofwxVmTON7I0Cy5OLZIKBSb5k2+0+EljQE1Sl8oCrWlccw4qhLtUbooGQ6n3ywOCt7KpGUYCp08XaTlV2JfQSUcxF7g1S1OUvw0hdQcRRHoGMcaLENxYZYdit9uAH8No+3R9YgPiGNyu1/gzJrHGEsSxcgOU5qVHEmSaXEYG1AmhZN2iDDoZqtL43D8Shx+VcfhTZAO9HTNSeCGKBra4tincjvg2TdomyzBr3t2iEvtZs8PVMH+0BL6svc8heXI0wWOeHZrKBRhFfIkKRDPtrJqsLx/sDlO1BfsQSFLn8CR6w2CV1pRkroY3bPciv3rt9I2j2FocT+A8vA/8BrEM7noOfC5JEVXp/hTT+dauvO5Ch0vnUzSVoRh+cF4lB0Sg/oJCZMrAiHUsvIWJk6IIV/+ClYdd6O2UDFYP3gCOx09kKEAeS3Ww9u4ePhdTwOebsUPdgU0ngues2LwSf2Cf2ZX4Cs4iyTPmpFuuAflXhKDblk8fg5sIJPyeKYvbI+cini2qS4eY6alWNC6CDnWL+HvwkEf7oshKOwK9jzaSX1MmPIfxWM83B87cvQgo8xNb/bbI/z+KGJ+xKOh4CU+edljsdw56oh7iruCCaxE4COqJOtoqVkrhEvt4aeWwETucFBzQjfymu3RtDCBHeULR+vDyWciS/HKUhzj68Spds5SvLMSh4XrT6ybdLQutavo353AKkMdiC1RpKij4kjrsIHz+qWQq2vFr4X9+L33KrSDE9iLBRcxNTQBngVyNNX3Kgvc3Y+m/66isiABmTKbMBy1DXbX15HmSVPa0v0KPjUJkzNgKVzbxNFRexV8B6VobOcUOiDhh3DHKTQ0koCQUXH0V64itTfbkFv8AGf/bYOD2x84TZHAliFFWiMqAT/RRBZRnUs5M/XxRVwCExknyXKQn2bO3kgeL8Jx7rYO7YI+jGItSeGuKrU4b6dZqxIhRNmYf/Aae2692KTipD7MtHtZ2OAEaR9IZE88E5nqu5Nw1onAhy8V1OmTyPTS9LEhTAKsczvEv9Zji0E8JfVo0rvGa+iesgM2lm+wNVOJJlao0QHVqTRs0IC0j/owv5XIdtUlovKeBC7KuFDy8h04+zgRrlIG+LB+B9Klq9lGN13SmPSWpvnV+L2gms2LV4Njegrlf5HAsm8L6bPEaSTfFqC99tUwr1bDnqYI1EhJok3+NDvrWs2Gjhqg9moVZHojsOz+APZ0D2D4/i+8HitAgM1j8l4jCa3PAxixkMSataexv9wAR2btRH+jAQQkIzHn1lR6fFgSDf0G0PTlpfpgSeSFnIbG2ufwLn2LVnsXOqc3hAhRTTJJPg2PaddZs00hnrS/hUO1NvWVSkL5mjKdL5OEyIQoJLlFaUvQBjp2QxLZD8uw+/ZplO8ch6jpdbbvbxMJrpAjzu2GWPNSEhwLjEjstSRt+XIa8eU21JQcieG3vDT752lwT9mFo8GGSOU+w5jmfzRn2gwoTHKZyswzKK0SpPUqu7B61hm225aTPDQGkVBxnb2a2YgtmmfYUwxiu8U/qGw/h9+Bl6DWeh03dp3Dqe/89KhPkDYbzcB4Wx59XeaG0rEtFCZgTu8jdsGikNGKH5FQihvEBr4aJAQuptrhSafNCUCe6xn0eJ9hhx1fo3rMkjKvXYb0qTM4u7iGOdWmUduSZfgaPwOWS5dBMPEMi/60C6s+74J0XTodHbqMeYft4JI3Az5e77HoGSepqwxh2+0zrNP/Ke0zHoJE1GwafDgDK2NqEPNyBjrtpqMjX5NunujErjcz8GC8APO7ppHAlWXw+TED9RHjcAgKJj2pmcCsazhRuBvnj5QjSmMpOVZFQVMzCeFWW2id7kwa1U9CdN8QxJ7sxr9lM1GwSszk8JqZmLV7K0I3rCFzPgfcao+h0Gol9Map0O9VN1jyoST2yuzGpH//m3SMG7D8HUhaTrEUETgTIh43IIQFk7y9HIppMzE7J4npuTtgiacDVgdYIUSmAnfCHJCXuRwp7ZLkvkuArhspUG5lMSRdnagsKRTHrtyAcIkDuh/MpI09SUyEXwI+Zs0wPCNDrfsvYziD6PjbQLQ+foFD2+zI/G0Sul854PSkSxlMOFD1txt4OdUR7rxS+BU1gvy+OiiacdA8UUdYiiWzVHkjikkWpt70bBgZDWPMeBiOGIYFOUJBS4puPBGg8ev2KFeSphPNFQg84giv7bXswDFHZEtsJunWaFyxT8ZotD/9ieEgeScpss4bBp+fJqmmG5HjeQ5KiZKC55J+pjHmCKtPwxjKTmZFUtOJOzcZ2+NHwZbl4F6ZFLqf1ULeKAfDz42ouyaZRc/ZA53+ErxYGoPXPMaw5DUGdUtRwjVukqsOgsNcNfolYwxR2z0wfiUFD4WbbP/rZPZo4U2slrKljYtvsqdxXug1fQtv05usmzuFpfpZUd6rICyelgKbqD0olEqBf/4eDM5JYflX9+C02iy0/E4nc/MZ1DLp63llfiRlkMK8FzxjHTxLSET4J+W5n8fsLbNI3W4W1pYZY2fCFkqwT0G6djBG9qWwDztTaVezMVSNgyGsU4W1KnsxoLoXsr6zoPbUGC4uATR7Kw9xR8+CU9EzfJ3CEL5vL24efIWYzBQ8/SlCjSU1VCNyC3bnU3BUiuGUeCyaL6aw3ZdSoF02i/6VzYLSAkZJbtPI6sc83JqnTlEts7CcbmGoM4Vtsh1D/MAs7PI/h20vUpD7bi8aDjP4Gg4AU6VR/WYqGQbeQjSPE2WLSaMsiWFNMgOHhDTsFZzA+nnoiX8sjKLSacHFW3BUlcYZcycEWzhhx1onuFs6YXn9LRg3MDqVtgPNZ2OJLg+whsvHsXuVNKwOOeHGW0auS6fSBWcpErNNZb2dxyHplIqvg+p0cl8qxiteY9FxaTyaDO9nsXiWv46y2p2Qt6SOKer9QqZxHbNLS4XLRkD5Qir7WpHKVgjHQV2iFE+bP2GoIZUF+tZBQtsZF7XfsDNnb0B5kTM2DH5C1ekARM+Pw9nTdYiMec68R1PZga/SqJTpwfihNrT4vUFkuSOt+fYLfsMcZP4A4HkJdFSHQO0jo5VaaTimtI0c5/9G2MwdtPWJMy0WqmfTvGyoTbQe+WL1OG05Gzy3BElgDsGSi4ue/XiD26r1MN6ZBlODerbsfNwkk7+Fk2Ma2zY1FA6uaSzraDjFOg+CewPByyeNRWMfhk7Oxob+MpJzrGcRbXHo9RvEfvt96PUiupmdBkIR9sbtIefc2TD13IeS6Homl13Prk9U0cpEBRItr8ddVzV6cFSNxDKacLl4H9o7Z5NnP8FIaDeyHS7iyOs0yL9JY2fknqPZ4yIqgqeRq4AJPZHej6KFUrR1zn6802aUpyaDgVmr6MDcdHAtSke89TvWsqoBRwxkqGJ5JkRc3+FAdDzcgvYjsyMUCnwaZKbqQ10OMuh2TGebJlJpPt9CEv4wjealNTDF9AaEyiykwIFJR77VAO778eCW50ZvXjoLzpfBrSIZXOxrwEKeA1CYdgCzBYWpf5UDNHXeg1P3AGo60pn8Oi4TDYnbsBERp87h2aT3IR01kj54pbECSX6LiNP7APR3hoF3iiw+W97Gg8T3sBLJYOedbuGaqCwSZDJYzdoEaFmKU9b+FTDjVaXzvitQlc1F++L5yMM4A4axK/A0mY9MW74g/tsBrH2TRDyRrfCxy0CTwEFI7JDF4l8V6Fu9g7Sr+KhL8iBa2m+jbpsSlT1fQcanMvDQcZipmX7A3bvCxDPERwfTM5ig60Hk3y2nUFttOleWwXJ+81HTlXRSqZSFUn0GZG5nMIEljTixuhGeZ+fRjx5Z3H+YwWYnPKFXQwchP/wBhaMZkJuQpbMTshhpLoGIzE4a5TyE27rb6fOqPnCFNjLNka8oXc9PjamNTE1xBPHKh4i3tBH9Sw8hWTWT/TI4BKsJbdpUt5L6djlRzPZYHEizph+froM7xZ9U132D1bxCbFS4DIsT0+mZ4mWsin6Lr6ONzMsvESjdA5+iQAo4mQjli4dwT7wJM8oPkZdXJqs4KYctIXIQ+dWHdO5N5N1xCPfbvkGxNBFzOr6BKyUTJT8OYfmvQxioTKYtNqa4XJYJw3I5ShJzwZsrmfAzeoyTG+/hxO1MnNd/BaN5Lki7I4cpP5ppbXATQnozYb7SBfu+TKcTcU3gN3NB21YXnM5pgkxoFL3Z4YIHpWton4cLopMfQ+iJDlmFuyCjtQlBUaNM624T06y9hz0C8vj6tAntdXY0mvwd6kNNyFZMQ+4cebRd9qAdN10Q+6UJlfPkobs4C4F68hhcIUmDfM2IEGgGt5k8fGWaUfV7lIlZy5PD5ixmpdPMDthnMXjLU+LmZmzc2ojbNq+hs+EwEo40wzg1Cz9S5bHE5TV+FgpQvf9h+hLXhY4LWaz5ahbzTfiBJ5PsGtt+Gj6t8vCxCaSg6q140FqE7w/k8e5pFuNo/4jB4Wb23+FAEhrJgt7bZnj/nEtVf7OYKPcZ8IsdJy3RdSQpsoC0JBVwVv0dqas9QoS0MMlqKpDt4los01mMY7n+pGU6xtSsHYnb7gjCtntR58rFZG+sgI+mZ9DSW0WRdvrk7HcESUdX06vwI4DbHWYYeQR5XmvJZXskskLvsBulf3HHdzHdPXyWWVwag9c+XhP9A9NoftJiOj/Je7zByXS+0IgulN9hL14eQcX3v7h9ezVefziCn42r4dB8BxEXFMjo9mKEXFLArV59qn43uff9HVSWzaDvtQrg4GiB928TUhtQIMvvaiSx1xXCmi3M7psCVEbOINjXFV+Xm0HT2Aw+4QfJX1gRf7V1ab9MNpsjm80+CCTBenwaOm/9gplCNnPiFaLnt11BMklgRor0btAVUyyyWWK2GY0f1yV7pd8o3a4I/zm/kbcjG3Y2SbCdcxT1LS34Of0Nbkq+w23fbFgsO4rwE4o45KdI34OzWSpx0sLPLWx9jCI407KhxWNOx7IU0Z+Xzc7MaGV1mb8hJ906WTfZrC31KKrTj+JTzkwa8wih4nu/Mb37NyJyxehljyIiniiSk00ry67cD/eOo1jQeRS2z7NZ67Oj0GPL6UHfKHIOtGJpVxJUPx+F72c5ErW/BeuwVqYkoIQusWPwfrqLJkaSkDI6k5p2VOGibA42/E7CLPkcJvI6CgtWHIOg9gh+GOawrDZz3BLaRsprcpjZQCvOHzuG+27HYGKjhGuBrqQTcwwSe3NYiGgHfZoRicjvnLTFRQnvxNfAxkcJAQ0ViLZJxqMFbdAbWEIsOofF6axB5OkchHN4U/WHY3DOz4HJpjZocLsh7ZoSVn95j3n725jLbDdsvZHD/M24yUNEh4ZmlyEgYTJPfw77sskN1jF/YfIhBwtHcpjsHjfULi+DcU0bk/Z1w+Obf/GpvQ3d+z+gJN4NBy9E4v2pD+A674bpVW7wu+kG235TshlpwVi8HhKm3cVAnxvGH0/g+nJlxL1zw9NBYXrbG4nWjefYmkY9RPQfJB7BL5Du1SOFF/qU8P4dvhum4KXXOfb7334K1HdHsYH7JO9aYCzkHO5ZuEPL+Ch5Hb6Lm0nnMJKiDBXfEApPU8bWgnPsnI87yCUFxcXn2KkSZUy5fI5d9UnBfIrB8uvK2Nd0ju28ZoGlNYr0+II7Lpe642OdOxoeKVNYqSs5t8jR33fK1PHpHCv0XEopVe/RL+CBZ80piHw8AimBOciSzGW/Z6+F+vXlFDprDjYvWAu7he1IMOYgzmM+9N3GA55W7ZDY0M7aTeZg6spcHN/vAYdVucz54iJ6Y5XLDPy+QsI2F8EBX5n55jlIjv4Kx0vWNPcIB61+mE29SqlwbYmApPscyO77AO65RmRulIrjAx7IPTMH25LmID89l71sbsfK3FwM5c3BX8Nr+GufivryOeh3TsVGDkGo7k+Ff1UuUupzkWjkiWMCHfi81hOV6oLQMd1IvCO5iPg0B/N1tOjReC6TGZi8w4oO3AnyhN2XBhglesI81RMOFdcgs9ScVkrkMXfFYLxYv4bGlfLYDo08NvJQn9KepaIoMpbeP9GnhveTvHkpgKRMVOCdaInp5/zp4y9PcP/xxB7hPrznT8OLakvwOeThoVMesz+kgm7FPnTlOdPndkss1/TC4s4OduJYHjTpO64MWeLf5w50xKhgaMt3vOXpxI1mQXowbR1icvKYhWUa3s/qZLODvZBvnYacSyoodqqG0P0VxLU+BeKOadhRl8eWo5PNonU4ZbKOVvbmQb1fBZd8G8nyeR7U3ucxs+jZ9PdjHnOcUIHkVxVcTNlAVpz5EK+cQvxXp1DHMk2KUP3BZPMrIJO3Di1z87FXUxUv4I2yeapo5AqhXv18dBioQq91HQT5P7HTy/IxZp4P/uMr6bDwR2ySNSTrzfnQrzWn4U+dzP5dBT6miZKEniKdPesNg4OqFHJEFR0UgluOrrAKyWdrNaxg0/4Dban5cHqiSYeWpePTb28E+RnSvMp8uFzJh8yM4/C3TEfIFhl6JjoADR8rhHkvoeEyQzr9SBUKz/OZ7VA+el7ksz+8YuR5aCrtm1ClnnIrLPuWD44/+ax0SgHzDTiOqZxqEPkWBdfme0zwzj0WcGoqHatZMpnnHlz7rDAkWYDSd1YYUFJDUuVx8lwjRkE6BRi9exwaU9ZTsmEBs5y7jDa9Oo4U5S70WakRt2oX+6kfjZAVy+jp1gJ2ZboP+tzEyP2RNsU6qOGYixpevC7DzgluWvq2DN0n1EjrSA1irX0gmCFGL2x/4Z3bemzNKGACmQVQc/kFL9UM1MZ2QVq2GSIpXawx9BfoagEaU3ywcO8uepfug6vmoVAa2URjbWpQurUevZOxqkMNtsMFTOlABvjeFzBt32OIK9ab7Ftq+K0eSdVcvigMlKXuKHuyyZXHgVh7Wr+OkxIkCtmHmeqkmaZD/4WG0Ayl+3iqXoiDY8KUorsBrgsLcej4JuKw9cWZKxk4u90Xz6COSlN1vPLkpI9m6jBdX4iQAF+sdriBXs/7WOS3gfb5T+ZxUod65H02w70QaS6eZDHvM9wzN6AmUJ342WdUtPji/uEJnEksZK4/ppFZx2scb7sPD9t+iPH/B982TqoR/A/OFeqYLfWHGTgK0/QvG+jx/P8wfdyTMg3/QHBeGGQfFzKdgUK2988NnBx0Q7zNf2j6qA4aU4dwsTI1Le3GS14uWqJYi2ZPOTITLGI/BOditk0327t3I5zki1iqVhE7Or8ISgEbYWhYxCTshqAUsxEtb/+D69h/8L/zBlcnmXJViBH1VXajqbYbQ43d0DlYxL4sOoEtuidwobebJQ1NcufxubDaoU8ZZidgGVoE2/fd7MpmCXK0OgGdhCIU/clErZ8+ORw9ga7HtYgRzAL/MQmSuVTEYs/qU7DqAxw89BZhF/XpVJTE5PkfsGXyE3hx4wQSf4chd3JmyT6dC47+uZS8IgvFw0VQTN9Hrz4XsZPjc6FukwXunyegPEUDnybjybAvjQda4yJXMeSiHuCvVjgueE9AQFwDJ3KsqUOmGF+ND5OVRjFrmqeBPdetYbT6H14sLEaquR/almvAx6iYDe47TKqPrbH9qTWmcknSCw8/zNtcDO8v1rgkJkk3OHvQu0ad/hwqZlGSunT3yj/UXPuHGSU3UNHmh8thGljS+Y+JmHlCeX4P/LzUKWj0Jr5mFSOPyx+qV4qZ+B0NklWxopuBNoh6UIygnmKI6TCa8VwDcsMapEG38LvkC7JfFzPTN8XsvHEsTdgwyBv4Q+jSBeIfKsS4uCaOr/PHNskSlqNUgiHlEsbxowfDf3qwoSsYWkYl7CrTxBvRTYj8qks8Eg9R6uGP9DkP2ehTbrLfUsJig/xRv00Tbwe56YreJvpXrECKxg9xFA9Z24ESzEuYPK/dQ9y55k2N9g/ZiT2bwBFUwnZx8ZB2iT8odi/9DyfokiU=</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+      </spectrumList>
+    </run>
+  </mzML>
+</indexedmzML>


### PR DESCRIPTION
## Summary

  Fixes #103. mzML files from Sciex TTOF6600 instruments use spectrum IDs like `sample=1 period=1 cycle=1 experiment=1` instead of containing a `scan=` attribute. This caused a segfault in `get_scan()` due to `strstr()` returning NULL
   and then performing pointer arithmetic on it (`NULL + 5 = 0x5`).

  - **`get_scan()`**: Bounds search to the opening `<spectrum ...>` tag via `strchr`. Returns -1 when `scan=` is absent; caller falls back to `index + 1`.
  - **`get_ms_level()` / `get_ret_time()`**: Now use `bounded_search()` (backed by `memmem` on Linux/macOS, portable fallback on Windows) to physically stop reading at the `</spectrum>` boundary, preventing O(n²) scanning when
  attributes are absent.
  - **`get_spectrum_end()` / `get_binary_start()`**: Fixed NULL-before-arithmetic bugs (same pattern as `get_scan`).
  - **Test data**: Added `test/data/sciex_ttof6600_100.mzML` — 100-spectrum subset of a TTOF6600 file with no `scan=` attribute.
  - **ctest**: `CompressSciexNoScanAttr` — compress/decompress roundtrip of the sciex file.
  - **pytest**: 4 tests covering read, scan fallback (`index+1`), compress/decompress roundtrip, and metadata parsing.

  ## Test plan

  - [x] 36/36 ctests pass (including new `CompressSciexNoScanAttr`)
  - [x] 55/55 key pytests pass (including 4 new sciex tests)
  - [ ] Verify on Windows CI (portable `bounded_search` fallback for `memmem`)'