### PR TITLE
bugfix: bound get_scan() to fix O(N*S) performance (#109)

### DIFF
--- a/src/preprocess.c
+++ b/src/preprocess.c
@@ -613,12 +613,13 @@ long get_ms_level(char* spectrum_start, size_t search_len) {
  */
 long get_scan(char* spectrum_start) {
    // Limit search to the opening <spectrum ...> tag.
-   char* tag_end = strchr(spectrum_start, '>');
+   char* tag_end = memchr(spectrum_start, '>', 4096);
    if (tag_end == NULL)
       return -1;
 
-   char* ptr = strstr(spectrum_start, "scan=");
-   if (ptr == NULL || ptr >= tag_end)
+   size_t tag_len = (size_t)(tag_end - spectrum_start);
+   char* ptr = bounded_search(spectrum_start, tag_len, "scan=", 5);
+   if (ptr == NULL)
       return -1;
 
    ptr += sizeof("scan=") - 1;


### PR DESCRIPTION
## Summary
- `get_scan()` used unbounded `strstr()` to search for `scan=` — when absent (Sciex TTOF6600 files), it scanned from the current spectrum to EOF, causing O(N×S) ≈ O(N²) performance
- Replaced `strchr`/`strstr` with `memchr`/`bounded_search` (`memmem`) limited to the opening `<spectrum ...>` tag
- 973MB file with 35K spectra: **30+ min → ~2 seconds**

Closes #109

## Test plan
- [x] All 36 C tests pass (`ctest --test-dir cli`)
- [x] All 123 Python tests pass (`uv run pytest`)
- [x] Verified compression + decompression roundtrip on 973MB Sciex TTOF6600 DDA file
- [x] Verified no regression on standard mzML files with `scan=` attribute

