### PR TITLE
bugfix: handle empty <binary></binary> arrays in per-spectrum extraction

### DIFF
--- a/python/test/test_parquet.py
+++ b/python/test/test_parquet.py
@@ -159,11 +159,6 @@ def test_parquet_to_mszx_full(parquet_path, parquet_table, tmp_path):
             assert ann.peptide == peptides[i]
 
 
-@pytest.mark.skip(
-    reason="Empty <binary></binary> blocks crash the C extractor (bus error). "
-           "Real consensus parquets always have n_peaks > 0; revisit if that "
-           "assumption breaks."
-)
 def test_parquet_to_msz_empty_peaks(tmp_path, parquet_path):
     """A row with empty mz/intensity must still round-trip cleanly."""
     src = pq.read_table(str(parquet_path))

--- a/src/extract.c
+++ b/src/extract.c
@@ -703,8 +703,18 @@ int encode_binary_block(block_len_t* blk, data_positions_t* curr_dp,
    a_args->dest_len = &algo_output_len;
 
    for (int i = 0; i < total_spec; i++) {
+      size_t src_len = curr_dp->end_positions[i] - curr_dp->start_positions[i];
+
+      // Empty <binary></binary>: compression skipped it, so the cache holds
+      // no bytes for this spectrum. Calling target_fun with src_len==0 would
+      // walk into the next spectrum's payload and shift every later index.
+      if (src_len == 0) {
+         res_lens[i] = 0;
+         continue;
+      }
+
       a_args->src = (char**)&decmp_binary;
-      a_args->src_len = curr_dp->end_positions[i] - curr_dp->start_positions[i];
+      a_args->src_len = src_len;
       a_args->dest = (char **)(buff + buff_off);
       a_args->src_format = source_fmt;
       a_args->enc_fun = encode_fun;
@@ -760,6 +770,15 @@ char* extract_from_encoded_block(block_len_t* blk, long index,
                                  size_t* out_len) {
    size_t offset = 0;
    size_t len = blk->encoded_cache_lens[index];
+
+   // Empty spectrum: return a freeable non-NULL pointer (callers do
+   // free(res) unconditionally, and NULL would trip Python's "Failed to
+   // extract" error path in _core.pyx).
+   if (len == 0) {
+      *out_len = 0;
+      return malloc(1);
+   }
+
    char* res = malloc(len);
    if (!res)
       return NULL;


### PR DESCRIPTION
## Summary

Fixes #137. Empty `<binary></binary>` arrays in synthesized mzML (e.g. from the parquet→mzML path added in #136) caused per-spectrum `Spectrum.mz` / `Spectrum.intensity` reads to silently shift every subsequent spectrum down by one and bus-error at the last index.

Root cause was localized to `src/extract.c::encode_binary_block`: when a spectrum's source span is empty, `compress_routine` skips it entirely, so the decoded cache holds no bytes for that index. Calling `target_fun` with `src_len == 0` then runs the encode helpers' "invalid src_len" path, which is non-fatal (`error()` only prints) and falls through into reading `ZLIB_SIZE_OFFSET` bytes from `*src`, treating the *next* spectrum's header/payload as the current one. Every later index is shifted by one; the final index walks past the cache and bus-errors.

Both `compress.c` (`if (len == 0) continue;`) and `decompress.c` (full MSZ→mzML round-trip) already guarded zero-length spectra correctly. This change brings `encode_binary_block` in line.

### Changes

- `src/extract.c::encode_binary_block` — when `end_positions[i] == start_positions[i]`, record `res_lens[i] = 0` and `continue`; do not advance `decmp_binary` or call `target_fun`.
- `src/extract.c::extract_from_encoded_block` — when the per-spectrum encoded length is 0, return a freeable zero-length buffer instead of `malloc(0)` / a `memcpy` from an offset past the cache. The Python wrapper's `out_len == 0` path (`_core.pyx:1046-1052`) already returns `np.array([], dtype=...)`, and the wrapper unconditionally `free(res)`'s in `finally`.
- `python/test/test_parquet.py::test_parquet_to_msz_empty_peaks` — removed `@pytest.mark.skip`.

## Test plan

- [x] `cd python && uv sync --all-extras --reinstall` rebuilds the extension cleanly
- [x] `cd python && uv run pytest test/test_parquet.py::test_parquet_to_msz_empty_peaks -v` — previously bus-errored, now passes (asserts `len(msz.spectra) == 100`, `s0.size == 0`, and `s1.mz` is bit-exact)
- [x] `cd python && uv run pytest` — 213/213 pass, no regressions on non-empty paths
- [x] `cmake --build . && ctest --test-dir cli` — 41/41 pass, canonical extraction paths unaffected