### PR TITLE
bugfix: fix segfault on corrupt base64 and harden MSZ extraction

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -48,9 +48,11 @@ void decode_base64(char* src, char* dest, size_t src_len, size_t* out_len)
 {
    int b64_ret = base64_decode(src, src_len, dest, out_len, 0);
 
-   if (b64_ret == 0)
-      error("decode_base64: base64_decode returned with an error. (%d)\n",
-            b64_ret);
+   if (b64_ret == 0) {
+      warning("decode_base64: base64_decode failed (len=%zu). "
+              "Input may contain invalid characters.\n", src_len);
+      *out_len = 0;
+   }
 }
 
 /**

--- a/src/extract.c
+++ b/src/extract.c
@@ -380,7 +380,7 @@ char* extract_spectrum_start_xml(char* input_map, ZSTD_DCtx* dctx,
 
    uint64_t xml_start_position;
    uint64_t xml_end_position;
-   int division_index;
+   int division_index = -1;
    long xml_start_offset;  // Offset relative to spectrum
    long xml_buff_offset;   // Offset relative to start of compressed block
    long xml_sum;
@@ -410,6 +410,11 @@ char* extract_spectrum_start_xml(char* input_map, ZSTD_DCtx* dctx,
          }
          xml_sum += xml->end_positions[j] - xml->start_positions[j];
       }
+   }
+
+   if (!found) {
+      error("extract_spectrum_start_xml: Could not find division for spectrum.\n");
+      return NULL;
    }
 
    xml_blk_len = get_block_by_index(xml_block_lens, division_index);
@@ -468,7 +473,7 @@ char* extract_spectrum_inner_xml(char* input_map, ZSTD_DCtx* dctx,
 
    uint64_t xml_start_position;
    uint64_t xml_end_position;
-   int division_index;
+   int division_index = -1;
    long xml_buff_offset;  // Offset relative to start of compressed block
    long xml_sum;
    block_len_t* xml_blk_len;
@@ -493,11 +498,16 @@ char* extract_spectrum_inner_xml(char* input_map, ZSTD_DCtx* dctx,
             xml_end_position = xml->end_positions[j];
             division_index = i;
             xml_buff_offset = xml_sum;
-            found = 0;
+            found = 1;
             break;
          }
          xml_sum += xml->end_positions[j] - xml->start_positions[j];
       }
+   }
+
+   if (!found) {
+      error("extract_spectrum_inner_xml: Could not find division for spectrum.\n");
+      return NULL;
    }
 
    xml_blk_len = get_block_by_index(xml_block_lens, division_index);
@@ -555,7 +565,7 @@ char* extract_spectrum_last_xml(char* input_map, ZSTD_DCtx* dctx,
 
    uint64_t xml_start_position;
    uint64_t xml_end_position;
-   int division_index;
+   int division_index = -1;
    long xml_buff_offset;  // Offset relative to start of compressed block
    long xml_sum;
    block_len_t* xml_blk_len;
@@ -587,6 +597,11 @@ char* extract_spectrum_last_xml(char* input_map, ZSTD_DCtx* dctx,
       }
    }
 
+   if (!found) {
+      error("extract_spectrum_last_xml: Could not find division for spectrum.\n");
+      return NULL;
+   }
+
    xml_blk_len = get_block_by_index(xml_block_lens, division_index);
    xml_blk_offset =
        xml_pos + get_block_offset_by_index(xml_block_lens, division_index);
@@ -594,11 +609,11 @@ char* extract_spectrum_last_xml(char* input_map, ZSTD_DCtx* dctx,
    if (!xml_blk_len->cache) {
       decmp_xml = (char*)decmp_block(df->xml_decompression_fun, dctx, input_map,
                                      xml_blk_offset, xml_blk_len);
-      xml_blk_len->cache = decmp_xml;
       if (decmp_xml == NULL) {
          error("extract_spectrum_last_xml: Failed to decompress XML block.\n");
          return NULL;
       }
+      xml_blk_len->cache = decmp_xml;
    } else
       decmp_xml = xml_blk_len->cache;
 
@@ -809,6 +824,11 @@ char* extract_spectrum_mz(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
       mz_off += mz->total_spec;
    }
 
+   if (division_index >= divisions->n_divisions) {
+      error("extract_spectrum_mz: Could not find division for spectrum index %ld.\n", index);
+      return NULL;
+   }
+
    mz_blk_len = get_block_by_index(mz_binary_block_lens, division_index);
    mz_blk_offset =
        mz_binary_blk_pos +
@@ -879,7 +899,7 @@ char* extract_spectrum_inten(char* input_map, ZSTD_DCtx* dctx,
    char* decmp_inten;
    char* res;
 
-   // Determine what division contains iten and in which position
+   // Determine what division contains inten and in which position
    for (division_index; division_index < divisions->n_divisions;
         division_index++) {
       division_t* curr = divisions->divisions[division_index];
@@ -892,6 +912,11 @@ char* extract_spectrum_inten(char* input_map, ZSTD_DCtx* dctx,
          break;
       }
       inten_off += inten->total_spec;
+   }
+
+   if (division_index >= divisions->n_divisions) {
+      error("extract_spectrum_inten: Could not find division for spectrum index %ld.\n", index);
+      return NULL;
    }
 
    inten_blk_len = get_block_by_index(inten_binary_block_lens, division_index);


### PR DESCRIPTION
## Summary

Fixes crashes (signal 11) during spectrum access on mzML files containing corrupt base64 data, and hardens the MSZ extraction path against several latent bugs.

- **`decode.c`**: `base64_decode` returns 0 on invalid input, but the old code called `error()` (print-only) and continued with an undefined `*out_len`, causing downstream crashes in zlib decompression. Now sets `*out_len = 0` on failure, which propagates cleanly as an empty array — zero performance overhead on valid data.
- **`extract.c:496`**: `extract_spectrum_inner_xml()` set `found = 0` instead of `found = 1`, so the division search never terminated early — could select wrong division and cause out-of-bounds `memcpy`.
- **`extract.c:383,475,562`**: All three XML extraction functions used uninitialized `division_index` — now initialized to `-1` with an early-return guard if no division is found.
- **`extract.c:597`**: `extract_spectrum_last_xml()` cached the decompression result before the NULL check — now checks first, matching the other two functions.
- **`extract.c:811,900`**: `extract_spectrum_mz()` and `extract_spectrum_inten()` had no bounds check when the division search loop completed without a match.

## Validated against

| File | Spectra | Before | After |
|------|---------|--------|-------|
| PXD000089/111229_pHL02.mzML | 30,318 | Segfault at ~3074 | All read (1 empty) |
| PXD000563/GSC13_48h_R2.mzML | 59,607 | Segfault at ~19,000 | All read (3 empty) |
| PXD009070/HF170324_DM_EG_GSK591_HeLa_Fwd_Mono01.mzML | 79,409 | Segfault at ~50,000 | All read (1 empty) |

## Test plan

- [x] 36/36 C tests pass (`ctest --test-dir cli`)
- [x] 123/123 Python tests pass (`uv run pytest`)
- [x] Dense sequential access on all three affected files completes without crash

Closes #111