### PR TITLE
feat: add JAX dataloader (mirrors PyTorch dataset)

### DIFF
--- a/python/mscompress/datasets/jax.py
+++ b/python/mscompress/datasets/jax.py
@@ -1,0 +1,230 @@
+"""JAX/grain DataLoaders for MSCompress datasets.
+
+The :class:`MSCompressJaxDataset` class satisfies grain's random-access
+data-source protocol (``__len__`` + ``__getitem__``), so it can be plugged
+directly into a grain pipeline::
+
+    import grain
+    from mscompress.datasets.jax import MSCompressJaxDataset, pad_collate
+
+    source = MSCompressJaxDataset("/path/to/data")
+    pipeline = (
+        grain.MapDataset.source(source)
+        .shuffle(seed=0)
+        .batch(32, batch_fn=pad_collate)
+    )
+
+``__getitem__`` returns plain ``numpy.ndarray`` objects (not ``jax.numpy``)
+so that grain's multiprocess workers can pickle items cheaply. Move to a
+device with ``jax.device_put`` or rely on JAX's implicit numpy conversion
+inside a jitted function.
+"""
+import mscompress
+from mscompress.mszx import MSZXFile
+from mscompress.annotations.psms import BasePSMReader
+from mscompress.types import AnnotationFormat
+from typing import Union, Optional, List, Dict, Any, Sequence, Tuple, cast
+from typing_extensions import TypeAlias
+from pathlib import Path
+import numpy as np
+import numpy.typing as npt
+
+
+FloatArray: TypeAlias = npt.NDArray[np.floating]
+AnnotationsDict: TypeAlias = Dict[AnnotationFormat, List[Any]]
+BatchItem: TypeAlias = Union[
+    Tuple[FloatArray, FloatArray],
+    Tuple[FloatArray, FloatArray, AnnotationsDict],
+]
+
+
+class MSCompressJaxDatasetMember:
+    def __init__(self, path: Union[str, Path], load_annotations: Optional[List[AnnotationFormat]] = None):
+        self._path = Path(path)
+        self._handle = mscompress.read(str(self._path))
+        self._load_annotations: List[AnnotationFormat] = load_annotations or []
+        self._annotation_readers: Dict[AnnotationFormat, List[BasePSMReader]] = {}
+
+        if isinstance(self._handle, MSZXFile) and self._load_annotations:
+            for annotation_format in self._load_annotations:
+                readers = self._handle.get_annotation_readers_by_format(annotation_format)
+                if readers:
+                    self._annotation_readers[annotation_format] = readers
+
+    @property
+    def path(self):
+        return self._path
+
+    def __len__(self) -> int:
+        """Return the number of spectra in the dataset member."""
+        return len(self._handle.spectra)
+
+    def __getitem__(self, index) -> BatchItem:
+        """Get spectrum by index in the MSZ/mzML/MSZX file."""
+        spectrum = self._handle.spectra[index]
+        mz = spectrum.mz
+        intensity = spectrum.intensity
+
+        if self._annotation_readers:
+            annotations_dict: AnnotationsDict = {}
+            scan_number = spectrum.scan
+
+            for annotation_format, readers in self._annotation_readers.items():
+                format_psms: List[Any] = []
+                for reader in readers:
+                    psms = reader.get_by_scan(scan_number)
+                    format_psms.extend(psms)
+                annotations_dict[annotation_format] = format_psms
+
+            return (mz, intensity, annotations_dict)
+
+        return (mz, intensity)
+
+
+class MSCompressJaxDataset:
+    """JAX-friendly random-access dataset over mzML / MSZ / MSZX files.
+
+    Implements the grain ``RandomAccessDataSource`` protocol (``__len__`` and
+    ``__getitem__``) so it composes directly with ``grain.MapDataset.source``.
+    """
+
+    def __init__(
+            self,
+            path: Union[str, Path],
+            load_annotations: Optional[List[AnnotationFormat]] = None
+        ):
+        """
+        Args:
+            path: Path to a msz, mszx, or mzML file, or a directory containing such files.
+            load_annotations: List of annotation formats to load from MSZX files.
+                Only applicable for MSZX files. Annotations will be returned in __getitem__ if present.
+        """
+        self._path = Path(path)
+        self._load_annotations: List[AnnotationFormat] = load_annotations or []
+
+        self.members: Dict[str, MSCompressJaxDatasetMember] = {}
+        if self._path.is_dir():
+            for file in self._path.iterdir():
+                if file.suffix.lower() in {'.msz', '.mszx', '.mzml'}:
+                    member = MSCompressJaxDatasetMember(file, load_annotations=self._load_annotations)
+                    self.members[file.name] = member
+        elif self._path.suffix.lower() in {'.msz', '.mszx', '.mzml'}:
+            member = MSCompressJaxDatasetMember(self._path, load_annotations=self._load_annotations)
+            self.members[self._path.name] = member
+        else:
+            raise ValueError("Provided path is neither a valid file nor a directory containing valid files.")
+
+        self._index_lookup: Dict[int, Tuple[MSCompressJaxDatasetMember, int]] = {}
+        global_index = 0
+        for member in self.members.values():
+            for local_index in range(len(member)):
+                self._index_lookup[global_index] = (member, local_index)
+                global_index += 1
+        self._total_spectra = global_index
+
+    @property
+    def path(self):
+        return self._path
+
+    def __len__(self) -> int:
+        """Return the total number of spectra in the dataset."""
+        return self._total_spectra
+
+    def __getitem__(self, index) -> BatchItem:
+        """Get spectrum by index across all dataset members."""
+        if index < 0:
+            index = self._total_spectra + index
+
+        if index not in self._index_lookup:
+            raise IndexError(f"Index {index} out of range for dataset with {self._total_spectra} spectra.")
+
+        member, local_index = self._index_lookup[index]
+        return member[local_index]
+
+
+def list_collate(batch: Sequence[BatchItem]) -> Tuple:
+    """Collate variable-length spectra into Python lists (no padding).
+
+    Mirrors the simple ragged-batch pattern used by the PyTorch example loader.
+    Useful when downstream code handles variable-length arrays directly.
+
+    Args:
+        batch: Sequence of items returned by ``MSCompressJaxDataset.__getitem__``.
+            Each item is ``(mz, intensity)`` or ``(mz, intensity, annotations)``.
+
+    Returns:
+        ``(mzs, intensities)`` or ``(mzs, intensities, annotations)`` where each
+        component is a Python ``list`` of length ``len(batch)``.
+    """
+    if len(batch) == 0:
+        raise ValueError("Cannot collate an empty batch.")
+
+    has_annotations = len(batch[0]) == 3
+    mzs: List[FloatArray] = []
+    intensities: List[FloatArray] = []
+    annotations: List[AnnotationsDict] = []
+
+    for item in batch:
+        mzs.append(item[0])
+        intensities.append(item[1])
+        if len(item) == 3:
+            annotations.append(cast(AnnotationsDict, item[2]))  # ty: ignore[index-out-of-bounds]
+
+    if has_annotations:
+        return (mzs, intensities, annotations)
+    return (mzs, intensities)
+
+
+def pad_collate(
+    batch: Sequence[BatchItem],
+    *,
+    pad_value: float = 0.0,
+    return_mask: bool = True,
+) -> Tuple:
+    """Collate variable-length spectra into rectangular arrays via right-padding.
+
+    Produces stacked ``(B, max_len)`` arrays suitable for ``jax.jit`` / ``jax.vmap``.
+    Spectrum dtypes are preserved (e.g. float32 vs float64 from the source file).
+
+    Args:
+        batch: Sequence of items returned by ``MSCompressJaxDataset.__getitem__``.
+        pad_value: Value used for right-padding shorter spectra.
+        return_mask: If True, also return a boolean mask (True for real peaks).
+
+    Returns:
+        A tuple of stacked numpy arrays. Without annotations and with mask:
+        ``(mz, intensity, mask)``. With annotations: ``(mz, intensity, mask, annotations)``
+        where ``annotations`` is a list (no sensible way to stack PSM dicts).
+    """
+    if len(batch) == 0:
+        raise ValueError("Cannot collate an empty batch.")
+
+    has_annotations = len(batch[0]) == 3
+    batch_size = len(batch)
+    max_len = max(item[0].shape[0] for item in batch)
+
+    mz_dtype = batch[0][0].dtype
+    intensity_dtype = batch[0][1].dtype
+
+    mz_out = np.full((batch_size, max_len), pad_value, dtype=mz_dtype)
+    intensity_out = np.full((batch_size, max_len), pad_value, dtype=intensity_dtype)
+    mask_out = np.zeros((batch_size, max_len), dtype=np.bool_) if return_mask else None
+    annotations: List[AnnotationsDict] = []
+
+    for i, item in enumerate(batch):
+        mz = item[0]
+        intensity = item[1]
+        if len(item) == 3:
+            annotations.append(cast(AnnotationsDict, item[2]))  # ty: ignore[index-out-of-bounds]
+        n = mz.shape[0]
+        mz_out[i, :n] = mz
+        intensity_out[i, :n] = intensity
+        if mask_out is not None:
+            mask_out[i, :n] = True
+
+    components: List[Any] = [mz_out, intensity_out]
+    if mask_out is not None:
+        components.append(mask_out)
+    if has_annotations:
+        components.append(annotations)
+    return tuple(components)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,12 +28,16 @@ pytorch = ["torch>=2.0"]
 
 parquet = ["pyarrow>=14"]
 
