### PR TITLE
chore(ci): test windows-2025-vs2026 runner ahead of June 2026 migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
             runner: ubuntu-24.04-arm
             arch: arm64
           - platform: windows
-            runner: windows-latest
+            runner: windows-2025-vs2026
             arch: x86_64
           - platform: macos
             runner: macos-15-intel
@@ -58,7 +58,7 @@ jobs:
       - name: Configure CMake (Windows)
         if: matrix.platform == 'windows'
         working-directory: ./cli
-        run: cmake -G "Visual Studio 17 2022" -A x64 -DENABLE_DEBUG_SYMBOLS=ON -S . -B build
+        run: cmake -A x64 -DENABLE_DEBUG_SYMBOLS=ON -S . -B build
       
       - name: Build CLI (Unix)
         if: matrix.platform != 'windows'
@@ -164,7 +164,7 @@ jobs:
             cibw_arch: aarch64
             os_name: Linux
             cibw_build_full: "cp310-* cp311-* cp312-* cp313-* cp314-*"
-          - runner: windows-latest
+          - runner: windows-2025-vs2026
             cibw_arch: AMD64
             os_name: Windows
             cibw_build_full: "cp310-* cp311-* cp312-* cp313-* cp314-*"
@@ -260,7 +260,7 @@ jobs:
             runner: macos-15-intel
             arch: x86_64
           - platform: windows
-            runner: windows-latest
+            runner: windows-2025-vs2026
             arch: x86_64
 
     steps:


### PR DESCRIPTION
## Summary
- Pins all three Windows jobs (`build-cli`, `build-python`, `build-node`) to `windows-2025-vs2026` to validate the new Visual Studio 2026 image before the `windows-latest` auto-migration on June 8-15, 2026.
- Drops the explicit `-G "Visual Studio 17 2022"` from the CLI CMake configure so CMake auto-detects the VS toolchain on the runner (avoids being tied to a specific VS version or requiring CMake 4.2+ for the `Visual Studio 18 2026` generator).

Closes #147.

## Test plan
- [x] `build-cli` (Windows) — CMake configures, builds, and `ctest -C Release` passes — **41/41 tests passed**
- [x] `build-python` (Windows) — cibuildwheel builds the wheel and the in-wheel pytest passes — **167 passed, 2 skipped** (PR builds run cp312 only; cp310–cp314 run on `stage`/tags)
- [x] `build-node` (Windows) — `prebuild` + `cmake-js` produces a `.node` addon and `vitest` passes — **98/98 tests passed**, prebuild `mscompress-v1.0.15-napi-v8-win32-x64.tar.gz` produced
- [x] Linux + macOS jobs still pass (unchanged) — all 9 non-Windows jobs green

## Follow-up
If all Windows jobs pass, the June 8 auto-migration of `windows-latest` should be safe — this PR can be reverted (or left in to make the pin explicit until the rollout completes). If anything fails, fix here or temporarily pin to `windows-2022` per the options in #147.