### PR TITLE
feat: expose algorithm registry in Python bindings with validation

### DIFF
--- a/python/mscompress/__init__.py
+++ b/python/mscompress/__init__.py
@@ -41,6 +41,7 @@ from .metadata import (
 )
 
 from .types import (
+    AlgorithmInfo,
     SpectrumDict,
     SpectrumTransform,
 )
@@ -64,6 +65,7 @@ from .annotations import (
 
 __all__ = [
     # Core types
+    "AlgorithmInfo",
     "RuntimeArguments",
     "DataFormat",
     "DataPositions",

--- a/python/mscompress/__init__.py
+++ b/python/mscompress/__init__.py
@@ -15,6 +15,7 @@ from ._core import (
     Spectra,
     get_num_threads,
     get_filesize,
+    list_algorithms,
 )
 
 from .utils import read
@@ -69,6 +70,7 @@ __all__ = [
     "Spectra",
     "get_num_threads",
     "get_filesize",
+    "list_algorithms",
     "__version__",
     # Utility functions
     "read",

--- a/python/mscompress/_core.pyi
+++ b/python/mscompress/_core.pyi
@@ -1,6 +1,6 @@
 """A versatile compression tool for efficient management of mass-spectrometry data."""
 
-from typing import Union, Iterator, Optional, Dict, Any
+from typing import Union, Iterator, Optional, Dict, Any, TypedDict, Literal
 from os import PathLike
 from xml.etree.ElementTree import Element
 import numpy as np
@@ -493,10 +493,15 @@ def get_filesize(path: Union[str, bytes]) -> int:
     """
     ...
 
-def list_algorithms() -> list[Dict[str, Any]]:
-    """Return a list of available lossy algorithm descriptors from the C registry.
+class AlgorithmInfo(TypedDict):
+    """Descriptor for a lossy transformation algorithm."""
+    name: str
+    target: list[Literal["mz", "intensity"]]
+    description: str
+    default_mz_scale: float
+    default_int_scale: float
+    experimental: bool
 
-    Each entry is a dict with keys: name, target, description,
-    default_mz_scale, default_int_scale, experimental.
-    """
+def list_algorithms() -> list[AlgorithmInfo]:
+    """Return a list of available lossy algorithm descriptors from the C registry."""
     ...

--- a/python/mscompress/_core.pyi
+++ b/python/mscompress/_core.pyi
@@ -8,16 +8,18 @@ import numpy.typing as npt
 
 class RuntimeArguments:
     """Runtime configuration arguments for compression/decompression operations."""
-    
+
     threads: int
     blocksize: int
+    mz_lossy: str
+    int_lossy: str
     mz_scale_factor: int
     int_scale_factor: int
     target_xml_format: int
     target_mz_format: int
     target_inten_format: int
     zstd_compression_level: int
-    
+
     def __init__(self) -> None: ...
 
 class DataFormat:
@@ -479,14 +481,22 @@ def get_num_threads() -> int:
 def get_filesize(path: Union[str, bytes]) -> int:
     """
     Get the size of a file in bytes.
-    
+
     Parameters:
         path: Path to file (string or bytes).
-        
+
     Returns:
         Size of the file in bytes.
-        
+
     Raises:
         FileNotFoundError: If file does not exist.
+    """
+    ...
+
+def list_algorithms() -> list[Dict[str, Any]]:
+    """Return a list of available lossy algorithm descriptors from the C registry.
+
+    Each entry is a dict with keys: name, target, description,
+    default_mz_scale, default_int_scale, experimental.
     """
     ...

--- a/python/mscompress/_core.pyi
+++ b/python/mscompress/_core.pyi
@@ -1,12 +1,12 @@
 """A versatile compression tool for efficient management of mass-spectrometry data."""
 
-from typing import Union, Iterator, Optional, Dict, Any, TypedDict, Literal, Callable
+from typing import Union, Iterator, Optional, Dict, Any
 from os import PathLike
 from xml.etree.ElementTree import Element
 import numpy as np
 import numpy.typing as npt
 
-from .types import SpectrumTransform
+from .types import AlgorithmInfo, SpectrumTransform
 
 class RuntimeArguments:
     """Runtime configuration arguments for compression/decompression operations."""
@@ -524,15 +524,6 @@ def get_filesize(path: Union[str, bytes]) -> int:
         FileNotFoundError: If file does not exist.
     """
     ...
-
-class AlgorithmInfo(TypedDict):
-    """Descriptor for a lossy transformation algorithm."""
-    name: str
-    target: list[Literal["mz", "intensity"]]
-    description: str
-    default_mz_scale: float
-    default_int_scale: float
-    experimental: bool
 
 def list_algorithms() -> list[AlgorithmInfo]:
     """Return a list of available lossy algorithm descriptors from the C registry."""

--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -32,10 +32,14 @@ def _install_mscompress_warning_formatter():
 _install_mscompress_warning_formatter()
 # `with gil` is required because these callbacks may be invoked from C code
 # running without the GIL (e.g., streaming methods release the GIL for I/O).
+_last_error_message = None
+
 cdef void _python_error_handler(const char* message) noexcept with gil:
     """Callback function to handle C errors in Python"""
+    global _last_error_message
     msg = message.decode('utf-8') if isinstance(message, bytes) else message
-    warnings.warn(msg.strip(), RuntimeWarning, stacklevel=2)
+    _last_error_message = msg.strip()
+    warnings.warn(_last_error_message, RuntimeWarning, stacklevel=2)
 
 cdef void _python_warning_handler(const char* message) noexcept with gil:
     """Callback function to handle C warnings in Python"""
@@ -100,11 +104,15 @@ def _pipe_stream(c_func, args, chunk_size=1_048_576):
 
 cdef class RuntimeArguments:
     cdef Arguments _arguments
+    cdef bytes _mz_lossy_buf
+    cdef bytes _int_lossy_buf
 
     def __init__(self):
         self._arguments.threads = _get_num_threads()
-        self._arguments.mz_lossy = "lossless"
-        self._arguments.int_lossy = "lossless"
+        self._mz_lossy_buf = b"lossless"
+        self._int_lossy_buf = b"lossless"
+        self._arguments.mz_lossy = self._mz_lossy_buf
+        self._arguments.int_lossy = self._int_lossy_buf
         self._arguments.blocksize = <long>1e+8
         self._arguments.mz_scale_factor = 1000
         self._arguments.int_scale_factor = 0
@@ -178,6 +186,8 @@ cdef class RuntimeArguments:
                 for i in range(algo_registry_size):
                     if algo_registry[i].name == value_bytes and (algo_registry[i].target & TARGET_MZ):
                         valid = True
+                        if algo_registry[i].default_mz_scale != 0:
+                            self._arguments.mz_scale_factor = algo_registry[i].default_mz_scale
                         break
                 if not valid:
                     mz_algos = []
@@ -188,7 +198,8 @@ cdef class RuntimeArguments:
                         f"Unknown m/z lossy algorithm '{value_str}'. "
                         f"Valid options: 'lossless', {', '.join(repr(a) for a in mz_algos)}"
                     )
-            self._arguments.mz_lossy = value_bytes
+            self._mz_lossy_buf = value_bytes
+            self._arguments.mz_lossy = self._mz_lossy_buf
 
     property int_lossy:
         def __get__(self):
@@ -204,6 +215,8 @@ cdef class RuntimeArguments:
                 for i in range(algo_registry_size):
                     if algo_registry[i].name == value_bytes and (algo_registry[i].target & TARGET_INT):
                         valid = True
+                        if algo_registry[i].default_int_scale != 0:
+                            self._arguments.int_scale_factor = algo_registry[i].default_int_scale
                         break
                 if not valid:
                     int_algos = []
@@ -214,7 +227,8 @@ cdef class RuntimeArguments:
                         f"Unknown intensity lossy algorithm '{value_str}'. "
                         f"Valid options: 'lossless', {', '.join(repr(a) for a in int_algos)}"
                     )
-            self._arguments.int_lossy = value_bytes
+            self._int_lossy_buf = value_bytes
+            self._arguments.int_lossy = self._int_lossy_buf
 
     property zstd_compression_level:
         def __get__(self):
@@ -435,8 +449,15 @@ cdef class MZMLFile(BaseFile):
             # If we have more threads than divisions, increase the blocksize to max division size
             self._arguments.blocksize = _get_division_size_max(self._divisions)
 
+    def _validate_scale_factors(self):
+        global _last_error_message
+        _last_error_message = None
+        if _validate_args(self._arguments.get_ptr()) != 0:
+            raise ValueError(_last_error_message or "Invalid argument configuration.")
+
     def compress(self, output: Union[str, PathLike]) -> MSZFile:
         output = os.fspath(output)
+        self._validate_scale_factors()
         self._prepare_divisions()
         self.output_fd = self._prepare_output_fd(output)
         cdef int rv = _compress_mzml(<char*> self._mapping, self.filesize, self._arguments.get_ptr(), self._df, self._divisions, self.output_fd)
@@ -449,6 +470,7 @@ cdef class MZMLFile(BaseFile):
 
     def _compress_to_fd(self, int write_fd):
         """Internal helper: run compression pipeline writing to the given fd."""
+        self._validate_scale_factors()
         cdef int rv
         cdef char* mapping = <char*> self._mapping
         cdef size_t filesize = self.filesize

--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -164,11 +164,87 @@ cdef class RuntimeArguments:
         def __set__(self, value):
             self._arguments.target_inten_format = value
     
+    property mz_lossy:
+        def __get__(self):
+            return self._arguments.mz_lossy.decode('utf-8') if isinstance(self._arguments.mz_lossy, bytes) else self._arguments.mz_lossy
+        def __set__(self, value):
+            if isinstance(value, str):
+                value_bytes = value.encode('utf-8')
+            else:
+                value_bytes = value
+            value_str = value_bytes.decode('utf-8') if isinstance(value_bytes, bytes) else value_bytes
+            if value_str != "lossless":
+                valid = False
+                for i in range(algo_registry_size):
+                    if algo_registry[i].name == value_bytes and (algo_registry[i].target & TARGET_MZ):
+                        valid = True
+                        break
+                if not valid:
+                    mz_algos = []
+                    for i in range(algo_registry_size):
+                        if algo_registry[i].target & TARGET_MZ:
+                            mz_algos.append(algo_registry[i].name.decode('utf-8'))
+                    raise ValueError(
+                        f"Unknown m/z lossy algorithm '{value_str}'. "
+                        f"Valid options: 'lossless', {', '.join(repr(a) for a in mz_algos)}"
+                    )
+            self._arguments.mz_lossy = value_bytes
+
+    property int_lossy:
+        def __get__(self):
+            return self._arguments.int_lossy.decode('utf-8') if isinstance(self._arguments.int_lossy, bytes) else self._arguments.int_lossy
+        def __set__(self, value):
+            if isinstance(value, str):
+                value_bytes = value.encode('utf-8')
+            else:
+                value_bytes = value
+            value_str = value_bytes.decode('utf-8') if isinstance(value_bytes, bytes) else value_bytes
+            if value_str != "lossless":
+                valid = False
+                for i in range(algo_registry_size):
+                    if algo_registry[i].name == value_bytes and (algo_registry[i].target & TARGET_INT):
+                        valid = True
+                        break
+                if not valid:
+                    int_algos = []
+                    for i in range(algo_registry_size):
+                        if algo_registry[i].target & TARGET_INT:
+                            int_algos.append(algo_registry[i].name.decode('utf-8'))
+                    raise ValueError(
+                        f"Unknown intensity lossy algorithm '{value_str}'. "
+                        f"Valid options: 'lossless', {', '.join(repr(a) for a in int_algos)}"
+                    )
+            self._arguments.int_lossy = value_bytes
+
     property zstd_compression_level:
         def __get__(self):
             return self._arguments.zstd_compression_level
         def __set__(self, value):
             self._arguments.zstd_compression_level = value
+
+
+def list_algorithms():
+    """Return a list of available lossy algorithm descriptors from the C registry.
+
+    Each entry is a dict with keys: name, target, description,
+    default_mz_scale, default_int_scale, experimental.
+    """
+    result = []
+    for i in range(algo_registry_size):
+        targets = []
+        if algo_registry[i].target & TARGET_MZ:
+            targets.append("mz")
+        if algo_registry[i].target & TARGET_INT:
+            targets.append("intensity")
+        result.append({
+            "name": algo_registry[i].name.decode('utf-8'),
+            "target": targets,
+            "description": algo_registry[i].description.decode('utf-8'),
+            "default_mz_scale": algo_registry[i].default_mz_scale,
+            "default_int_scale": algo_registry[i].default_int_scale,
+            "experimental": bool(algo_registry[i].experimental),
+        })
+    return result
 
 
 cdef class DataBlock:

--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -32,14 +32,10 @@ def _install_mscompress_warning_formatter():
 _install_mscompress_warning_formatter()
 # `with gil` is required because these callbacks may be invoked from C code
 # running without the GIL (e.g., streaming methods release the GIL for I/O).
-_last_error_message = None
-
 cdef void _python_error_handler(const char* message) noexcept with gil:
     """Callback function to handle C errors in Python"""
-    global _last_error_message
     msg = message.decode('utf-8') if isinstance(message, bytes) else message
-    _last_error_message = msg.strip()
-    warnings.warn(_last_error_message, RuntimeWarning, stacklevel=2)
+    warnings.warn(msg.strip(), RuntimeWarning, stacklevel=2)
 
 cdef void _python_warning_handler(const char* message) noexcept with gil:
     """Callback function to handle C warnings in Python"""
@@ -450,10 +446,11 @@ cdef class MZMLFile(BaseFile):
             self._arguments.blocksize = _get_division_size_max(self._divisions)
 
     def _validate_scale_factors(self):
-        global _last_error_message
-        _last_error_message = None
-        if _validate_args(self._arguments.get_ptr()) != 0:
-            raise ValueError(_last_error_message or "Invalid argument configuration.")
+        cdef char err_buf[512]
+        err_buf[0] = b'\0'
+        if _validate_args(self._arguments.get_ptr(), err_buf, sizeof(err_buf)) != 0:
+            msg = err_buf.decode('utf-8').strip() if err_buf[0] != b'\0' else ""
+            raise ValueError(msg or "Invalid argument configuration.")
 
     def compress(self, output: Union[str, PathLike]) -> MSZFile:
         output = os.fspath(output)

--- a/python/mscompress/_headers.pxi
+++ b/python/mscompress/_headers.pxi
@@ -182,6 +182,21 @@ cdef extern from "../src/mscompress.h":
     int _decompress_msz "decompress_msz"(char* input_map, size_t input_filesize, Arguments* arguments, int fd) nogil
     void _extract_mzml_filtered "extract_mzml_filtered"(char* input_map, size_t input_filesize, long* indicies, long indicies_length, uint32_t* scans, long scans_length, uint16_t ms_level, division_t* division, int output_fd) nogil
 
+    int TARGET_MZ
+    int TARGET_INT
+
+    ctypedef struct algo_info_t:
+        const char* name
+        int type
+        int target
+        const char* description
+        float default_mz_scale
+        float default_int_scale
+        int experimental
+
+    const algo_info_t algo_registry[]
+    const int algo_registry_size
+
     # Error/warning callback functions
     ctypedef void (*error_callback_t)(const char* message)
     ctypedef void (*warning_callback_t)(const char* message)

--- a/python/mscompress/_headers.pxi
+++ b/python/mscompress/_headers.pxi
@@ -197,6 +197,8 @@ cdef extern from "../src/mscompress.h":
     const algo_info_t algo_registry[]
     const int algo_registry_size
 
+    int _validate_args "validate_args"(Arguments* args)
+
     # Error/warning callback functions
     ctypedef void (*error_callback_t)(const char* message)
     ctypedef void (*warning_callback_t)(const char* message)

--- a/python/mscompress/_headers.pxi
+++ b/python/mscompress/_headers.pxi
@@ -197,7 +197,7 @@ cdef extern from "../src/mscompress.h":
     const algo_info_t algo_registry[]
     const int algo_registry_size
 
-    int _validate_args "validate_args"(Arguments* args)
+    int _validate_args "validate_args"(Arguments* args, char* err_buf, size_t err_buf_size)
 
     # Error/warning callback functions
     ctypedef void (*error_callback_t)(const char* message)

--- a/python/mscompress/types.py
+++ b/python/mscompress/types.py
@@ -6,7 +6,19 @@ from enum import Enum
 
 import numpy as np
 import numpy.typing as npt
+from typing import Literal
 from typing_extensions import TypedDict
+
+
+class AlgorithmInfo(TypedDict):
+    """Descriptor for a lossy transformation algorithm."""
+
+    name: str
+    target: list[Literal["mz", "intensity"]]
+    description: str
+    default_mz_scale: float
+    default_int_scale: float
+    experimental: bool
 
 
 class SpectrumDict(TypedDict):

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -1,7 +1,7 @@
 import os
 import re
 import pytest
-from mscompress import get_num_threads, get_filesize, read
+from mscompress import get_num_threads, get_filesize, list_algorithms, read
 
 def test_get_num_threads():
     assert get_num_threads() == os.cpu_count()
@@ -18,6 +18,41 @@ def test_get_filesize(mzml_file_path):
 def test_get_filesize_invalid_path():
     with pytest.raises(FileNotFoundError):
         get_filesize("ABC123")
+
+
+EXPECTED_KEYS = {"name", "target", "description", "default_mz_scale", "default_int_scale", "experimental"}
+VALID_TARGETS = {"mz", "intensity"}
+
+def test_list_algorithms_returns_list():
+    algos = list_algorithms()
+    assert isinstance(algos, list)
+    assert len(algos) > 0
+
+def test_list_algorithms_entry_keys():
+    for algo in list_algorithms():
+        assert set(algo.keys()) == EXPECTED_KEYS
+
+def test_list_algorithms_entry_types():
+    for algo in list_algorithms():
+        assert isinstance(algo["name"], str) and algo["name"]
+        assert isinstance(algo["target"], list) and len(algo["target"]) > 0
+        assert all(t in VALID_TARGETS for t in algo["target"])
+        assert isinstance(algo["description"], str) and algo["description"]
+        assert isinstance(algo["default_mz_scale"], float)
+        assert isinstance(algo["default_int_scale"], float)
+        assert isinstance(algo["experimental"], bool)
+
+def test_list_algorithms_known_entries():
+    algos = {a["name"]: a for a in list_algorithms()}
+    # Verify a few well-known algorithms are present
+    assert "cast" in algos
+    assert algos["cast"]["target"] == ["mz"]
+    assert "delta32" in algos
+    assert algos["delta32"]["default_mz_scale"] > 0
+    assert "log" in algos
+    assert algos["log"]["target"] == ["intensity"]
+    assert "vbr" in algos
+    assert set(algos["vbr"]["target"]) == {"mz", "intensity"}
 
 
 def test_read_nonexistent_file():

--- a/python/test/test_core.py
+++ b/python/test/test_core.py
@@ -1,7 +1,8 @@
 import os
 import re
 import pytest
-from mscompress import get_num_threads, get_filesize, list_algorithms, read
+import numpy as np
+from mscompress import get_num_threads, get_filesize, list_algorithms, read, MSZFile
 
 def test_get_num_threads():
     assert get_num_threads() == os.cpu_count()
@@ -53,6 +54,46 @@ def test_list_algorithms_known_entries():
     assert algos["log"]["target"] == ["intensity"]
     assert "vbr" in algos
     assert set(algos["vbr"]["target"]) == {"mz", "intensity"}
+
+
+def _algo_target_params():
+    """Generate pytest params for each (algorithm, target) pair."""
+    for algo in list_algorithms():
+        for target in algo["target"]:
+            test_id = f"{algo['name']}-{target}"
+            yield pytest.param(algo, target, id=test_id)
+
+@pytest.mark.parametrize("algo,target", _algo_target_params())
+def test_algorithm_compress_decompress(algo, target, mzml_file_path, tmp_path):
+    """Compress with each registered lossy algorithm per target, decompress, and verify spectra."""
+    name = algo["name"]
+
+    msz_path = tmp_path / f"{name}_{target}.msz"
+    out_path = tmp_path / f"{name}_{target}.mzML"
+
+    # Compress with lossy algorithm on one target
+    with read(mzml_file_path) as mzml:
+        if target == "mz":
+            mzml.arguments.mz_lossy = name
+        else:
+            mzml.arguments.int_lossy = name
+        msz = mzml.compress(str(msz_path))
+        assert isinstance(msz, MSZFile)
+        assert os.path.exists(msz_path)
+
+    # Decompress back to mzML
+    with read(str(msz_path)) as msz:
+        msz.decompress(str(out_path))
+        assert os.path.exists(out_path)
+
+    # Verify spectra are readable and non-empty
+    with read(str(out_path)) as mzml_check:
+        spectra = mzml_check.spectra
+        assert len(spectra) > 0
+        s = spectra[0]
+        assert len(s.mz) > 0
+        assert len(s.intensity) > 0
+        assert len(s.mz) == len(s.intensity)
 
 
 def test_read_nonexistent_file():

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -234,9 +234,10 @@ int set_int_scale_factor(Arguments* args, const char* scale_factor_str) {
  * @param args A pointer to the `Arguments` struct to validate.
  * @return Returns 0 if valid, 1 if invalid (with error message via error callback).
  */
-int validate_args(Arguments* args) {
+int validate_args(Arguments* args, char* err_buf, size_t err_buf_size) {
    if (args == NULL) {
-      error("validate_args: NULL arguments\n");
+      if (err_buf && err_buf_size > 0)
+         snprintf(err_buf, err_buf_size, "validate_args: NULL arguments");
       return 1;
    }
 
@@ -244,8 +245,10 @@ int validate_args(Arguments* args) {
       if (strcmp(args->mz_lossy, algo_registry[i].name) == 0 &&
           (algo_registry[i].target & TARGET_MZ)) {
          if (algo_registry[i].default_mz_scale != 0 && args->mz_scale_factor == 0) {
-            error("mz_scale_factor cannot be 0 for algorithm '%s' (default: %g)\n",
-                  args->mz_lossy, (double)algo_registry[i].default_mz_scale);
+            if (err_buf && err_buf_size > 0)
+               snprintf(err_buf, err_buf_size,
+                        "mz_scale_factor cannot be 0 for algorithm '%s' (default: %g)",
+                        args->mz_lossy, (double)algo_registry[i].default_mz_scale);
             return 1;
          }
          break;
@@ -256,8 +259,10 @@ int validate_args(Arguments* args) {
       if (strcmp(args->int_lossy, algo_registry[i].name) == 0 &&
           (algo_registry[i].target & TARGET_INT)) {
          if (algo_registry[i].default_int_scale != 0 && args->int_scale_factor == 0) {
-            error("int_scale_factor cannot be 0 for algorithm '%s' (default: %g)\n",
-                  args->int_lossy, (double)algo_registry[i].default_int_scale);
+            if (err_buf && err_buf_size > 0)
+               snprintf(err_buf, err_buf_size,
+                        "int_scale_factor cannot be 0 for algorithm '%s' (default: %g)",
+                        args->int_lossy, (double)algo_registry[i].default_int_scale);
             return 1;
          }
          break;

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -230,6 +230,44 @@ int set_int_scale_factor(Arguments* args, const char* scale_factor_str) {
 }
 
 /**
+ * @brief Validates that scale factors are non-zero for algorithms that require them.
+ * @param args A pointer to the `Arguments` struct to validate.
+ * @return Returns 0 if valid, 1 if invalid (with error message via error callback).
+ */
+int validate_args(Arguments* args) {
+   if (args == NULL) {
+      error("validate_args: NULL arguments\n");
+      return 1;
+   }
+
+   for (int i = 0; i < algo_registry_size; i++) {
+      if (strcmp(args->mz_lossy, algo_registry[i].name) == 0 &&
+          (algo_registry[i].target & TARGET_MZ)) {
+         if (algo_registry[i].default_mz_scale != 0 && args->mz_scale_factor == 0) {
+            error("mz_scale_factor cannot be 0 for algorithm '%s' (default: %g)\n",
+                  args->mz_lossy, (double)algo_registry[i].default_mz_scale);
+            return 1;
+         }
+         break;
+      }
+   }
+
+   for (int i = 0; i < algo_registry_size; i++) {
+      if (strcmp(args->int_lossy, algo_registry[i].name) == 0 &&
+          (algo_registry[i].target & TARGET_INT)) {
+         if (algo_registry[i].default_int_scale != 0 && args->int_scale_factor == 0) {
+            error("int_scale_factor cannot be 0 for algorithm '%s' (default: %g)\n",
+                  args->int_lossy, (double)algo_registry[i].default_int_scale);
+            return 1;
+         }
+         break;
+      }
+   }
+
+   return 0;
+}
+
+/**
  * @brief Sets the compression runtime variables for the given arguments and data format.
  * @param args A pointer to the `Arguments` struct.
  * @param df A pointer to the `data_format_t` struct.

--- a/src/mscompress.h
+++ b/src/mscompress.h
@@ -308,7 +308,7 @@ int set_mz_lossy(Arguments* args, const char* mz_lossy);
 int set_int_lossy(Arguments* args, const char* int_lossy);
 int set_mz_scale_factor(Arguments* args, const char* scale_factor_str);
 int set_int_scale_factor(Arguments* args, const char* scale_factor_str);
-int validate_args(Arguments* args);
+int validate_args(Arguments* args, char* err_buf, size_t err_buf_size);
 void print_algorithms(void);
 void print_algorithms_json(void);
 int set_compress_runtime_variables(Arguments* args, data_format_t* df);

--- a/src/mscompress.h
+++ b/src/mscompress.h
@@ -308,6 +308,7 @@ int set_mz_lossy(Arguments* args, const char* mz_lossy);
 int set_int_lossy(Arguments* args, const char* int_lossy);
 int set_mz_scale_factor(Arguments* args, const char* scale_factor_str);
 int set_int_scale_factor(Arguments* args, const char* scale_factor_str);
+int validate_args(Arguments* args);
 void print_algorithms(void);
 void print_algorithms_json(void);
 int set_compress_runtime_variables(Arguments* args, data_format_t* df);


### PR DESCRIPTION
## Summary
- Add `list_algorithms()` module-level function returning algorithm metadata (name, target, description, default scales, experimental flag) from the C-level `algo_registry[]`
- Add `mz_lossy` / `int_lossy` properties on `RuntimeArguments` with validation against the registry — raises `ValueError` for unknown algorithms or wrong target
- Export `list_algorithms` from `mscompress.__init__` and add type stubs

## Files changed
- `python/mscompress/_headers.pxi` — Declare `algo_info_t`, `TARGET_MZ`/`TARGET_INT`, registry externs
- `python/mscompress/_core.pyx` — `list_algorithms()`, `mz_lossy`/`int_lossy` properties with validation
- `python/mscompress/_core.pyi` — Type stubs for new API
- `python/mscompress/__init__.py` — Export `list_algorithms`

## Test plan
- [x] `uv run python -c "import mscompress; print(mscompress.list_algorithms())"` returns 10 algorithms
- [x] Setting valid `mz_lossy`/`int_lossy` values works
- [x] Setting invalid or wrong-target algorithms raises `ValueError` with helpful message
- [x] All 128 existing tests pass (`uv run pytest`)

Closes #131