### PR TITLE
feat: add --json flag for CLI informational commands

### DIFF
--- a/cli/mscompress.c
+++ b/cli/mscompress.c
@@ -78,6 +78,9 @@ static void print_usage(FILE* stream, int exit_code) {
        "  -d, --describe                Print header/footer in CSV format\n");
    fprintf(stream,
            "      --list-algorithms         List available lossy algorithms.\n");
+   fprintf(stream,
+           "      --json                    Output in JSON format (for "
+           "--version, --describe, --list-algorithms).\n");
    fprintf(stream, "  -h, --help                    Show this help message.\n");
    fprintf(stream,
            "  -V, --version                 Show version information.\n\n");
@@ -101,8 +104,18 @@ static int parse_arguments(int argc, char* argv[], Arguments* arguments) {
       return 1;
    }
 
+   /* Pre-scan for --json so it takes effect before early-exit flags. */
    for (i = 1; i < argc; i++) {
-      if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--verbose") == 0) {
+      if (strcmp(argv[i], "--json") == 0) {
+         arguments->json_output = 1;
+         break;
+      }
+   }
+
+   for (i = 1; i < argc; i++) {
+      if (strcmp(argv[i], "--json") == 0) {
+         continue;  /* Already handled in pre-scan. */
+      } else if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--verbose") == 0) {
          arguments->verbose = 1;
       } else if (strcmp(argv[i], "-t") == 0 ||
                  strcmp(argv[i], "--threads") == 0) {
@@ -219,15 +232,27 @@ static int parse_arguments(int argc, char* argv[], Arguments* arguments) {
          }
          arguments->zstd_compression_level = num;
       } else if (strcmp(argv[i], "--list-algorithms") == 0) {
-         print_algorithms();
+         if (arguments->json_output)
+            print_algorithms_json();
+         else
+            print_algorithms();
          exit(0);
       } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
          print_usage(stdout, 0);
       } else if (strcmp(argv[i], "-V") == 0 ||
                  strcmp(argv[i], "--version") == 0) {
-         fprintf(stdout, "MSCompress version %s %s\n", VERSION, STATUS);
-         fprintf(stdout, "Supports msz versions %s-%s\n", MIN_SUPPORT,
-                 MAX_SUPPORT);
+         if (arguments->json_output) {
+            printf("{\n");
+            printf("  \"version\": \"%s\",\n", VERSION);
+            printf("  \"status\": \"%s\",\n", STATUS);
+            printf("  \"min_support\": \"%s\",\n", MIN_SUPPORT);
+            printf("  \"max_support\": \"%s\"\n", MAX_SUPPORT);
+            printf("}\n");
+         } else {
+            fprintf(stdout, "MSCompress version %s %s\n", VERSION, STATUS);
+            fprintf(stdout, "Supports msz versions %s-%s\n", MIN_SUPPORT,
+                    MAX_SUPPORT);
+         }
          exit(0);
       } else if (arguments->input_file == NULL) {
          arguments->input_file = argv[i];
@@ -379,7 +404,10 @@ int main(int argc, char* argv[]) {
          footer_t* footer = read_footer(input_map, input_filesize);
          if (!footer)
             exit(1);
-         print_footer_csv(footer);
+         if (arguments.json_output)
+            print_footer_json(footer);
+         else
+            print_footer_csv(footer);
          break;
       };
    }

--- a/cli/test/CMakeLists.txt
+++ b/cli/test/CMakeLists.txt
@@ -9,6 +9,31 @@ add_test(NAME HelpTest COMMAND mscompress --help)
 
 add_test(NAME ListAlgorithmsTest COMMAND mscompress --list-algorithms)
 
