### PR TITLE
feat: add on-the-fly spectrum transforms in Python bindings

### DIFF
--- a/python/mscompress/__init__.py
+++ b/python/mscompress/__init__.py
@@ -18,6 +18,7 @@ from ._core import (
 )
 
 from .utils import read
+from .types import SpectrumDict, SpectrumTransform
 
 from .metadata import (
     # Core abstractions
@@ -72,6 +73,9 @@ __all__ = [
     "__version__",
     # Utility functions
     "read",
+    # Transform types
+    "SpectrumDict",
+    "SpectrumTransform",
     # Metadata abstractions
     "MetadataBuilder",
     "FieldDefinition",

--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -1437,6 +1437,7 @@ cdef class Spectra:
     cdef object _cache  # Store computed spectra
     cdef int _index
     cdef size_t length
+    cdef object _transform
 
     def __init__(self, BaseFile f, DataFormat df, Division positions):
         self._f = f
@@ -1445,6 +1446,7 @@ cdef class Spectra:
         self.length = self._df.source_total_spec
         self._cache = [None] * self.length  # Initialize cache
         self._index = 0
+        self._transform = None
     
     def __iter__(self):
         self._index = 0  # Reset index for new iteration
@@ -1467,6 +1469,31 @@ cdef class Spectra:
         
         return self._cache[index]
     
+    def set_transform(self, transform):
+        """Set a transform function applied lazily to each spectrum's data.
+
+        Parameters
+        ----------
+        transform : callable
+            ``({"mz": ndarray, "intensity": ndarray}) -> {"mz": ndarray, "intensity": ndarray}``
+        """
+        if transform is not None and not callable(transform):
+            raise TypeError("transform must be callable or None")
+        self._transform = transform
+        # Invalidate cached spectra so they pick up the new transform
+        self._cache = [None] * self.length
+
+    def with_transform(self, transform):
+        """Return a *new* Spectra sharing the same file but with *transform* set.
+
+        The original Spectra is not modified.
+        """
+        if transform is not None and not callable(transform):
+            raise TypeError("transform must be callable or None")
+        new = Spectra(self._f, self._df, self._positions)
+        new._transform = transform
+        return new
+
     cdef Spectrum _compute_spectrum(self, size_t index):
         if self._positions.ret_times is not None:
             retention_time = self._positions.ret_times[index]
@@ -1477,7 +1504,8 @@ cdef class Spectra:
             scan=self._positions.scans[index],
             ms_level=self._positions.ms_levels[index],
             retention_time=retention_time,
-            file=self._f
+            file=self._f,
+            transform=self._transform,
         )
 
     def __len__(self) -> int:
@@ -1504,8 +1532,10 @@ cdef class Spectrum:
         object _mz
         object _intensity
         object _xml
+        object _transform
+        bint _transformed
 
-    def __init__(self, uint64_t index, uint32_t scan, uint16_t ms_level, float retention_time, BaseFile file):
+    def __init__(self, uint64_t index, uint32_t scan, uint16_t ms_level, float retention_time, BaseFile file, transform=None):
         self.index = index
         self.scan = scan
         self.ms_level = ms_level
@@ -1514,6 +1544,8 @@ cdef class Spectrum:
         self._mz = None
         self._intensity = None
         self._xml = None
+        self._transform = transform
+        self._transformed = False
         
     def __repr__(self):
         return f"Spectrum(index={self.index}, scan={self.scan}, ms_level={self.ms_level}, retention_time={self.retention_time})"
@@ -1532,16 +1564,14 @@ cdef class Spectrum:
                 self._xml = self._file.get_xml(self.index)
             return self._xml
 
-    property size: 
+    property size:
         def __get__(self):
-            if self._mz is None:
-                self._mz = self._file.get_mz_binary(self.index)
-            return len(self._mz)
-    
+            return len(self.raw_mz)
+
     property ms_level:
         def __get__(self):
             return self.ms_level
-    
+
     property retention_time:
         def __get__(self):
             if math.isnan(self._retention_time): # If the ms level wasn't derived from preprocessing step, find it
@@ -1560,17 +1590,43 @@ cdef class Spectrum:
             else:
                 return self._retention_time
 
-    property mz:
+    property raw_mz:
         def __get__(self):
             if self._mz is None:
                 self._mz = self._file.get_mz_binary(self.index)
             return self._mz
 
-    property intensity:
+    property raw_intensity:
         def __get__(self):
             if self._intensity is None:
                 self._intensity = self._file.get_inten_binary(self.index)
             return self._intensity
+
+    cdef _apply_transform(self):
+        if self._transformed:
+            return
+        if self._transform is not None:
+            # Ensure raw data is loaded
+            raw_mz = self.raw_mz
+            raw_intensity = self.raw_intensity
+            result = self._transform({"mz": raw_mz, "intensity": raw_intensity})
+            self._mz = result["mz"]
+            self._intensity = result["intensity"]
+        self._transformed = True
+
+    property mz:
+        def __get__(self):
+            if self._transform is not None:
+                self._apply_transform()
+                return self._mz
+            return self.raw_mz
+
+    property intensity:
+        def __get__(self):
+            if self._transform is not None:
+                self._apply_transform()
+                return self._intensity
+            return self.raw_intensity
 
     property peaks:
         def __get__(self):

--- a/python/mscompress/types.py
+++ b/python/mscompress/types.py
@@ -1,8 +1,41 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, TYPE_CHECKING
 from enum import Enum
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
+
+
+class SpectrumDict:
+    """TypedDict-like specification for the dict passed to spectrum transforms.
+
+    Keys:
+        mz: NDArray[np.float64] — raw m/z values
+        intensity: NDArray[np.float64] — raw intensity values
+    """
+    __slots__ = ()
+
+    # Provided for documentation; actual dicts are plain dicts at runtime.
+    mz: NDArray[np.float64]
+    intensity: NDArray[np.float64]
+
+
+class SpectrumTransform:
+    """Protocol-style base describing the callable signature for transforms.
+
+    A spectrum transform is any callable with the signature::
+
+        (dict with keys "mz" and "intensity") -> dict with keys "mz" and "intensity"
+
+    You do **not** need to subclass this; any callable matching the signature works.
+    """
+    __slots__ = ()
+
+    def __call__(self, data: dict) -> dict:
+        raise NotImplementedError
 
 
 class AnnotationFormat(Enum):

--- a/python/test/test_transforms.py
+++ b/python/test/test_transforms.py
@@ -1,0 +1,163 @@
+import numpy as np
+import pytest
+
+from mscompress import read, SpectrumDict, SpectrumTransform
+
+
+def _intensity_threshold(data, threshold=1e3):
+    """Keep only peaks with intensity >= threshold."""
+    mask = data["intensity"] >= threshold
+    return {"mz": data["mz"][mask], "intensity": data["intensity"][mask]}
+
+
+def _top_n(data, n=5):
+    """Keep only the top-n most intense peaks."""
+    if len(data["intensity"]) <= n:
+        return data
+    idx = np.argsort(data["intensity"])[-n:]
+    idx = np.sort(idx)
+    return {"mz": data["mz"][idx], "intensity": data["intensity"][idx]}
+
+
+# ---------- set_transform ----------
+
+
+def test_set_transform_filters_peaks(mzml_file_path):
+    with read(mzml_file_path) as f:
+        f.spectra.set_transform(_intensity_threshold)
+        spec = f.spectra[0]
+        # All returned intensities should be >= threshold
+        assert (spec.intensity >= 1e3).all()
+
+
+def test_set_transform_raw_data_unaffected(mzml_file_path):
+    with read(mzml_file_path) as f:
+        raw_mz = f.spectra[0].raw_mz.copy()
+        raw_inten = f.spectra[0].raw_intensity.copy()
+
+        f.spectra.set_transform(_intensity_threshold)
+        spec = f.spectra[0]
+
+        # raw accessors still return full arrays
+        np.testing.assert_array_equal(spec.raw_mz, raw_mz)
+        np.testing.assert_array_equal(spec.raw_intensity, raw_inten)
+
+
+def test_set_transform_none_clears(mzml_file_path):
+    with read(mzml_file_path) as f:
+        original_len = len(f.spectra[0].mz)
+        f.spectra.set_transform(_intensity_threshold)
+        filtered_len = len(f.spectra[0].mz)
+
+        f.spectra.set_transform(None)
+        restored_len = len(f.spectra[0].mz)
+
+        assert restored_len == original_len
+        # Filtering should have removed some peaks (or at least not added)
+        assert filtered_len <= original_len
+
+
+def test_set_transform_rejects_non_callable(mzml_file_path):
+    with read(mzml_file_path) as f:
+        with pytest.raises(TypeError, match="callable"):
+            f.spectra.set_transform("not a function")
+
+
+# ---------- with_transform ----------
+
+
+def test_with_transform_returns_new_spectra(mzml_file_path):
+    with read(mzml_file_path) as f:
+        original = f.spectra
+        transformed = f.spectra.with_transform(_top_n)
+        # Different objects
+        assert original is not transformed
+        # Original unaffected
+        assert len(original[0].mz) >= len(transformed[0].mz)
+
+
+def test_with_transform_rejects_non_callable(mzml_file_path):
+    with read(mzml_file_path) as f:
+        with pytest.raises(TypeError, match="callable"):
+            f.spectra.with_transform(42)
+
+
+# ---------- paired filtering ----------
+
+
+def test_paired_mz_intensity_filtering(mzml_file_path):
+    """Transform filters both arrays in lockstep — no misalignment."""
+    with read(mzml_file_path) as f:
+        f.spectra.set_transform(lambda d: _intensity_threshold(d, threshold=0))
+        spec = f.spectra[0]
+        assert len(spec.mz) == len(spec.intensity)
+
+
+# ---------- .peaks reflects transforms ----------
+
+
+def test_peaks_reflects_transform(mzml_file_path):
+    with read(mzml_file_path) as f:
+        f.spectra.set_transform(_top_n)
+        spec = f.spectra[0]
+        peaks = spec.peaks
+        assert peaks.shape[0] <= 5
+        assert peaks.shape[1] == 2
+        np.testing.assert_array_equal(peaks[:, 0], spec.mz)
+        np.testing.assert_array_equal(peaks[:, 1], spec.intensity)
+
+
+# ---------- .size uses raw data ----------
+
+
+def test_size_uses_raw_data(mzml_file_path):
+    with read(mzml_file_path) as f:
+        raw_size = f.spectra[0].size
+        f.spectra.set_transform(_top_n)
+        spec = f.spectra[0]
+        # size reflects pre-transform length
+        assert spec.size == raw_size
+
+
+# ---------- works with MSZFile ----------
+
+
+def test_transform_with_msz(msz_file_path):
+    with read(msz_file_path) as f:
+        f.spectra.set_transform(_intensity_threshold)
+        spec = f.spectra[0]
+        assert (spec.intensity >= 1e3).all()
+        # raw data still intact
+        assert len(spec.raw_mz) >= len(spec.mz)
+
+
+# ---------- works with MZMLFile ----------
+
+
+def test_transform_with_mzml(mzml_file_path):
+    with read(mzml_file_path) as f:
+        f.spectra.set_transform(_top_n)
+        spec = f.spectra[0]
+        assert len(spec.mz) <= 5
+
+
+# ---------- transform caching ----------
+
+
+def test_transform_cached_per_spectrum(mzml_file_path):
+    """Accessing .mz twice returns the same object (cached)."""
+    with read(mzml_file_path) as f:
+        f.spectra.set_transform(_top_n)
+        spec = f.spectra[0]
+        first = spec.mz
+        second = spec.mz
+        assert first is second
+
+
+# ---------- type exports ----------
+
+
+def test_types_importable():
+    """SpectrumDict and SpectrumTransform are importable from the package."""
+    assert SpectrumDict is not None
+    assert SpectrumTransform is not None


### PR DESCRIPTION
## Summary
- Adds `set_transform()` and `with_transform()` API to `Spectra` class for lazy, cached transforms on spectrum data (HuggingFace-style)
- Adds `SpectrumDict` and `SpectrumTransform` types to `types.py`, exported from `__init__.py`
- Renames `mz`/`intensity` properties → `raw_mz`/`raw_intensity` for raw data access; new `mz`/`intensity` apply transform lazily and cache per-Spectrum
- `size` uses `raw_mz` (pre-transform length); `.peaks` reflects transforms
- Pure Python-level change — no C modifications needed

Closes #122

## Test plan
- [x] 13 new tests in `test_transforms.py` covering:
  - `set_transform` filters peaks, raw data unaffected, clearing with `None`, type validation
  - `with_transform` returns new Spectra, type validation
  - Paired mz/intensity filtering (no misalignment)
  - `.peaks` reflects transforms
  - `.size` uses raw (pre-transform) data
  - Works with both `MZMLFile` and `MSZFile`
  - Transform caching per-Spectrum
  - Type exports importable
- [x] All 141 tests pass (128 existing + 13 new)