+jax = ["jax>=0.4", "grain>=0.2"]
+
 all = [
     "mlcroissant>=1.0.0",
     "numpy<2",
     "zstandard>=0.19.0",
     "torch>=2.0",
     "pyarrow>=14",
+    "jax>=0.4",
+    "grain>=0.2",
 ]
 
 [tool.setuptools]

--- a/python/test/test_dataset_jax.py
+++ b/python/test/test_dataset_jax.py
@@ -1,0 +1,176 @@
+import numpy as np
+import pytest
+
+from mscompress.types import AnnotationFormat
+from mscompress.datasets.jax import (
+    MSCompressJaxDataset,
+    list_collate,
+    pad_collate,
+)
+
+
+def test_jax_dataset_single_file(msz_file_path):
+    dataset = MSCompressJaxDataset(msz_file_path)
+    assert len(dataset.members) == 1
+    member = next(iter(dataset.members.values()))
+    assert len(member) > 0
+    sample = member[0]
+    assert isinstance(sample, tuple)
+    assert len(sample) == 2
+    mz, intensity = sample
+    assert isinstance(mz, np.ndarray)
+    assert isinstance(intensity, np.ndarray)
+    assert mz.ndim == 1
+    assert intensity.ndim == 1
+    assert mz.shape == intensity.shape
+
+
+def test_jax_dataset_directory(test_data_dir):
+    dataset = MSCompressJaxDataset(test_data_dir)
+    assert len(dataset.members) > 0
+    total_spectra = sum(len(member) for member in dataset.members.values())
+    assert total_spectra > 0
+    assert dataset._total_spectra == total_spectra
+
+    # Test global indexing
+    global_index = 0
+    for member in dataset.members.values():
+        for local_index in range(len(member)):
+            sample = dataset._index_lookup[global_index]
+            assert sample[0] is member
+            assert sample[1] == local_index
+            global_index += 1
+    assert global_index == total_spectra
+
+    # Test same sample from test.mzML and test.msz (identical data)
+    mzml_member = dataset.members["test.mzML"]
+    msz_member = dataset.members["test.msz"]
+    sample_mzml = mzml_member[0]
+    sample_msz = msz_member[0]
+    assert np.array_equal(sample_mzml[0], sample_msz[0])
+    assert np.array_equal(sample_mzml[1], sample_msz[1])
+
+
+def test_jax_dataset_w_annotations(mszx_file_path):
+    dataset = MSCompressJaxDataset(
+        mszx_file_path,
+        load_annotations=[AnnotationFormat.PEPXML],
+    )
+    assert len(dataset.members) > 0
+    total_spectra = sum(len(member) for member in dataset.members.values())
+    assert total_spectra > 0
+    assert dataset._total_spectra == total_spectra
+
+    for member in dataset.members.values():
+        for i in range(len(member)):
+            sample = member[i]
+            assert isinstance(sample, tuple)
+            assert len(sample) == 3
+            mz, intensity, psm = sample
+            assert isinstance(mz, np.ndarray)
+            assert isinstance(intensity, np.ndarray)
+            assert mz.ndim == 1
+            assert intensity.ndim == 1
+            assert psm is not None
+
+
+def test_jax_dataset_global_getitem(test_data_dir):
+    dataset = MSCompressJaxDataset(test_data_dir)
+    sample0 = dataset[0]
+    assert isinstance(sample0, tuple)
+    assert len(sample0) in (2, 3)
+    mz, intensity = sample0[0], sample0[1]
+    assert isinstance(mz, np.ndarray)
+    assert isinstance(intensity, np.ndarray)
+
+    # Negative indexing
+    sample_last = dataset[-1]
+    sample_last_pos = dataset[len(dataset) - 1]
+    assert np.array_equal(sample_last[0], sample_last_pos[0])
+    assert np.array_equal(sample_last[1], sample_last_pos[1])
+
+    with pytest.raises(IndexError):
+        dataset[len(dataset)]
+
+
+def test_list_collate_passthrough(msz_file_path):
+    dataset = MSCompressJaxDataset(msz_file_path)
+    member = next(iter(dataset.members.values()))
+    n = min(4, len(member))
+    batch = [member[i] for i in range(n)]
+
+    mzs, intensities = list_collate(batch)
+    assert isinstance(mzs, list)
+    assert isinstance(intensities, list)
+    assert len(mzs) == n
+    assert len(intensities) == n
+    for original, collated_mz, collated_int in zip(batch, mzs, intensities):
+        assert collated_mz is original[0]
+        assert collated_int is original[1]
+
+
+def test_pad_collate_shapes(msz_file_path):
+    dataset = MSCompressJaxDataset(msz_file_path)
+    member = next(iter(dataset.members.values()))
+    n = min(4, len(member))
+    batch = [member[i] for i in range(n)]
+    individual_lens = [item[0].shape[0] for item in batch]
+    expected_max = max(individual_lens)
+
+    mz, intensity, mask = pad_collate(batch)
+
+    assert mz.shape == (n, expected_max)
+    assert intensity.shape == (n, expected_max)
+    assert mask.shape == (n, expected_max)
+    assert mask.dtype == np.bool_
+    assert mz.dtype == batch[0][0].dtype
+    assert intensity.dtype == batch[0][1].dtype
+
+    for i, length in enumerate(individual_lens):
+        assert mask[i, :length].all()
+        if length < expected_max:
+            assert not mask[i, length:].any()
+            assert (mz[i, length:] == 0).all()
+            assert (intensity[i, length:] == 0).all()
+        np.testing.assert_array_equal(mz[i, :length], batch[i][0])
+        np.testing.assert_array_equal(intensity[i, :length], batch[i][1])
+
+
+def test_pad_collate_no_mask(msz_file_path):
+    dataset = MSCompressJaxDataset(msz_file_path)
+    member = next(iter(dataset.members.values()))
+    batch = [member[i] for i in range(min(2, len(member)))]
+    result = pad_collate(batch, return_mask=False)
+    assert len(result) == 2
+    mz, intensity = result
+    assert mz.ndim == 2
+    assert intensity.ndim == 2
+
+
+def test_pad_collate_with_annotations(mszx_file_path):
+    dataset = MSCompressJaxDataset(
+        mszx_file_path,
+        load_annotations=[AnnotationFormat.PEPXML],
+    )
+    member = next(iter(dataset.members.values()))
+    batch = [member[i] for i in range(min(2, len(member)))]
+
+    mz, intensity, mask, annotations = pad_collate(batch)
+    assert mz.ndim == 2 and intensity.ndim == 2 and mask.ndim == 2
+    assert isinstance(annotations, list)
+    assert len(annotations) == len(batch)
+    for ann in annotations:
+        assert isinstance(ann, dict)
+
+
+def test_grain_pipeline_smoke(test_data_dir):
+    grain = pytest.importorskip("grain")
+    dataset = MSCompressJaxDataset(test_data_dir)
+    pipeline = grain.MapDataset.source(dataset).batch(2, batch_fn=list_collate)
+    first = next(iter(pipeline))
+    assert isinstance(first, tuple)
+    mzs, intensities = first[0], first[1]
+    assert isinstance(mzs, list)
+    assert isinstance(intensities, list)
+    assert len(mzs) == 2
+    assert all(isinstance(x, np.ndarray) for x in mzs)


