### PR TITLE
feat: add on-the-fly spectrum transforms in Python bindings

### DIFF
--- a/python/mscompress/__init__.py
+++ b/python/mscompress/__init__.py
@@ -39,6 +39,11 @@ from .metadata import (
     build_composite_metadata,
 )
 
+from .types import (
+    SpectrumDict,
+    SpectrumTransform,
+)
+
 from .mszx import (
     # MSZX classes
     MSZXFile,
@@ -67,6 +72,8 @@ __all__ = [
     "MSZFile",
     "Spectrum",
     "Spectra",
+    "SpectrumDict",
+    "SpectrumTransform",
     "get_num_threads",
     "get_filesize",
     "__version__",

--- a/python/mscompress/_core.pyi
+++ b/python/mscompress/_core.pyi
@@ -1,10 +1,12 @@
 """A versatile compression tool for efficient management of mass-spectrometry data."""
 
-from typing import Union, Iterator, Optional, Dict, Any
+from typing import Union, Iterator, Optional, Dict, Any, Callable
 from os import PathLike
 from xml.etree.ElementTree import Element
 import numpy as np
 import numpy.typing as npt
+
+from .types import SpectrumTransform
 
 class RuntimeArguments:
     """Runtime configuration arguments for compression/decompression operations."""
@@ -399,73 +401,103 @@ class MSZFile(BaseFile):
 
 class Spectrum:
     """Represents a single mass spectrum."""
-    
+
     index: int
     scan: int
     ms_level: int
-    
+
     def __init__(
         self,
         index: int,
         scan: int,
         ms_level: int,
         retention_time: float,
-        file: BaseFile
+        file: BaseFile,
+        transform: Optional[SpectrumTransform] = None,
     ) -> None: ...
-    
+
     def __repr__(self) -> str: ...
-    
+
     @property
     def xml(self) -> Element:
         """XML metadata for this spectrum."""
         ...
-    
+
     @property
     def size(self) -> int:
-        """Number of m/z - intensity pairs."""
+        """Number of m/z - intensity pairs (pre-transform)."""
         ...
-    
+
     @property
     def retention_time(self) -> float:
         """Retention time of this spectrum."""
         ...
-    
+
+    @property
+    def raw_mz(self) -> npt.NDArray[Union[np.float32, np.float64]]:
+        """Raw m/z values array (before any transform)."""
+        ...
+
+    @property
+    def raw_intensity(self) -> npt.NDArray[Union[np.float32, np.float64]]:
+        """Raw intensity values array (before any transform)."""
+        ...
+
     @property
     def mz(self) -> npt.NDArray[Union[np.float32, np.float64]]:
-        """m/z values array."""
+        """m/z values array (after transform, if set)."""
         ...
-    
+
     @property
     def intensity(self) -> npt.NDArray[Union[np.float32, np.float64]]:
-        """Intensity values array."""
+        """Intensity values array (after transform, if set)."""
         ...
-    
+
     @property
     def peaks(self) -> npt.NDArray[Union[np.float32, np.float64]]:
-        """Combined m/z and intensity as 2D array."""
+        """Combined m/z and intensity as 2D array (after transform, if set)."""
         ...
 
 class Spectra:
     """
     Collection of spectra with lazy loading and iteration support.
-    
+
     Allows indexing and iteration over all spectra in a file.
     """
-    
+
     def __init__(
         self,
         f: BaseFile,
         df: DataFormat,
         positions: Division
     ) -> None: ...
-    
+
     def __iter__(self) -> Iterator[Spectrum]: ...
-    
+
     def __next__(self) -> Spectrum: ...
-    
+
     def __getitem__(self, index: int) -> Spectrum: ...
-    
+
     def __len__(self) -> int: ...
+
+    def set_transform(self, transform: Optional[SpectrumTransform]) -> None:
+        """Set a transform function applied lazily to all spectra.
+
+        Parameters:
+            transform: A callable (SpectrumDict) -> SpectrumDict, or None to clear.
+        """
+        ...
+
+    def with_transform(self, transform: Optional[SpectrumTransform]) -> Spectra:
+        """Return a new Spectra with the given transform, without modifying this one.
+
+        Parameters:
+            transform: A callable (SpectrumDict) -> SpectrumDict, or None.
+
+        Returns:
+            A new Spectra instance with the transform set.
+        """
+        ...
 
 def get_num_threads() -> int:
     """

--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -1413,21 +1413,21 @@ cdef class BaseFile:
 cdef class Spectra:
     """
     A class to represent and manage a collection of spectra, allowing (lazy) iteration and access by index.
-   
+
     Methods:
     __init__(self, DataFormat df, Division positions):
         Initializes the Spectra object with a data format and a list of postions.
-    
+
     __iter__(self):
         Resets the iteration index and returns the iterator object.
-    
+
     __next__(self):
         Returns the next spectrum in the sequence during iteration, raises `StopIteration` when the end is reached.
-    
+
     __getitem__(self, size_t index):
         Computes and returns the spectrum at the specified index.
         Raises `IndexError` if the index is out of range.
-    
+
     __len__(self) -> int:
         Returns the total number of spectra.
     """
@@ -1437,6 +1437,7 @@ cdef class Spectra:
     cdef object _cache  # Store computed spectra
     cdef int _index
     cdef size_t length
+    cdef object _transform
 
     def __init__(self, BaseFile f, DataFormat df, Division positions):
         self._f = f
@@ -1445,7 +1446,8 @@ cdef class Spectra:
         self.length = self._df.source_total_spec
         self._cache = [None] * self.length  # Initialize cache
         self._index = 0
-    
+        self._transform = None
+
     def __iter__(self):
         self._index = 0  # Reset index for new iteration
         return self
@@ -1453,20 +1455,20 @@ cdef class Spectra:
     def __next__(self):
         if self._index >= self.length:
             raise StopIteration
-        
+
         result = self[self._index]
         self._index += 1
         return result
-    
+
     def __getitem__(self, size_t index):
         if index >= self.length:
             raise IndexError("Spectra index out of range")
-        
+
         if self._cache[index] is None:
             self._cache[index] = self._compute_spectrum(index)
-        
+
         return self._cache[index]
-    
+
     cdef Spectrum _compute_spectrum(self, size_t index):
         if self._positions.ret_times is not None:
             retention_time = self._positions.ret_times[index]
@@ -1477,8 +1479,48 @@ cdef class Spectra:
             scan=self._positions.scans[index],
             ms_level=self._positions.ms_levels[index],
             retention_time=retention_time,
-            file=self._f
+            file=self._f,
+            transform=self._transform
         )
+
+    def set_transform(self, transform):
+        """Set a transform function to apply lazily to all spectra.
+
+        The transform must be a callable that accepts a dict with 'mz' and
+        'intensity' NumPy array keys and returns a dict with the same keys.
+
+        Setting a new transform invalidates cached spectra so they will be
+        recomputed with the new transform on next access.
+
+        Parameters:
+            transform: A callable matching the SpectrumTransform protocol,
+                       or None to clear the transform.
+        """
+        from .types import SpectrumTransform
+        if transform is not None and not isinstance(transform, SpectrumTransform):
+            raise TypeError(
+                "transform must be a callable with signature "
+                "(SpectrumDict) -> SpectrumDict, or None"
+            )
+        self._transform = transform
+        # Invalidate cache so spectra are recomputed with new transform
+        self._cache = [None] * self.length
+
+    def with_transform(self, transform):
+        """Return a new Spectra instance with the given transform applied.
+
+        The original Spectra is not modified.
+
+        Parameters:
+            transform: A callable matching the SpectrumTransform protocol,
+                       or None for no transform.
+
+        Returns:
+            A new Spectra instance with the transform set.
+        """
+        new = Spectra(self._f, self._df, self._positions)
+        new.set_transform(transform)
+        return new
 
     def __len__(self) -> int:
         return self.length
@@ -1491,7 +1533,7 @@ cdef class Spectrum:
     Attributes:
     index (int): Index of spectrum relative to the file.
     scan (int): Scan number of spectrum reported by instrument.
-    size (int): Number of m/z - intensity pairs.
+    size (int): Number of m/z - intensity pairs (pre-transform).
     ms_level (int): MS level of spectrum.
     retention_time (float): Retention time of spectrum.
     """
@@ -1504,8 +1546,10 @@ cdef class Spectrum:
         object _mz
         object _intensity
         object _xml
+        object _transform
+        object _transformed
 
-    def __init__(self, uint64_t index, uint32_t scan, uint16_t ms_level, float retention_time, BaseFile file):
+    def __init__(self, uint64_t index, uint32_t scan, uint16_t ms_level, float retention_time, BaseFile file, transform=None):
         self.index = index
         self.scan = scan
         self.ms_level = ms_level
@@ -1514,34 +1558,43 @@ cdef class Spectrum:
         self._mz = None
         self._intensity = None
         self._xml = None
-        
+        self._transform = transform
+        self._transformed = None
+
     def __repr__(self):
         return f"Spectrum(index={self.index}, scan={self.scan}, ms_level={self.ms_level}, retention_time={self.retention_time})"
+
+    cdef dict _apply_transform(self):
+        """Apply the transform and cache the result."""
+        if self._transformed is None and self._transform is not None:
+            self._transformed = self._transform({
+                'mz': self.raw_mz,
+                'intensity': self.raw_intensity,
+            })
+        return self._transformed
 
     property index:
         def __get__(self):
             return self.index
-    
+
     property scan:
         def __get__(self):
             return self.scan
-    
+
     property xml:
         def __get__(self):
             if self._xml is None:
                 self._xml = self._file.get_xml(self.index)
             return self._xml
 
-    property size: 
+    property size:
         def __get__(self):
-            if self._mz is None:
-                self._mz = self._file.get_mz_binary(self.index)
-            return len(self._mz)
-    
+            return len(self.raw_mz)
+
     property ms_level:
         def __get__(self):
             return self.ms_level
-    
+
     property retention_time:
         def __get__(self):
             if math.isnan(self._retention_time): # If the ms level wasn't derived from preprocessing step, find it
@@ -1560,17 +1613,29 @@ cdef class Spectrum:
             else:
                 return self._retention_time
 
-    property mz:
+    property raw_mz:
         def __get__(self):
             if self._mz is None:
                 self._mz = self._file.get_mz_binary(self.index)
             return self._mz
 
-    property intensity:
+    property raw_intensity:
         def __get__(self):
             if self._intensity is None:
                 self._intensity = self._file.get_inten_binary(self.index)
             return self._intensity
+
+    property mz:
+        def __get__(self):
+            if self._transform is not None:
+                return self._apply_transform()['mz']
+            return self.raw_mz
+
+    property intensity:
+        def __get__(self):
+            if self._transform is not None:
+                return self._apply_transform()['intensity']
+            return self.raw_intensity
 
     property peaks:
         def __get__(self):

--- a/python/mscompress/types.py
+++ b/python/mscompress/types.py
@@ -1,8 +1,31 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
 from enum import Enum
+
+import numpy as np
+import numpy.typing as npt
+from typing_extensions import TypedDict
+
+
+class SpectrumDict(TypedDict):
+    """Dictionary representing a spectrum's binary data arrays."""
+
+    mz: npt.NDArray[np.floating]
+    intensity: npt.NDArray[np.floating]
+
+
+@runtime_checkable
+class SpectrumTransform(Protocol):
+    """Protocol for spectrum transform callables.
+
+    A transform receives a SpectrumDict and returns a SpectrumDict.
+    Both input and output must contain 'mz' and 'intensity' keys
+    with NumPy arrays of equal length.
+    """
+
+    def __call__(self, data: SpectrumDict) -> SpectrumDict: ...
 
 
 class AnnotationFormat(Enum):

--- a/python/test/test_transforms.py
+++ b/python/test/test_transforms.py
@@ -1,0 +1,179 @@
+import numpy as np
+import pytest
+
+from mscompress import read, MZMLFile, MSZFile, Spectra, Spectrum, SpectrumDict, SpectrumTransform
+
+
+def _intensity_threshold_transform(data: SpectrumDict) -> SpectrumDict:
+    """Filter out peaks below a fixed intensity threshold."""
+    mask = data['intensity'] > 100.0
+    return {'mz': data['mz'][mask], 'intensity': data['intensity'][mask]}
+
+
+def _identity_transform(data: SpectrumDict) -> SpectrumDict:
+    """Return data unchanged."""
+    return {'mz': data['mz'].copy(), 'intensity': data['intensity'].copy()}
+
+
+# --- set_transform ---
+
+def test_set_transform_mzml(mzml_file_path):
+    with read(mzml_file_path) as f:
+        spectra = f.spectra
+        spectra.set_transform(_intensity_threshold_transform)
+        spectrum = spectra[0]
+        assert all(spectrum.intensity > 100.0)
+
+
+def test_set_transform_msz(msz_file_path):
+    with read(msz_file_path) as f:
+        spectra = f.spectra
+        spectra.set_transform(_intensity_threshold_transform)
+        spectrum = spectra[0]
+        assert all(spectrum.intensity > 100.0)
+
+
+def test_set_transform_none_clears(mzml_file_path):
+    with read(mzml_file_path) as f:
+        spectra = f.spectra
+        spectra.set_transform(_intensity_threshold_transform)
+        spectra.set_transform(None)
+        spectrum = spectra[0]
+        # With no transform, mz should equal raw_mz
+        np.testing.assert_array_equal(spectrum.mz, spectrum.raw_mz)
+        np.testing.assert_array_equal(spectrum.intensity, spectrum.raw_intensity)
+
+
+# --- with_transform ---
+
+def test_with_transform_returns_new_spectra(mzml_file_path):
+    with read(mzml_file_path) as f:
+        original = f.spectra
+        transformed = original.with_transform(_intensity_threshold_transform)
+        assert transformed is not original
+        assert len(transformed) == len(original)
+
+
+def test_with_transform_does_not_modify_original(mzml_file_path):
+    with read(mzml_file_path) as f:
+        original = f.spectra
+        original_mz = original[0].mz.copy()
+        _ = original.with_transform(_intensity_threshold_transform)
+        # Original should be unaffected
+        np.testing.assert_array_equal(original[0].mz, original_mz)
+
+
+# --- raw data unaffected ---
+
+def test_raw_data_unaffected_by_transform(mzml_file_path):
+    with read(mzml_file_path) as f:
+        spectra = f.spectra
+        raw_mz = spectra[0].raw_mz.copy()
+        raw_intensity = spectra[0].raw_intensity.copy()
+
+        transformed = f.spectra.with_transform(_intensity_threshold_transform)
+        t_spectrum = transformed[0]
+
+        # Raw data on transformed spectrum should match original
+        np.testing.assert_array_equal(t_spectrum.raw_mz, raw_mz)
+        np.testing.assert_array_equal(t_spectrum.raw_intensity, raw_intensity)
+
+
+def test_raw_mz_raw_intensity_exist_without_transform(mzml_file_path):
+    with read(mzml_file_path) as f:
+        spectrum = f.spectra[0]
+        assert isinstance(spectrum.raw_mz, np.ndarray)
+        assert isinstance(spectrum.raw_intensity, np.ndarray)
+        np.testing.assert_array_equal(spectrum.mz, spectrum.raw_mz)
+        np.testing.assert_array_equal(spectrum.intensity, spectrum.raw_intensity)
+
+
+# --- paired filtering ---
+
+def test_paired_filtering(mzml_file_path):
+    with read(mzml_file_path) as f:
+        spectra = f.spectra.with_transform(_intensity_threshold_transform)
+        spectrum = spectra[0]
+        # After filtering, mz and intensity must have the same length
+        assert len(spectrum.mz) == len(spectrum.intensity)
+        # Both should be shorter or equal to raw
+        assert len(spectrum.mz) <= len(spectrum.raw_mz)
+
+
+# --- peaks reflects transforms ---
+
+def test_peaks_reflects_transform(mzml_file_path):
+    with read(mzml_file_path) as f:
+        spectra = f.spectra.with_transform(_intensity_threshold_transform)
+        spectrum = spectra[0]
+        peaks = spectrum.peaks
+        np.testing.assert_array_equal(peaks[:, 0], spectrum.mz)
+        np.testing.assert_array_equal(peaks[:, 1], spectrum.intensity)
+
+
+# --- size uses raw (pre-transform) ---
+
+def test_size_uses_raw_mz(mzml_file_path):
+    with read(mzml_file_path) as f:
+        raw_size = f.spectra[0].size
+
+        spectra = f.spectra.with_transform(_intensity_threshold_transform)
+        spectrum = spectra[0]
+        # size should reflect pre-transform length
+        assert spectrum.size == raw_size
+        # But transformed mz may be shorter
+        assert len(spectrum.mz) <= spectrum.size
+
+
+# --- caching ---
+
+def test_transform_result_is_cached(mzml_file_path):
+    with read(mzml_file_path) as f:
+        spectra = f.spectra.with_transform(_identity_transform)
+        spectrum = spectra[0]
+        mz_first = spectrum.mz
+        mz_second = spectrum.mz
+        # Should be the exact same object (cached)
+        assert mz_first is mz_second
+
+
+# --- works with MZMLFile and MSZFile ---
+
+def test_transform_with_mzml_file(mzml_file_path):
+    with read(mzml_file_path) as f:
+        assert isinstance(f, MZMLFile)
+        spectra = f.spectra.with_transform(_intensity_threshold_transform)
+        for spectrum in spectra:
+            assert all(spectrum.intensity > 100.0)
+            break  # Just check first spectrum
+
+
+def test_transform_with_msz_file(msz_file_path):
+    with read(msz_file_path) as f:
+        assert isinstance(f, MSZFile)
+        spectra = f.spectra.with_transform(_intensity_threshold_transform)
+        for spectrum in spectra:
+            assert all(spectrum.intensity > 100.0)
+            break  # Just check first spectrum
+
+
+# --- type validation ---
+
+def test_set_transform_rejects_non_callable(mzml_file_path):
+    with read(mzml_file_path) as f:
+        spectra = f.spectra
+        with pytest.raises(TypeError):
+            spectra.set_transform("not a callable")
+
+
+def test_set_transform_rejects_int(mzml_file_path):
+    with read(mzml_file_path) as f:
+        spectra = f.spectra
+        with pytest.raises(TypeError):
+            spectra.set_transform(42)
+
+
+def test_spectrum_transform_protocol():
+    """Verify that a plain function with the right signature satisfies the protocol."""
+    assert isinstance(_intensity_threshold_transform, SpectrumTransform)
+    assert not isinstance("not a callable", SpectrumTransform)


### PR DESCRIPTION
## Summary
- Adds `set_transform()` / `with_transform()` API to `Spectra` class for lazy, cached HuggingFace-style transforms on spectrum data
- Adds `SpectrumDict` (TypedDict) and `SpectrumTransform` (runtime-checkable Protocol) to `types.py`, exported from `__init__.py`
- Renames `mz`/`intensity` properties to `raw_mz`/`raw_intensity` for raw data access; new `mz`/`intensity` apply transform if set and cache the result per-Spectrum
- `size` uses `raw_mz` (pre-transform length) to maintain consistency
- Pure Python-level change — no C modifications needed

Closes #122

## Test plan
- [x] 16 new tests in `test_transforms.py` covering:
  - `set_transform` on MZMLFile and MSZFile
  - `with_transform` returns new Spectra without modifying original
  - Clearing transforms with `None`
  - Raw data unaffected by transforms
  - Paired mz/intensity filtering stays aligned
  - `peaks` reflects transformed data
  - `size` uses pre-transform length
  - Transform result caching
  - Type validation rejects non-callables
  - `SpectrumTransform` protocol conformance
- [x] All 144 existing tests still pass