+# --json flag tests
+add_test(NAME JsonVersionTest
+    COMMAND ${CMAKE_COMMAND}
+    -DEXECUTABLE=$<TARGET_FILE:mscompress>
+    "-DARGS=--json;--version"
+    -DEXPECTED_PATTERN=version
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/run_test_json.cmake
+)
+
+add_test(NAME JsonListAlgorithmsTest
+    COMMAND ${CMAKE_COMMAND}
+    -DEXECUTABLE=$<TARGET_FILE:mscompress>
+    "-DARGS=--json;--list-algorithms"
+    -DEXPECTED_PATTERN=name
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/run_test_json.cmake
+)
+
+add_test(NAME JsonDescribeTest
+    COMMAND ${CMAKE_COMMAND}
+    -DEXECUTABLE=$<TARGET_FILE:mscompress>
+    "-DARGS=--json;-d"
+    -DINPUT_FILE=${TEST_DATA_DIR}/test.msz
+    -DEXPECTED_PATTERN=num_spectra
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/run_test_json.cmake
+)
 
 # Test compression and decompression using the run_test.cmake script
 add_test(NAME CompressTest

--- a/cli/test/run_test_json.cmake
+++ b/cli/test/run_test_json.cmake
@@ -1,0 +1,50 @@
+# CMake script to test mscompress --json output
+#
+# Expected variables:
+# EXECUTABLE: Path to mscompress executable
+# ARGS: Arguments to pass (semicolon-separated)
+# EXPECTED_PATTERN: A string that must appear in stdout
+# INPUT_FILE: (optional) Input file to append to command
+
+if(NOT EXISTS "${EXECUTABLE}")
+    message(FATAL_ERROR "Executable not found: ${EXECUTABLE}")
+endif()
+
+set(ARGS_LIST ${ARGS})
+
+if(DEFINED INPUT_FILE AND EXISTS "${INPUT_FILE}")
+    list(APPEND ARGS_LIST "${INPUT_FILE}")
+endif()
+
+message(STATUS "Running: ${EXECUTABLE} ${ARGS_LIST}")
+
+execute_process(
+    COMMAND ${EXECUTABLE} ${ARGS_LIST}
+    RESULT_VARIABLE CMD_RESULT
+    OUTPUT_VARIABLE CMD_OUTPUT
+    ERROR_VARIABLE CMD_ERROR
+)
+
+if(NOT CMD_RESULT EQUAL 0)
+    message(STATUS "Command output: ${CMD_OUTPUT}")
+    message(STATUS "Command error: ${CMD_ERROR}")
+    message(FATAL_ERROR "Command failed with return code: ${CMD_RESULT}")
+endif()
+
+# Verify output contains expected pattern
+string(FIND "${CMD_OUTPUT}" "${EXPECTED_PATTERN}" PATTERN_POS)
+if(PATTERN_POS EQUAL -1)
+    message(STATUS "Output was: ${CMD_OUTPUT}")
+    message(FATAL_ERROR "Expected pattern '${EXPECTED_PATTERN}' not found in output")
+endif()
+
+# Verify output starts with { or [ (valid JSON)
+string(STRIP "${CMD_OUTPUT}" STRIPPED_OUTPUT)
+string(SUBSTRING "${STRIPPED_OUTPUT}" 0 1 FIRST_CHAR)
+if(NOT FIRST_CHAR STREQUAL "{" AND NOT FIRST_CHAR STREQUAL "[")
+    message(STATUS "Output was: ${CMD_OUTPUT}")
+    message(FATAL_ERROR "Output does not start with '{' or '[' — not valid JSON")
+endif()
+
+message(STATUS "JSON output validated successfully")
+message(STATUS "Test passed!")

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -46,6 +46,8 @@ void init_args(Arguments* args) {
    args->target_inten_format = _ZSTD_compression_;  // default
 
    args->zstd_compression_level = 3;  // default
+
+   args->json_output = 0;
 }
 
 /**
@@ -107,6 +109,25 @@ void print_algorithms(void) {
    }
    printf("\nUse -z/--mz-lossy or -i/--int-lossy to enable an algorithm.\n");
    printf("Use --mz-scale-factor or --int-scale-factor to override the default.\n");
+}
+
+/**
+* @brief Prints available lossy transformation algorithms as a JSON array.
+*/
+void print_algorithms_json(void) {
+   printf("[\n");
+   for (int i = 0; i < algo_registry_size; i++) {
+      const algo_info_t* a = &algo_registry[i];
+      printf("  {\n");
+      printf("    \"name\": \"%s\",\n", a->name);
+      printf("    \"target\": \"%s\",\n", target_str(a->target));
+      printf("    \"description\": \"%s\",\n", a->description);
+      printf("    \"default_mz_scale\": %g,\n", (double)a->default_mz_scale);
+      printf("    \"default_int_scale\": %g,\n", (double)a->default_int_scale);
+      printf("    \"experimental\": %s\n", a->experimental ? "true" : "false");
+      printf("  }%s\n", (i < algo_registry_size - 1) ? "," : "");
+   }
+   printf("]\n");
 }
 
 /**

--- a/src/file.c
+++ b/src/file.c
@@ -504,6 +504,29 @@ void print_footer_csv(footer_t* footer) {
           footer->mz_fmt, footer->inten_fmt);
 }
 
+void print_footer_json(footer_t* footer) {
+   if (!footer) {
+      warning("print_footer_json: footer is NULL.\n");
+      return;
+   }
+
+   printf("{\n");
+   printf("  \"xml_pos\": %lu,\n", footer->xml_pos);
+   printf("  \"mz_binary_pos\": %lu,\n", footer->mz_binary_pos);
+   printf("  \"inten_binary_pos\": %lu,\n", footer->inten_binary_pos);
+   printf("  \"xml_blk_pos\": %lu,\n", footer->xml_blk_pos);
+   printf("  \"mz_binary_blk_pos\": %lu,\n", footer->mz_binary_blk_pos);
+   printf("  \"inten_binary_blk_pos\": %lu,\n", footer->inten_binary_blk_pos);
+   printf("  \"divisions_t_pos\": %lu,\n", footer->divisions_t_pos);
+   printf("  \"num_spectra\": %zu,\n", footer->num_spectra);
+   printf("  \"original_filesize\": %lu,\n", footer->original_filesize);
+   printf("  \"n_divisions\": %d,\n", footer->n_divisions);
+   printf("  \"magic_tag\": %d,\n", footer->magic_tag);
+   printf("  \"mz_fmt\": %d,\n", footer->mz_fmt);
+   printf("  \"inten_fmt\": %d\n", footer->inten_fmt);
+   printf("}\n");
+}
+
 /**
  * @brief Determines if a memory-mapped file is an MSZ file.
  *

--- a/src/mscompress.h
+++ b/src/mscompress.h
@@ -122,6 +122,8 @@ typedef struct {
    int target_inten_format;
 
    int zstd_compression_level;
+
+   int json_output;
 } Arguments;
 
 typedef struct {
@@ -307,6 +309,7 @@ int set_int_lossy(Arguments* args, const char* int_lossy);
 int set_mz_scale_factor(Arguments* args, const char* scale_factor_str);
 int set_int_scale_factor(Arguments* args, const char* scale_factor_str);
 void print_algorithms(void);
+void print_algorithms_json(void);
 int set_compress_runtime_variables(Arguments* args, data_format_t* df);
 int set_decompress_runtime_variables(data_format_t* df, footer_t* msz_footer);
 
@@ -326,6 +329,7 @@ data_format_t* get_header_df(void* input_map);
 size_t write_footer(footer_t* footer, int fd);
 footer_t* read_footer(void* input_map, long filesize);
 void print_footer_csv(footer_t* footer);
+void print_footer_json(footer_t* footer);
 int prepare_fds(char* input_path, char** output_path, char* debug_output,
                 char** input_map, long* input_filesize, int* fds);
 int determine_filetype(void* input_map, size_t input_length);


### PR DESCRIPTION
## Summary
- Adds a global `--json` flag that switches CLI output to JSON format for `--version`, `--list-algorithms`, and `--describe`
- Uses a pre-scan approach to detect `--json` before early-exit flags in the argument parser
- Hand-writes minimal JSON output (no external JSON library needed)

Closes #130

## Test plan
- [x] `ctest --test-dir cli` — all 41 tests pass (3 new JSON tests)
- [x] `./mscompress --json --list-algorithms | python3 -m json.tool`
- [x] `./mscompress --json --version | python3 -m json.tool`
- [x] `./mscompress --json -d test/data/test.msz | python3 -m json.tool`