### PR TITLE
bugfix: fix swapped mz/intensity dtypes (issue #105)

### DIFF
--- a/node-ts/test/fixtures.ts
+++ b/node-ts/test/fixtures.ts
@@ -6,3 +6,4 @@ export const TEST_DATA_DIR = path.resolve(__dirname, "../../test/data");
 export const MZML_PATH = path.join(TEST_DATA_DIR, "test.mzML");
 export const MSZ_PATH = path.join(TEST_DATA_DIR, "test.msz");
 export const MSZX_PATH = path.join(TEST_DATA_DIR, "mszx", "test.mszx");
+export const SCIEX_MZML_PATH = path.join(TEST_DATA_DIR, "sciex_ttof6600_100.mzML");

--- a/node-ts/test/mzml.test.ts
+++ b/node-ts/test/mzml.test.ts
@@ -13,7 +13,7 @@ import {
   DataPositions,
   RuntimeArguments,
 } from "../src/index.js";
-import { MZML_PATH } from "./fixtures.js";
+import { MZML_PATH, SCIEX_MZML_PATH } from "./fixtures.js";
 
 describe("MZMLFile", () => {
   let file: MZMLFile | null = null;
@@ -221,5 +221,47 @@ describe("MZMLFile", () => {
 
     const rt10 = spectra.get(10).retentionTime!;
     expect(Math.abs(rt10 - 1.15352136)).toBeLessThan(1e-4);
+  });
+});
+
+describe("Sciex TTOF6600 dtype handling (issue #105)", () => {
+  it("MSZ round-trip preserves correct dtypes (mz=float64, intensity=float32)", () => {
+    const mzml = read(SCIEX_MZML_PATH) as MZMLFile;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mscompress-test-"));
+    const mszPath = path.join(tmpDir, "sciex.msz");
+
+    try {
+      const msz = mzml.compress(mszPath);
+      mzml.close();
+
+      const spectrum = msz.spectra.get(49);
+      expect(spectrum.mz).toBeInstanceOf(Float64Array);
+      expect(spectrum.intensity).toBeInstanceOf(Float32Array);
+      msz.close();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("MSZ round-trip produces matching mz/intensity lengths", () => {
+    const mzml = read(SCIEX_MZML_PATH) as MZMLFile;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mscompress-test-"));
+    const mszPath = path.join(tmpDir, "sciex.msz");
+
+    try {
+      const msz = mzml.compress(mszPath);
+      mzml.close();
+
+      for (let i = 0; i < msz.spectra.length; i++) {
+        const spectrum = msz.spectra.get(i);
+        const mz = spectrum.mz;
+        const intensity = spectrum.intensity;
+        if (mz.length === 0 && intensity.length === 0) continue;
+        expect(mz.length).toBe(intensity.length);
+      }
+      msz.close();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/python/test/test_sciex_no_scan.py
+++ b/python/test/test_sciex_no_scan.py
@@ -1,13 +1,17 @@
-"""Regression tests for GitHub issue #103.
+"""Regression tests for GitHub issues #103 and #105.
 
-Sciex TTOF6600 mzML files use spectrum IDs like
+Issue #103: Sciex TTOF6600 mzML files use spectrum IDs like
   sample=1 period=1 cycle=1 experiment=1
 instead of containing a scan= attribute. This caused a segfault in get_scan()
 due to NULL pointer arithmetic, and O(n^2) scanning from unbounded strstr.
+
+Issue #105: MSZ read returns swapped dtypes for mz/intensity arrays when the
+source mzML has different precisions (e.g. mz=float64, intensity=float32).
 """
 import tempfile
 from pathlib import Path
 
+import numpy as np
 import pytest
 from mscompress import read, MZMLFile, MSZFile
 
@@ -57,3 +61,76 @@ def test_sciex_spectrum_metadata(sciex_mzml_file_path):
     assert spectrum.ms_level in (1, 2)
     assert spectrum.retention_time is not None
     assert spectrum.retention_time >= 0
+
+
+# --- Issue #105 regression tests: dtype swap ---
+
+def test_sciex_msz_dtype_preserved(sciex_mzml_file_path):
+    """After compress/decompress, mz should be float64 and intensity float32.
+
+    Regression test for GitHub issue #105: the dtypes were swapped because the
+    C core used source_mz_fmt instead of source_inten_fmt when setting up the
+    intensity compression/decompression algorithms.
+    """
+    msz_path = Path(sciex_mzml_file_path).with_suffix('.msz')
+
+    with read(sciex_mzml_file_path) as mzml:
+        mzml.compress(output=msz_path)
+
+    try:
+        with read(str(msz_path)) as msz:
+            assert isinstance(msz, MSZFile)
+            # Check an MS2 spectrum (index 49 per the issue report)
+            spectrum = msz.spectra[49]
+            assert spectrum.mz.dtype == np.float64, (
+                f"Expected mz dtype float64, got {spectrum.mz.dtype}"
+            )
+            assert spectrum.intensity.dtype == np.float32, (
+                f"Expected intensity dtype float32, got {spectrum.intensity.dtype}"
+            )
+    finally:
+        msz_path.unlink(missing_ok=True)
+
+
+def test_sciex_msz_array_lengths_match(sciex_mzml_file_path):
+    """mz and intensity arrays must have the same length after round-trip.
+
+    Before the fix, the dtype swap caused a ~4x length mismatch.
+    """
+    msz_path = Path(sciex_mzml_file_path).with_suffix('.msz')
+
+    with read(sciex_mzml_file_path) as mzml:
+        mzml.compress(output=msz_path)
+
+    try:
+        with read(str(msz_path)) as msz:
+            for i, spectrum in enumerate(msz.spectra):
+                mz = spectrum.mz
+                intensity = spectrum.intensity
+                if len(mz) == 0 and len(intensity) == 0:
+                    continue
+                assert len(mz) == len(intensity), (
+                    f"Spectrum {i}: mz length {len(mz)} != intensity length {len(intensity)}"
+                )
+    finally:
+        msz_path.unlink(missing_ok=True)
+
+
+def test_sciex_mzml_vs_msz_data_match(sciex_mzml_file_path):
+    """Binary data from MSZ round-trip should match the original mzML values."""
+    msz_path = Path(sciex_mzml_file_path).with_suffix('.msz')
+
+    with read(sciex_mzml_file_path) as mzml:
+        mzml.compress(output=msz_path)
+        # Read a few spectra from the original
+        orig_mz_0 = mzml.spectra[0].mz.copy()
+        orig_inten_0 = mzml.spectra[0].intensity.copy()
+
+    try:
+        with read(str(msz_path)) as msz:
+            msz_mz_0 = msz.spectra[0].mz
+            msz_inten_0 = msz.spectra[0].intensity
+            np.testing.assert_array_equal(orig_mz_0, msz_mz_0)
+            np.testing.assert_array_equal(orig_inten_0, msz_inten_0)
+    finally:
+        msz_path.unlink(missing_ok=True)

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -266,7 +266,7 @@ int set_decompress_runtime_variables(data_format_t* df, footer_t* msz_footer) {
    df->encode_source_compression_mz_fun = set_encode_fun(
        df->source_compression, msz_footer->mz_fmt, df->source_mz_fmt);
    df->encode_source_compression_inten_fun = set_encode_fun(
-       df->source_compression, msz_footer->inten_fmt, df->source_mz_fmt);
+       df->source_compression, msz_footer->inten_fmt, df->source_inten_fmt);
 
    if (df->encode_source_compression_mz_fun == NULL ||
        df->encode_source_compression_inten_fun == NULL) {

--- a/src/compress.c
+++ b/src/compress.c
@@ -553,10 +553,8 @@ void cmp_binary_routine(compression_fun compression_fun, ZSTD_CCtx* czstd,
    a_args->src_len = len;
    a_args->dest = &binary_buff;
    a_args->dest_len = &binary_len;
-   a_args->src_format = df->source_mz_fmt;  // TODO: This is a hack. Need to
-                                            // fix.
 
-   df->target_mz_fun((void*)a_args);  // TODO: This is a hack. Need to fix.
+   a_args->algo_fun((void*)a_args);
 
    if (binary_buff == NULL)
       error("cmp_binary_routine: binary_buff is NULL\n");
@@ -661,9 +659,13 @@ void* compress_routine(void* args)
    if (cb_args->mode == _mass_) {
       a_args->dec_fun = cb_args->df->decode_source_compression_mz_fun;
       a_args->scale_factor = cb_args->df->mz_scale_factor;
+      a_args->src_format = cb_args->df->source_mz_fmt;
+      a_args->algo_fun = cb_args->df->target_mz_fun;
    } else if (cb_args->mode == _intensity_) {
       a_args->dec_fun = cb_args->df->decode_source_compression_inten_fun;
       a_args->scale_factor = cb_args->df->int_scale_factor;
+      a_args->src_format = cb_args->df->source_inten_fmt;
+      a_args->algo_fun = cb_args->df->target_inten_fun;
    } else if (cb_args->mode == _xml_)
       a_args->dec_fun = NULL;
    else
@@ -897,8 +899,6 @@ int compress_mzml(char* input_map, size_t input_filesize, Arguments* arguments,
 
    print("\t===m/z binary===\n");
    footer->mz_binary_pos = output_pos;
-   df->target_mz_fun = set_compress_algo(
-       footer->mz_fmt, df->source_mz_fmt);  // TODO, rename target_mz_fun
    mz_binary_block_lens = compress_parallel(
        (char*)input_map, mz_divisions, df, df->mz_compression_fun, blocksize,
        blocksize / 3, _mass_, divisions->n_divisions, threads, output_fd,
@@ -915,8 +915,6 @@ int compress_mzml(char* input_map, size_t input_filesize, Arguments* arguments,
 
    print("\t===int binary===\n");
    footer->inten_binary_pos = output_pos;
-   df->target_mz_fun = set_compress_algo(
-       footer->inten_fmt, df->source_mz_fmt);  // TODO, rename target_mz_fun
    inten_binary_block_lens = compress_parallel(
        (char*)input_map, inten_divisions, df, df->inten_compression_fun,
        blocksize, blocksize / 3, _intensity_, divisions->n_divisions, threads,

--- a/src/mscompress.h
+++ b/src/mscompress.h
@@ -571,6 +571,7 @@ typedef struct {
    z_stream* z;
    float scale_factor;
    int ret_code;
+   Algo algo_fun;
 } algo_args;
 
 Algo set_compress_algo(int algo, int accession);

--- a/src/preprocess.c
+++ b/src/preprocess.c
@@ -341,18 +341,32 @@ division_t* alloc_division(size_t n_xml, size_t n_mz, size_t n_inten) {
  * @param acc A parsed integer of an accession attribute (expanded by `parse_acc_to_int`).
  * @param current_type A pass-by-reference variable indicating whether the traversal
  *        is within an m/z or intensity array. Updated by this function.
+ * @param pending_fmt A pass-by-reference variable that buffers a format accession
+ *        when it appears before the array type identifier in the XML.
  * @param df An allocated, partially populated data_format_t struct to be further populated.
  * @return 1 if `data_format_t` struct is fully populated (both m/z and intensity formats detected), 0 otherwise.
  */
-int map_to_df(int acc, int* current_type, data_format_t* df)
+int map_to_df(int acc, int* current_type, int* pending_fmt, data_format_t* df)
 {
    if (acc >= _mass_ && acc <= _no_comp_) {
       switch (acc) {
          case _intensity_:
             *current_type = _intensity_;
+            if (*pending_fmt) {
+               df->source_inten_fmt = *pending_fmt;
+               df->populated++;
+               *pending_fmt = 0;
+               *current_type = 0;
+            }
             break;
          case _mass_:
             *current_type = _mass_;
+            if (*pending_fmt) {
+               df->source_mz_fmt = *pending_fmt;
+               df->populated++;
+               *pending_fmt = 0;
+               *current_type = 0;
+            }
             break;
          case _zlib_:
             df->source_compression = _zlib_;
@@ -365,15 +379,21 @@ int map_to_df(int acc, int* current_type, data_format_t* df)
                if (*current_type == _intensity_) {
                   df->source_inten_fmt = acc;
                   df->populated++;
+                  *current_type = 0;
                } else if (*current_type == _mass_) {
                   df->source_mz_fmt = acc;
                   df->populated++;
-               }
-               if (df->populated >= 2) {
-                  return 1;
+                  *current_type = 0;
+               } else {
+                  /* Format accession appeared before array type identifier;
+                     buffer it until the type is known. */
+                  *pending_fmt = acc;
                }
             }
             break;
+      }
+      if (df->populated >= 2) {
+         return 1;
       }
    }
    return 0;
@@ -408,6 +428,9 @@ data_format_t* pattern_detect(char* input_map)
    int current_type =
        0; /* A pass-by-reference variable to indicate to map_to_df of current
              binary data array type (m/z or intensity) */
+   int pending_fmt =
+       0; /* Buffers a format accession when it appears before the array type
+             identifier in the XML (e.g. 64-bit float before m/z array). */
 
    for (; *input_map; input_map++) {
       yxml_ret_t r = yxml_parse(xml, *input_map);
@@ -454,7 +477,7 @@ data_format_t* pattern_detect(char* input_map)
                df->source_total_spec = atoi(attrbuf);
                attrcur = NULL;
             } else if (in_cvParam && attrcur) {
-               if (map_to_df(parse_acc_to_int(attrbuf), &current_type, df)) {
+               if (map_to_df(parse_acc_to_int(attrbuf), &current_type, &pending_fmt, df)) {
                   free(xml);
                   return df;
                }


### PR DESCRIPTION
## Summary

- Fix swapped `source_mz_fmt`/`source_inten_fmt` when mzML has different precisions for m/z and intensity (e.g. Sciex TTOF6600: m/z=float64, intensity=float32)
- Root cause: `map_to_df()` in `preprocess.c` assigned format accessions based on stale `current_type` from the previous binary data array, because the format cvParam appears before the array type cvParam in the XML
- Also fixed two secondary bugs in `arguments.c` and `compress.c` where the intensity stream's compression/decompression functions were initialized with `source_mz_fmt` instead of `source_inten_fmt`
- Refactored `compress.c` to eliminate the `target_mz_fun` overwrite hack — algo dispatch is now per-stream via `algo_args.algo_fun`, set alongside `dec_fun`/`scale_factor`/`src_format` based on mode

## Test plan

- [x] All 36 C tests pass (`ctest --test-dir cli`)
- [x] All 123 Python tests pass (`uv run pytest`), including 3 new regression tests:
  - `test_sciex_msz_dtype_preserved` — verifies mz=float64, intensity=float32 after round-trip
  - `test_sciex_msz_array_lengths_match` — verifies no 4x length mismatch
  - `test_sciex_mzml_vs_msz_data_match` — verifies binary data integrity
- [ ] 2 new Node.js regression tests (dtype + length) — to be validated in CI

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)