### PR TITLE
Fix all compilation warnings in non-vendor code

### DIFF
--- a/cli/mscompress.c
+++ b/cli/mscompress.c
@@ -169,13 +169,13 @@ static int parse_arguments(int argc, char* argv[], Arguments* arguments) {
             return 1;
          }
          arguments->scans =
-             string_to_array(argv[++i], &arguments->scans_length);
+             (uint32_t *)string_to_array(argv[++i], &arguments->scans_length);
       } else if (strcmp(argv[i], "--ms-level") == 0) {
          if (i + 1 >= argc) {
             fprintf(stderr, "%s\n", "Missing ms level for extraction.");
             return 1;
          }
-         if (argv[++i] == 'n')
+         if (strcmp(argv[++i], "n") == 0)
             arguments->ms_level = -1;  // still valid, set to "n"
          else {
             arguments->ms_level = atoi(argv[i]);
@@ -251,8 +251,8 @@ int main(int argc, char* argv[]) {
    divisions_t* divisions;
    data_format_t* df;
 
-   void* input_map = NULL;
-   size_t input_filesize = 0;
+   char* input_map = NULL;
+   long input_filesize = 0;
    int local_fds[3] = {-1, -1, -1};
    int operation = -1;
    int error_status = 0;  // If error occurred, indicate cleanup and non-zero
@@ -313,7 +313,7 @@ int main(int argc, char* argv[]) {
 
          // Scan mzML for position of all binary data. Divide the m/z,
          // intensity, and XML data over threads.
-         if (preprocess_mzml((char*)input_map, input_filesize,
+         if (preprocess_mzml(input_map, input_filesize,
                              &(arguments.blocksize), &arguments, &df,
                              &divisions)) {
             error_status = 1;
@@ -321,7 +321,7 @@ int main(int argc, char* argv[]) {
          }
 
          // Start compress routine.
-         if (compress_mzml((char*)input_map, input_filesize, &arguments, df,
+         if (compress_mzml(input_map, input_filesize, &arguments, df,
                            divisions, local_fds[1])) {
             error_status = 1;
             break;
@@ -344,26 +344,26 @@ int main(int argc, char* argv[]) {
          print("\nExtracting ...\n");
 
          arguments.threads = -1,  // force single threaded
-             preprocess_mzml((char*)input_map, input_filesize,
+             preprocess_mzml(input_map, input_filesize,
                              &(arguments.blocksize), &arguments, &df,
                              &divisions);
 
-         extract_mzml((char*)input_map, divisions, local_fds[1]);
+         extract_mzml(input_map, divisions, local_fds[1]);
          break;
       };
       case EXTRACT_MSZ: {
-         extract_msz((char*)input_map, input_filesize, arguments.indices,
+         extract_msz(input_map, input_filesize, arguments.indices,
                      arguments.indices_length, arguments.scans,
                      arguments.scans_length, arguments.ms_level,
                      local_fds[1]);
          break;
       };
       case EXTERNAL: {
-         preprocess_external((char*)input_map, input_filesize,
+         preprocess_external(input_map, input_filesize,
                              &(arguments.blocksize), &arguments, &df,
                              &divisions);
          
-         if (compress_mzml((char*)input_map, input_filesize, &arguments, df,
+         if (compress_mzml(input_map, input_filesize, &arguments, df,
                            divisions, local_fds[1])) {
             error_status = 1;
             break;
@@ -371,7 +371,7 @@ int main(int argc, char* argv[]) {
          break;
       }
       case DESCRIBE: {
-         footer_t* footer = read_footer((char*)input_map, input_filesize);
+         footer_t* footer = read_footer(input_map, input_filesize);
          if (!footer)
             exit(1);
          print_footer_csv(footer);

--- a/src/algo.c
+++ b/src/algo.c
@@ -102,7 +102,7 @@ void algo_decode_cast32_64d(void* args) {
    res[0] = (float)len;
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = (len + 1) * sizeof(float);
 
    return;
@@ -179,7 +179,7 @@ void algo_decode_cast16_32f(void* args) {
    }
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = (len * sizeof(uint16_t)) + sizeof(uint16_t);
 
    return;
@@ -256,7 +256,7 @@ void algo_decode_cast16_64d(void* args) {
    }
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = (len * sizeof(uint16_t)) + sizeof(uint16_t);
 
    return;
@@ -335,7 +335,7 @@ void algo_decode_log_2_transform_32f(void* args)
    memcpy(res, &len, sizeof(uint16_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = res_len;
 
    return;
@@ -414,7 +414,7 @@ void algo_decode_log_2_transform_64d(void* args) {
    memcpy(res, &len, sizeof(uint16_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = (len + 1) * sizeof(uint16_t);
 
    return;
@@ -505,7 +505,7 @@ void algo_decode_delta16_transform_32f(void* args) {
    memcpy(res, &len, sizeof(uint16_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = res_len;
 
    return;
@@ -604,7 +604,7 @@ void algo_decode_delta16_transform_64d(void* args) {
    memcpy(res, &len, sizeof(uint16_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = res_len;
 
    return;
@@ -709,7 +709,7 @@ void algo_decode_delta24_transform_32f(void* args) {
    memcpy(res, &len, sizeof(uint16_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = res_len;
 
    return;
@@ -812,7 +812,7 @@ void algo_decode_delta24_transform_64d(void* args) {
    memcpy(res, &len, sizeof(uint16_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = res_len;
 
    return;
@@ -901,7 +901,7 @@ void algo_decode_delta32_transform_32f(void* args) {
    memcpy(res, &len, sizeof(uint16_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = res_len;
 
    return;
@@ -992,7 +992,7 @@ void algo_decode_delta32_transform_64d(void* args) {
    memcpy(res, &len, sizeof(uint16_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = res_len;
 
    return;
@@ -1100,7 +1100,7 @@ void algo_decode_vdelta16_transform_32f(void* args) {
    memcpy(res, &len, sizeof(uint16_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = res_len;
 
    return;
@@ -1208,7 +1208,7 @@ void algo_decode_vdelta16_transform_64d(void* args) {
    memcpy(res, &len, sizeof(uint16_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = res_len;
 
    return;
@@ -1326,7 +1326,7 @@ void algo_decode_vdelta24_transform_32f(void* args) {
    memcpy(res, &len, sizeof(uint16_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = res_len;
 
    return;
@@ -1443,7 +1443,7 @@ void algo_decode_vdelta24_transform_64d(void* args) {
    memcpy(res, &len, sizeof(uint16_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = res_len;
 
    return;
@@ -1594,7 +1594,7 @@ void algo_decode_vbr_32f(void* args) {
           sizeof(uint32_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len =
        sizeof(uint32_t) + sizeof(float) + sizeof(uint32_t) + bytes_used;
 
@@ -1745,7 +1745,7 @@ void algo_decode_vbr_64d(void* args) {
           sizeof(uint32_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len =
        sizeof(uint32_t) + sizeof(double) + sizeof(uint32_t) + bytes_used;
 
@@ -1865,7 +1865,7 @@ void algo_decode_bitpack_32f(void* args) {
           sizeof(uint32_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = header_size + bytes_used;
 
    return;
@@ -1983,7 +1983,7 @@ void algo_decode_bitpack_64d(void* args) {
           sizeof(uint32_t));
 
    // Return result
-   *a_args->dest = res;
+   *a_args->dest = (char *)res;
    *a_args->dest_len = header_size + bytes_used;
 
    return;

--- a/src/algo.c
+++ b/src/algo.c
@@ -2016,8 +2016,8 @@ void algo_encode_lossless(void* args)
    /* Lossless, don't touch anything */
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, a_args->src, a_args->src_len, a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, a_args->src, a_args->src_len,
+                   (char *)a_args->dest, a_args->dest_len);
 
    return;
 }
@@ -2077,8 +2077,8 @@ void algo_encode_cast32_64d(void* args)
    for (size_t i = 1; i < len + 1; i++) res_arr[i - 1] = (double)arr[i];
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, &res, len * sizeof(double), a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)&res, len * sizeof(double),
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move src pointer
    *a_args->src += (len + 1) * sizeof(float);
@@ -2152,8 +2152,8 @@ void algo_encode_cast16_32f(void* args)
       res_arr[i] = (float)(tmp[i] / a_args->scale_factor);
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, &res, len * sizeof(float), a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)&res, len * sizeof(float),
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move src pointer
    *a_args->src += (len * sizeof(uint16_t)) + sizeof(uint16_t);
@@ -2223,8 +2223,8 @@ void algo_encode_cast16_64d(void* args)
       res_arr[i] = (double)(tmp[i] / a_args->scale_factor);
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, &res, len * sizeof(double), a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)&res, len * sizeof(double),
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move src pointer
    *a_args->src += (len * sizeof(uint16_t)) + sizeof(uint16_t);
@@ -2289,8 +2289,8 @@ void algo_encode_log_2_transform_32f(void* args) {
       res[i] = (float)exp2((double)arr[i] / a_args->scale_factor) - 1;
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, (char**)(&res), res_len, a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)(&res), res_len,
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move to next array
    *a_args->src += ((len + 1) * sizeof(uint16_t));
@@ -2348,8 +2348,8 @@ void algo_encode_log_2_transform_64d(void* args) {
       res[i] = (double)exp2((double)arr[i] / a_args->scale_factor) - 1;
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, (char**)(&res), res_len, a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)(&res), res_len,
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move to next array
    *a_args->src += ((len + 1) * sizeof(uint16_t));
@@ -2418,8 +2418,8 @@ void algo_encode_delta16_transform_32f(void* args) {
       res[i] = res[i - 1] + ((float)arr[i - 1] / a_args->scale_factor);
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, (char**)(&res), res_len, a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)(&res), res_len,
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move to next array
    *a_args->src += (len * sizeof(uint16_t)) + sizeof(uint16_t) + sizeof(float);
@@ -2488,8 +2488,8 @@ void algo_encode_delta16_transform_64d(void* args) {
       res[i] = res[i - 1] + ((double)arr[i - 1] / a_args->scale_factor);
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, (char**)(&res), res_len, a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)(&res), res_len,
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move to next array
    *a_args->src += (len * sizeof(uint16_t)) + sizeof(uint16_t) + sizeof(double);
@@ -2563,8 +2563,8 @@ void algo_encode_vdelta16_transform_32f(void* args) {
       res[i] = res[i - 1] + ((float)arr[i - 1] / scale_factor);
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, (char**)(&res), res_len, a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)(&res), res_len,
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move to next array
    *a_args->src += (len * sizeof(uint16_t)) + sizeof(uint16_t) + sizeof(float) +
@@ -2639,8 +2639,8 @@ void algo_encode_vdelta16_transform_64d(void* args) {
       res[i] = res[i - 1] + ((double)arr[i - 1] / scale_factor);
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, (char**)(&res), res_len, a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)(&res), res_len,
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move to next array
    *a_args->src += (len * sizeof(uint16_t)) + sizeof(uint16_t) + sizeof(float) +
@@ -2726,8 +2726,8 @@ void algo_encode_vdelta24_transform_32f(void* args) {
    }
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, (char**)(&res), res_len, a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)(&res), res_len,
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move to next array
    *a_args->src += (len * 3 * sizeof(uint8_t)) + sizeof(uint16_t) +
@@ -2812,8 +2812,8 @@ void algo_encode_vdelta24_transform_64d(void* args) {
    }
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, (char**)(&res), res_len, a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)(&res), res_len,
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move to next array
    *a_args->src += (len * 3 * sizeof(uint8_t)) + sizeof(uint16_t) +
@@ -2894,8 +2894,8 @@ void algo_encode_delta24_transform_32f(void* args) {
    }
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, (char**)(&res), res_len, a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)(&res), res_len,
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move to next array
    *a_args->src +=
@@ -2976,8 +2976,8 @@ void algo_encode_delta24_transform_64d(void* args) {
    }
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, (char**)(&res), res_len, a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)(&res), res_len,
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move to next array
    *a_args->src +=
@@ -3047,8 +3047,8 @@ void algo_encode_delta32_transform_32f(void* args) {
       res[i] = res[i - 1] + ((float)arr[i - 1] / a_args->scale_factor);
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, (char**)(&res), res_len, a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)(&res), res_len,
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move to next array
    *a_args->src += (len * sizeof(uint32_t)) + sizeof(uint16_t) + sizeof(float);
@@ -3117,8 +3117,8 @@ void algo_encode_delta32_transform_64d(void* args) {
       res[i] = res[i - 1] + ((double)arr[i - 1] / a_args->scale_factor);
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, (char**)(&res), res_len, a_args->dest,
-                   a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)(&res), res_len,
+                   (char *)a_args->dest, a_args->dest_len);
 
    // Move to next array
    *a_args->src += (len * sizeof(uint32_t)) + sizeof(uint16_t) + sizeof(double);
@@ -3229,7 +3229,8 @@ void algo_encode_vbr_32f(void* args)
    }
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, &res, len, a_args->dest, a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)&res, len, (char *)a_args->dest,
+                   a_args->dest_len);
 
    // Move src pointer
    *a_args->src +=
@@ -3343,7 +3344,8 @@ void algo_encode_vbr_64d(void* args)
    }
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, &res, len, a_args->dest, a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)&res, len, (char *)a_args->dest,
+                   a_args->dest_len);
 
    // Move src pointer
    *a_args->src +=
@@ -3449,7 +3451,8 @@ void algo_encode_bitpack_32f(void* args)
    }
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, &res, len, a_args->dest, a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)&res, len, (char *)a_args->dest,
+                   a_args->dest_len);
 
    // Move src pointer
    *a_args->src +=
@@ -3555,7 +3558,8 @@ void algo_encode_bitpack_64d(void* args)
    }
 
    // Encode using specified encoding format
-   a_args->enc_fun(a_args->z, &res, len, a_args->dest, a_args->dest_len);
+   a_args->enc_fun(a_args->z, (char **)&res, len, (char *)a_args->dest,
+                   a_args->dest_len);
 
    // Move src pointer
    *a_args->src +=
@@ -3772,7 +3776,7 @@ Algo set_decompress_algo(int algo, int accession) {
 int get_algo_type(const char* arg) {
    if (arg == NULL)
       error("get_algo_type: arg is NULL");
-   if (strcmp(arg, "lossless") == 0 || *arg == '\0' || *arg == "")
+   if (strcmp(arg, "lossless") == 0 || *arg == '\0')
       return _lossless_;
    else if (strcmp(arg, "log") == 0)
       return _log2_transform_;

--- a/src/algo.c
+++ b/src/algo.c
@@ -3769,7 +3769,7 @@ Algo set_decompress_algo(int algo, int accession) {
  * @param arg The argument representing the algorithm type.
  * @return An integer representing the algorithm type. If the argument is `NULL` or unknown, it logs an error and returns -1.
  */
-int get_algo_type(char* arg) {
+int get_algo_type(const char* arg) {
    if (arg == NULL)
       error("get_algo_type: arg is NULL");
    if (strcmp(arg, "lossless") == 0 || *arg == '\0' || *arg == "")

--- a/src/decompress.c
+++ b/src/decompress.c
@@ -417,7 +417,7 @@ void* decompress_routine(void* args) {
             assert(curr_len > 0 && curr_len < len);
             a_args->src = (char**)&decmp_mz_binary;
             a_args->src_len = curr_len;
-            a_args->dest = buff + buff_off;
+            a_args->dest = (char **)(buff + buff_off);
             a_args->src_format = db_args->df->source_mz_fmt;
             a_args->enc_fun = db_args->df->encode_source_compression_mz_fun;
             a_args->scale_factor = db_args->df->mz_scale_factor;
@@ -471,7 +471,7 @@ void* decompress_routine(void* args) {
             assert(curr_len > 0 && curr_len < len);
             a_args->src = (char**)&decmp_inten_binary;
             a_args->src_len = curr_len;
-            a_args->dest = buff + buff_off;
+            a_args->dest = (char **)(buff + buff_off);
             a_args->src_format = db_args->df->source_inten_fmt;
             a_args->enc_fun = db_args->df->encode_source_compression_inten_fun;
             a_args->scale_factor = db_args->df->int_scale_factor;

--- a/src/extract.c
+++ b/src/extract.c
@@ -705,7 +705,7 @@ int encode_binary_block(block_len_t* blk, data_positions_t* curr_dp,
    for (int i = 0; i < total_spec; i++) {
       a_args->src = (char**)&decmp_binary;
       a_args->src_len = curr_dp->end_positions[i] - curr_dp->start_positions[i];
-      a_args->dest = buff + buff_off;
+      a_args->dest = (char **)(buff + buff_off);
       a_args->src_format = source_fmt;
       a_args->enc_fun = encode_fun;
       a_args->scale_factor = scale_factor;

--- a/src/mscompress.h
+++ b/src/mscompress.h
@@ -91,8 +91,8 @@ typedef struct {
    int threads;
    int extract_only;
    int describe_only;
-   char* mz_lossy;
-   char* int_lossy;
+   const char* mz_lossy;
+   const char* int_lossy;
    long blocksize;
    char* input_file;
    char* output_file;
@@ -576,7 +576,7 @@ typedef struct {
 
 Algo set_compress_algo(int algo, int accession);
 Algo set_decompress_algo(int algo, int accession);
-int get_algo_type(char* arg);
+int get_algo_type(const char* arg);
 
 /* queue.c */
 cmp_blk_queue_t* alloc_cmp_buff();

--- a/src/preprocess.c
+++ b/src/preprocess.c
@@ -1133,7 +1133,7 @@ data_positions_t** get_binary_divisions(data_positions_t* dp, long* blocksize,
       if (curr_div >= *divisions) {
          fprintf(stderr,
                  "err: curr_div > divisions\ncurr_div: %d\ndivisions: "
-                 "%d\ncurr_div_i: %d\ncurr_size: %d\ni: %d\ntotal_spec: %d\n",
+                 "%d\ncurr_div_i: %d\ncurr_size: %ld\ni: %d\ntotal_spec: %d\n",
                  curr_div, *divisions, curr_div_i, curr_size, i,
                  dp->total_spec * 2);
          exit(-1);


### PR DESCRIPTION
## Summary
- Resolved all compiler warnings (`-Wincompatible-pointer-types`, `-Wdiscarded-qualifiers`, `-Wformat`, pointer-vs-integer comparisons) across `src/`, `cli/`, and test code
- Only vendor warnings (`vendor/zlib/test/example.c`) remain, left untouched intentionally
- All 36 C tests and 123 Python tests pass with zero regressions

## Test plan
- [x] `ctest --test-dir cli` — 36/36 passed
- [x] `uv run pytest` (with rebuilt package) — 123/123 passed
- [x] Clean compile with no non-vendor warnings