### PR TITLE
chore(ci): upgrade actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,16 +40,16 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
-      
-      - name: Setup MSVC Developer Command Prompt (Windows)
+
+      - name: Setup MSBuild (Windows)
         if: matrix.platform == 'windows'
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: microsoft/setup-msbuild@v3
         with:
-          arch: x64
-      
+          msbuild-architecture: x64
+
       - name: Configure CMake (Unix)
         if: matrix.platform != 'windows'
         working-directory: ./cli
@@ -103,14 +103,14 @@ jobs:
       
       - name: Upload CLI artifact (Unix)
         if: matrix.platform != 'windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: mscompress-cli-${{ matrix.platform }}-${{ matrix.arch }}
           path: ./cli/mscompress
       
       - name: Upload CLI artifact (Windows)
         if: matrix.platform == 'windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: mscompress-cli-${{ matrix.platform }}-${{ matrix.arch }}
           path: |
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload to GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ./cli/release/*
         env:
@@ -180,26 +180,26 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
-      
+
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      
-      - name: Setup MSVC Developer Command Prompt (Windows)
+
+      - name: Setup MSBuild (Windows)
         if: matrix.os_name == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: microsoft/setup-msbuild@v3
         with:
-          arch: x64
-      
+          msbuild-architecture: x64
+
       - name: Generate config.h for base64
         run: python vendor/generate_config.py
-      
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21
+        uses: pypa/cibuildwheel@v3
         env:
           CIBW_BUILD: ${{ (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/stage') && matrix.cibw_build_full || 'cp312-*' }}
           CIBW_SKIP: "*-musllinux_*"
@@ -236,7 +236,7 @@ jobs:
           fi
 
       - name: Upload Python artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: python-package-${{ matrix.os_name }}-${{ matrix.cibw_arch }}
           path: |
@@ -265,25 +265,25 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
-      - name: Setup MSVC Developer Command Prompt (Windows)
+      - name: Setup MSBuild (Windows)
         if: matrix.platform == 'windows'
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: microsoft/setup-msbuild@v3
         with:
-          arch: x64
+          msbuild-architecture: x64
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Generate config.h for base64
         run: python vendor/generate_config.py
@@ -311,7 +311,7 @@ jobs:
         run: npm test
 
       - name: Upload prebuild artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: prebuild-${{ matrix.platform }}-${{ matrix.arch }}
           path: ./node-ts/prebuilds/*.tar.gz
@@ -329,7 +329,7 @@ jobs:
     
     steps:
       - name: Download all Python artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: python-package-*
           merge-multiple: true
@@ -354,15 +354,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract version from tag
         if: startsWith(github.ref, 'refs/tags/v')
@@ -371,14 +371,14 @@ jobs:
 
       - name: Log in to Docker Hub
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build Docker image
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -386,7 +386,7 @@ jobs:
 
       - name: Build and push Docker image
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -409,24 +409,24 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 
       - name: Download all prebuild artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: prebuild-*
           path: ./node-ts/prebuilds
           merge-multiple: true
 
       - name: Upload prebuilds to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ./node-ts/prebuilds/*.tar.gz
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,14 +103,14 @@ jobs:
       
       - name: Upload CLI artifact (Unix)
         if: matrix.platform != 'windows'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: mscompress-cli-${{ matrix.platform }}-${{ matrix.arch }}
           path: ./cli/mscompress
       
       - name: Upload CLI artifact (Windows)
         if: matrix.platform == 'windows'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: mscompress-cli-${{ matrix.platform }}-${{ matrix.arch }}
           path: |
@@ -236,7 +236,7 @@ jobs:
           fi
 
       - name: Upload Python artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: python-package-${{ matrix.os_name }}-${{ matrix.cibw_arch }}
           path: |
@@ -311,7 +311,7 @@ jobs:
         run: npm test
 
       - name: Upload prebuild artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: prebuild-${{ matrix.platform }}-${{ matrix.arch }}
           path: ./node-ts/prebuilds/*.tar.gz
@@ -329,7 +329,7 @@ jobs:
     
     steps:
       - name: Download all Python artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           pattern: python-package-*
           merge-multiple: true
@@ -378,7 +378,7 @@ jobs:
 
       - name: Build Docker image
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -386,7 +386,7 @@ jobs:
 
       - name: Build and push Docker image
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -419,7 +419,7 @@ jobs:
           node-version: '24'
 
       - name: Download all prebuild artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           pattern: prebuild-*
           path: ./node-ts/prebuilds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,7 @@ jobs:
         run: python vendor/generate_config.py
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3
+        uses: pypa/cibuildwheel@v3.4
         env:
           CIBW_BUILD: ${{ (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/stage') && matrix.cibw_build_full || 'cp312-*' }}
           CIBW_SKIP: "*-musllinux_*"


### PR DESCRIPTION
Closes #148.

## Summary
- Bump every action in `build.yml` to a release that runs on Node 24, ahead of GitHub's 2026-06-02 cutover for JavaScript actions.
- Swap `ilammy/msvc-dev-cmd@v1` for `microsoft/setup-msbuild@v3` in all three Windows steps. Upstream `msvc-dev-cmd` has no Node 24 release (last release Jan 2024, work still in open PR), and our cmake / cmake-js / cibuildwheel flows only need `msbuild.exe` on PATH — not a full MSVC dev shell.
- Align `build-node`'s runtime Node from `'20'` to `'24'` so it matches `publish-node`. Prebuilds are NAPI v8 so this is ABI-safe.

## Version bumps
| Action | Before | After | Runtime |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v5` | node24 |
| `actions/setup-python` | `@v5` | `@v6` | node24 |
| `actions/setup-node` | `@v4` | `@v5` | node24 |
| `actions/upload-artifact` | `@v4` | `@v6` | node24 (v5 still node20) |
| `actions/download-artifact` | `@v4` | `@v7` | node24 (v5–v6 still node20) |
| `docker/setup-qemu-action` | `@v3` | `@v4` | node24 |
| `docker/setup-buildx-action` | `@v3` | `@v4` | node24 |
| `docker/build-push-action` | `@v5` | `@v7` | node24 (v6 still node20) |
| `docker/login-action` | `@v3` | `@v4` | node24 |
| `softprops/action-gh-release` | `@v2` | `@v3` | node24 |
| `pypa/cibuildwheel` | `@v2.21` | `@v3.4` | composite |
| `ilammy/msvc-dev-cmd@v1` | — | replaced by `microsoft/setup-msbuild@v3` | node24 |

`pypa/gh-action-pypi-publish@release/v1` is left as-is — rolling tag, already Node 24.

> Note: `upload-artifact`, `download-artifact`, and `docker/build-push-action` each had one or two majors past their first-Node-24 release that *still* shipped a Node 20 runtime — caught on the first CI run and bumped to the right majors.

## Test plan
- [x] `build-cli` matrix passes on linux-x86_64, linux-arm64, windows-x86_64, macos-x86_64, macos-arm64
- [x] `build-python` (cibuildwheel v3.4) passes on all 5 matrix entries; cp310–cp314 still build cleanly
- [x] `build-node` passes on linux-x86_64, macos-arm64, macos-x86_64, windows-x86_64 with Node 24
- [x] `build-docker` builds multi-arch image successfully
- [x] No `Node.js 20` deprecation warnings in the workflow run summary

## Risk notes
1. **Windows / setup-msbuild swap** — passed cleanly across CLI, Python (cibuildwheel), and Node (cmake-js) Windows builds; cmake auto-detected the VS 2026 generator without a dev-shell.
2. **cibuildwheel v3.4** kept all env vars we use (`CIBW_BUILD`, `CIBW_SKIP`, `CIBW_ARCHS`, `CIBW_MANYLINUX_*_IMAGE`, `CIBW_BEFORE_BUILD`, `CIBW_TEST_REQUIRES`, `CIBW_TEST_COMMAND`, `CIBW_TEST_COMMAND_WINDOWS`, `CIBW_BUILD_VERBOSITY`). v3 removed pre-installed `setuptools`/`wheel` from build envs but we use our own `setup.py` + Cython.
3. **upload-artifact v6 / download-artifact v7** — paired bump, same storage format as v4.
4. **publish-python** / **publish-node** only fire on `refs/tags/v*`, so they're not exercised by this PR. They'll be validated next release.