### PR TITLE
chore: sync __version__ and add to cz version_files

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -5,5 +5,6 @@ version_files = [
     "node-ts/package.json",
     "electron/package.json",
     "python/pyproject.toml",
+    "python/mscompress/__init__.py:__version__",
 ]
 create_tag = false

--- a/python/mscompress/__init__.py
+++ b/python/mscompress/__init__.py
@@ -1,6 +1,6 @@
 """A versatile compression tool for efficient management of mass-spectrometry data."""
 
-__version__ = "1.0.7"
+__version__ = "1.0.13"
 
 
 from ._core import (


### PR DESCRIPTION
## Summary
- Updated `python/mscompress/__init__.py` `__version__` from `"1.0.7"` to `"1.0.13"` to match `.cz.toml`
- Added `python/mscompress/__init__.py:__version__` to `version_files` in `.cz.toml` so future `cz bump` keeps it in sync

Closes #117