### PR DESCRIPTION
## Summary

- Adds `mscompress.datasets.jax` mirroring `mscompress.datasets.torch`: `MSCompressJaxDataset` / `MSCompressJaxDatasetMember` over mzML / MSZ / MSZX files, returning `numpy.ndarray` so grain's multiprocess workers can pickle items cheaply.
- The dataset class satisfies grain's `RandomAccessDataSource` protocol (`__len__` + `__getitem__`) — usable as `grain.MapDataset.source(MSCompressJaxDataset(path))`. Grain is a soft-import; the class itself works without it.
- Ships two collate utilities: `list_collate` (ragged, mirrors the existing PyTorch example) and `pad_collate` (right-pads to a rectangular `(B, max_len)` tensor + bool mask, jit/vmap-friendly).
- New optional extra: `mscompress[jax]` → `jax>=0.4`, `grain>=0.2` (also rolled into `all`).

## Test plan

- [x] `uv run pytest test/test_dataset_jax.py` — 9 new tests pass (single-file, directory, annotations, global indexing, both collates, grain pipeline smoke).
- [x] `uv run pytest test/test_dataset.py` — existing PyTorch tests still pass.
- [x] Full suite: 168 passed / 1 skipped, no regressions.
- [x] Manual smoke: grain pipeline with both collates + `jnp.asarray(...)` device transfer.