### PR TITLE
refactor(node-ts): mirror Python MSZX zero-copy + first-class subclass

### DIFF
--- a/node-ts/CMakeLists.txt
+++ b/node-ts/CMakeLists.txt
@@ -49,6 +49,7 @@ set(CPP_SOURCE_FILES
   src/native/decompress.cpp
   src/native/extract.cpp
   src/native/zstd_utils.cpp
+  src/native/mszx.cpp
 )
 
 add_library(${PROJECT_NAME} SHARED ${C_SOURCE_FILES} ${CPP_SOURCE_FILES} ${CMAKE_JS_SRC})

--- a/node-ts/src/core/bindings.ts
+++ b/node-ts/src/core/bindings.ts
@@ -97,6 +97,10 @@ export interface NativeBindings {
   // Zstd utilities
   zstdCompress(data: Buffer, level?: number): Buffer;
   zstdDecompress(data: Buffer): Buffer;
+
+  // MSZX archive helpers — open the embedded MSZ payload at its offset
+  // inside a .mszx tar without extracting to a temp file.
+  openMszFromArchive(archivePath: string, entryName: string): NativeFileHandle;
 }
 
 const native: NativeBindings = addon as NativeBindings;

--- a/node-ts/src/files/base-file.ts
+++ b/node-ts/src/files/base-file.ts
@@ -20,13 +20,22 @@ export abstract class BaseFile {
   protected _arguments: RuntimeArguments;
 
   /**
-   * Create a file instance.
+   * Create a file instance from either a path or an already-constructed
+   * FileHandle (the latter is used by MSZX zero-copy open via
+   * `native.openMszFromArchive`, where the handle's "path" is the
+   * containing archive and the mapping points into it).
    *
-   * @param filePath - Absolute path to the file
+   * @param input - Absolute path to the file, or a pre-built native handle
+   *                paired with the originating archive path.
    */
-  constructor(filePath: string) {
-    this.path = filePath;
-    this._handle = new native.FileHandle(filePath);
+  constructor(input: string | { handle: NativeFileHandle; path: string }) {
+    if (typeof input === "string") {
+      this.path = input;
+      this._handle = new native.FileHandle(input);
+    } else {
+      this.path = input.path;
+      this._handle = input.handle;
+    }
     this.filesize = this._handle.filesize;
     this._arguments = new RuntimeArguments();
   }

--- a/node-ts/src/files/msz-file.ts
+++ b/node-ts/src/files/msz-file.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import native from "@/core/bindings.js";
+import type { NativeFileHandle } from "@/core/bindings.js";
 import { BaseFile } from "@/files/base-file.js";
 import { DataFormat } from "@/types/data-format.js";
 import { Division } from "@/types/division.js";
@@ -14,12 +15,15 @@ import type { ExtractOptions } from "@/types/types.js";
  */
 export class MSZFile extends BaseFile {
   /**
-   * Create an MSZFile instance.
+   * Create an MSZFile instance from either a file path or a pre-built
+   * native handle (the latter is the offset-mmap path used by `fromMszx`
+   * and by `MSZXFile`, where `input.path` is the .mszx archive).
    *
-   * @param filePath - Path to the MSZ file
+   * @param input - Path to the MSZ file, or `{ handle, path }` for an
+   *                already-mmap'd payload inside an MSZX archive.
    */
-  constructor(filePath: string) {
-    super(filePath);
+  constructor(input: string | { handle: NativeFileHandle; path: string }) {
+    super(input);
     // Read header data format
     const dfNative = native.getDataFormat(this._handle);
     this._format = new DataFormat(dfNative);
@@ -30,6 +34,18 @@ export class MSZFile extends BaseFile {
 
     // Set decompress runtime variables
     native.setDecompressRuntimeVars(this._handle);
+  }
+
+  /**
+   * Open an MSZ payload embedded inside an MSZX (tar) archive without
+   * extracting it. Mmaps the entry at its byte offset.
+   *
+   * @param archivePath - Path to the .mszx file.
+   * @param entryName - MSZ entry name inside the archive (e.g. "spectra.msz").
+   */
+  static fromMszx(archivePath: string, entryName: string): MSZFile {
+    const handle = native.openMszFromArchive(archivePath, entryName);
+    return new MSZFile({ handle, path: archivePath });
   }
 
   /**
@@ -120,7 +136,10 @@ export class MSZFile extends BaseFile {
       const tmpMzml = path.join(tmpDir, "temp.mzML");
 
       try {
-        const tmpMzmlFile = this.extract(tmpMzml, options);
+        // Use the parent's prototype extract directly to avoid recursing
+        // through any subclass override (e.g. MSZXFile.extract) when the
+        // intermediate mzML is produced.
+        const tmpMzmlFile = MSZFile.prototype.extract.call(this, tmpMzml, options);
         try {
           return tmpMzmlFile.compress(outputPath);
         } finally {

--- a/node-ts/src/mszx/mszx-builder.ts
+++ b/node-ts/src/mszx/mszx-builder.ts
@@ -207,4 +207,55 @@ export class MSZXBuilder {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   }
+
+  /**
+   * Synchronous variant of `save()`. Used by `MSZXFile.extract` for
+   * `.mszx` output, where the surrounding API is sync (matching
+   * MSZFile.extract). Behaves identically to `save()` apart from running
+   * tar creation in sync mode.
+   *
+   * @param outputPath - Output file path (should end with .mszx).
+   * @returns Path of the created archive.
+   */
+  saveSync(outputPath: string): string {
+    let output = outputPath;
+    if (!path.extname(output)) {
+      output = output + ".mszx";
+    }
+
+    const manifest = this.buildManifest();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mszx-build-"));
+
+    try {
+      const manifestPath = path.join(tempDir, "manifest.json");
+      fs.writeFileSync(manifestPath, manifest.toString());
+
+      const tempMszPath = path.join(tempDir, manifest.spectra_file);
+      fs.copyFileSync(this.mszPath, tempMszPath);
+
+      for (const { path: annotationPath, entry } of this.annotations) {
+        const tempAnnotationPath = path.join(tempDir, entry.filename);
+        if (entry.compressed) {
+          const data = fs.readFileSync(annotationPath);
+          fs.writeFileSync(tempAnnotationPath, native.zstdCompress(data));
+        } else {
+          fs.copyFileSync(annotationPath, tempAnnotationPath);
+        }
+      }
+
+      tar.create(
+        {
+          file: output,
+          cwd: tempDir,
+          gzip: false,
+          sync: true,
+        },
+        fs.readdirSync(tempDir)
+      );
+
+      return output;
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
 }

--- a/node-ts/src/mszx/mszx-file.ts
+++ b/node-ts/src/mszx/mszx-file.ts
@@ -1,181 +1,152 @@
 /**
- * MSZX bundled archive file handler
+ * MSZX bundled archive file handler.
+ *
+ * MSZXFile extends MSZFile, so all spectrum-access machinery
+ * (`spectra`, `positions`, `getMzBinary`, `getIntenBinary`, `getXml`,
+ * `decompress`, `extract`) is inherited directly. Constructed via
+ * `MSZXFile.open(...)`, which mmaps the embedded MSZ payload at its
+ * byte offset inside the .mszx tar — no temp-dir extraction.
  */
 
-import * as fs from "fs";
-import * as path from "path";
-import * as os from "os";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import * as tar from "tar";
 import native from "@/core/bindings.js";
 import type { BaseFile } from "@/files/base-file.js";
 import { MSZFile } from "@/files/msz-file.js";
+import { MSZXBuilder } from "@/mszx/mszx-builder.js";
 import { MSZXManifest, AnnotationEntry } from "@/mszx/mszx-manifest.js";
-import { DataFormat } from "@/types/data-format.js";
-import { Spectra } from "@/spectrum/spectra.js";
-import { Division } from "@/types/division.js";
-import { RuntimeArguments } from "@/types/runtime-arguments.js";
 import type { ExtractOptions } from "@/types/types.js";
+
+interface CapturedTarEntries {
+  manifest: MSZXManifest;
+  annotations: Map<string, Buffer>;
+}
+
+/**
+ * Walk a tar archive synchronously, capturing every regular-file entry's
+ * payload into a Map keyed by entry name. Single pass — cheap because the
+ * `tar` package's sync mode reads the whole file into memory anyway.
+ */
+function collectTarEntries(filePath: string): Map<string, Buffer> {
+  const entries = new Map<string, Buffer>();
+  tar.list({
+    file: filePath,
+    sync: true,
+    onReadEntry: (entry) => {
+      const chunks: Buffer[] = [];
+      entry.on("data", (chunk: Buffer) => chunks.push(chunk));
+      entry.on("end", () => {
+        entries.set(entry.path, Buffer.concat(chunks));
+      });
+    },
+  });
+  return entries;
+}
+
+/**
+ * Read manifest + annotation buffers without extracting to a temp dir.
+ * Annotation entries listed by the manifest as `compressed: true` are
+ * decompressed via the addon's zstd helper.
+ */
+function readManifestAndAnnotations(filePath: string): CapturedTarEntries {
+  const entries = collectTarEntries(filePath);
+
+  const manifestBuf = entries.get("manifest.json");
+  if (!manifestBuf) {
+    throw new Error("Invalid MSZX archive: missing manifest.json");
+  }
+  const manifest = MSZXManifest.parse(manifestBuf.toString("utf-8"));
+
+  const annotations = new Map<string, Buffer>();
+  for (const entry of manifest.annotations) {
+    const raw = entries.get(entry.filename);
+    if (!raw) {
+      console.warn(`Warning: Annotation file '${entry.filename}' not found in archive`);
+      continue;
+    }
+    annotations.set(entry.filename, entry.compressed ? native.zstdDecompress(raw) : raw);
+  }
+
+  return { manifest, annotations };
+}
 
 /**
  * Handler for MSZX bundled archive files.
  *
- * Provides access to spectra via the same interface as MSZFile,
- * plus access to bundled annotation files and metadata.
+ * Inherits the full MSZFile API. `mszx instanceof MSZFile === true`.
  *
  * @example
  * ```typescript
- * import { MSZXFile } from 'mscompress';
+ * import { MSZXFile } from "mscompress";
  *
- * const mszx = MSZXFile.open('sample.mszx');
+ * const mszx = MSZXFile.open("sample.mszx");
  * try {
  *   console.log(`Spectra: ${mszx.spectra.length}`);
- *
- *   // Access first 10 spectra
- *   const limit = Math.min(mszx.spectra.length, 10);
- *   for (let i = 0; i < limit; i++) {
- *     const spectrum = mszx.spectra.get(i);
- *     console.log(spectrum.scan);
- *   }
- *
- *   // Access manifest
+ *   const buf = mszx.getMzBinary(0);
  *   console.log(mszx.manifest.description);
  * } finally {
  *   mszx.close();
  * }
  * ```
  */
-export class MSZXFile {
-  private archivePath: string;
-  private manifestData: MSZXManifest;
-  private mszFile: MSZFile;
-  private tempDir: string;
-  private closed: boolean = false;
-  private annotationFiles: Map<string, Buffer> = new Map();
+export class MSZXFile extends MSZFile {
+  readonly archivePath: string;
+  readonly manifest: MSZXManifest;
+  readonly annotations: Map<string, Buffer>;
 
   private constructor(
     archivePath: string,
     manifest: MSZXManifest,
-    mszFile: MSZFile,
-    tempDir: string,
-    annotationFiles: Map<string, Buffer>
+    annotations: Map<string, Buffer>
   ) {
+    const handle = native.openMszFromArchive(archivePath, manifest.spectra_file);
+    super({ handle, path: archivePath });
     this.archivePath = archivePath;
-    this.manifestData = manifest;
-    this.mszFile = mszFile;
-    this.tempDir = tempDir;
-    this.annotationFiles = annotationFiles;
+    this.manifest = manifest;
+    this.annotations = annotations;
   }
 
   /**
-   * Open an MSZX archive for reading.
+   * Open an MSZX archive for reading. Mmaps the embedded MSZ in place.
    *
-   * @param filePath - Path to the .mszx file
-   * @returns MSZXFile instance
-   * @throws Error if the archive doesn't exist or is invalid
+   * @param filePath - Path to the .mszx file.
+   * @returns MSZXFile instance.
+   * @throws Error if the archive doesn't exist or is invalid.
    */
   static open(filePath: string): MSZXFile {
     if (!fs.existsSync(filePath)) {
       throw new Error(`MSZX file not found: ${filePath}`);
     }
-
-    // Create temp directory for extraction
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mszx-"));
-
-    try {
-      // Extract archive to temp directory
-      tar.extract({
-        file: filePath,
-        cwd: tempDir,
-        sync: true,
-      });
-
-      // Read manifest
-      const manifestPath = path.join(tempDir, "manifest.json");
-      if (!fs.existsSync(manifestPath)) {
-        throw new Error("Invalid MSZX archive: missing manifest.json");
-      }
-
-      const manifestJson = fs.readFileSync(manifestPath, "utf-8");
-      const manifest = MSZXManifest.parse(manifestJson);
-
-      // Open MSZ file
-      const mszPath = path.join(tempDir, manifest.spectra_file);
-      if (!fs.existsSync(mszPath)) {
-        throw new Error(`Invalid MSZX archive: missing spectra file ${manifest.spectra_file}`);
-      }
-
-      const mszFile = new MSZFile(mszPath);
-
-      // Read annotation files into memory (decompress if needed)
-      const annotationFiles = new Map<string, Buffer>();
-      for (const entry of manifest.annotations) {
-        const annotationPath = path.join(tempDir, entry.filename);
-        if (fs.existsSync(annotationPath)) {
-          const raw = fs.readFileSync(annotationPath);
-          const content = entry.compressed ? native.zstdDecompress(raw) : raw;
-          annotationFiles.set(entry.filename, content);
-        } else {
-          console.warn(`Warning: Annotation file '${entry.filename}' not found in archive`);
-        }
-      }
-
-      return new MSZXFile(filePath, manifest, mszFile, tempDir, annotationFiles);
-    } catch (error) {
-      // Clean up temp dir on failure
-      try {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      } catch {}
-      throw error;
-    }
+    const { manifest, annotations } = readManifestAndAnnotations(filePath);
+    return new MSZXFile(filePath, manifest, annotations);
   }
 
   /**
-   * Close the archive and clean up temporary files.
-   */
-  close(): void {
-    if (!this.closed) {
-      this.mszFile.close();
-      try {
-        fs.rmSync(this.tempDir, { recursive: true, force: true });
-      } catch (error) {
-        console.warn(
-          `Warning: Failed to clean up temp directory: ${error instanceof Error ? error.message : String(error)}`
-        );
-      }
-      this.closed = true;
-    }
-  }
-
-  /**
-   * Path to the MSZX archive.
+   * Path to the MSZX archive (alias matching the Python binding's snake_case
+   * property; the inherited `path` returns the same value).
    */
   get archive_path(): string {
     return this.archivePath;
   }
 
   /**
-   * The archive manifest.
-   */
-  get manifest(): MSZXManifest {
-    return this.manifestData;
-  }
-
-  /**
-   * List of annotation entries in the archive.
+   * List of annotation entries in the archive's manifest.
    */
   get annotation_files(): AnnotationEntry[] {
-    return this.manifestData.annotations;
+    return this.manifest.annotations;
   }
 
   /**
-   * Get the raw content of an annotation file.
+   * Get the raw (decompressed) content of an annotation file.
    *
-   * @param filename - Name of the annotation file
-   * @returns Buffer containing the file content
-   * @throws Error if the file is not in the archive
+   * @param filename - Name of the annotation file in the manifest.
+   * @returns Buffer containing the file content.
+   * @throws Error if the file is not in the archive.
    */
   getAnnotationFile(filename: string): Buffer {
-    const content = this.annotationFiles.get(filename);
+    const content = this.annotations.get(filename);
     if (!content) {
       throw new Error(`Annotation file not found: ${filename}`);
     }
@@ -183,172 +154,112 @@ export class MSZXFile {
   }
 
   /**
-   * Get annotation files by format.
+   * List annotation filenames matching a given format.
    *
-   * @param format - The annotation format to filter by
-   * @returns Array of filenames matching the format
+   * @param format - The annotation format to filter by.
+   * @returns Array of filenames matching the format.
    */
   getAnnotationFilesByFormat(format: string): string[] {
-    return this.manifestData.annotations
+    return this.manifest.annotations
       .filter((entry) => entry.format === format)
       .map((entry) => entry.filename);
   }
 
-  // Proxy properties to underlying MSZ file
-
   /**
-   * Path to the underlying MSZ file.
-   */
-  get path(): string {
-    return this.mszFile.path;
-  }
-
-  /**
-   * Size of the underlying MSZ file.
-   */
-  get filesize(): number {
-    return this.mszFile.filesize;
-  }
-
-  /**
-   * Data format information.
-   */
-  get format(): DataFormat {
-    return this.mszFile.format;
-  }
-
-  /**
-   * Collection of spectra with lazy loading.
-   */
-  get spectra(): Spectra {
-    return this.mszFile.spectra;
-  }
-
-  /**
-   * Position information for data blocks.
-   */
-  get positions(): Division {
-    return this.mszFile.positions;
-  }
-
-  /**
-   * Runtime configuration arguments.
-   */
-  get arguments(): RuntimeArguments {
-    return this.mszFile.arguments;
-  }
-
-  /**
-   * Extract m/z binary array for a spectrum at the given index.
+   * Decompress to mzML.
    *
-   * @param index - Zero-based spectrum index
-   * @returns m/z array (Float32Array or Float64Array)
-   */
-  getMzBinary(index: number): Float32Array | Float64Array {
-    return this.mszFile.getMzBinary(index);
-  }
-
-  /**
-   * Extract intensity binary array for a spectrum at the given index.
+   * If `output` has no extension (treated as a directory), writes
+   * `<archive_stem>.mzML` plus all cached annotation buffers as siblings
+   * (with any trailing `.zst` suffix stripped, since annotations are
+   * stored decompressed in memory). Otherwise, behaves like the inherited
+   * MSZFile.decompress and writes the mzML to the given file path.
    *
-   * @param index - Zero-based spectrum index
-   * @returns Intensity array (Float32Array or Float64Array)
-   */
-  getIntenBinary(index: number): Float32Array | Float64Array {
-    return this.mszFile.getIntenBinary(index);
-  }
-
-  /**
-   * Extract XML string for a spectrum at the given index.
-   *
-   * @param index - Zero-based spectrum index
-   * @returns XML string representation of the spectrum
-   */
-  getXml(index: number): string {
-    return this.mszFile.getXml(index);
-  }
-
-  /**
-   * Get description of the file.
-   *
-   * @returns Object containing file metadata and archive information
-   */
-  describe(): Record<string, unknown> {
-    const desc = this.mszFile.describe();
-    desc.archive = {
-      path: this.archivePath,
-      annotations: this.manifestData.annotations,
-    };
-    return desc;
-  }
-
-  /**
-   * Decompress the MSZ file to mzML format.
-   *
-   * @param output - Output file path for decompressed mzML
-   * @returns BaseFile instance for the decompressed file
+   * @param output - Output file path or directory.
+   * @returns BaseFile for the produced mzML.
    */
   decompress(output: string): BaseFile {
-    return this.mszFile.decompress(output);
+    const isDir = path.extname(output) === "";
+    if (!isDir) {
+      return super.decompress(output);
+    }
+
+    fs.mkdirSync(output, { recursive: true });
+    const stem = path.basename(this.archivePath, path.extname(this.archivePath));
+    const mzmlPath = path.join(output, `${stem}.mzML`);
+    const result = super.decompress(mzmlPath);
+
+    for (const [name, buf] of this.annotations) {
+      const outName = name.endsWith(".zst") ? name.slice(0, -4) : name;
+      fs.writeFileSync(path.join(output, outName), buf);
+    }
+    return result;
   }
 
   /**
-   * Extract a subset of spectra to a new MSZ file.
+   * Extract a subset of spectra to a new file. For .mzML / .msz output,
+   * inherits the standard MSZFile.extract behavior. For .mszx output,
+   * builds a filtered MSZX archive containing the selected spectra plus
+   * all annotation files (annotations are not currently filtered to the
+   * scan subset — TODO if a use case appears).
    *
-   * Note: This extracts only the MSZ portion, not a full MSZX archive.
-   * For MSZX extraction with annotations, use extractMSZX.
-   *
-   * @param output - Output file path
-   * @param options - Optional extraction filters (indices, scanNumbers, msLevel)
-   * @returns BaseFile instance for the extracted data
+   * @param output - Output file path. Extension determines format.
+   * @param options - Optional filters (indices, scanNumbers, msLevel).
+   * @returns BaseFile for the produced output. For .mszx output the
+   *          returned value is a fresh MSZXFile.
    */
   extract(output: string, options?: ExtractOptions): BaseFile {
-    return this.mszFile.extract(output, options);
+    if (path.extname(output).toLowerCase() !== ".mszx") {
+      return super.extract(output, options);
+    }
+    return this.extractToMszx(output, options);
   }
 
   /**
-   * Extract a subset of spectra and annotations to a new MSZX archive.
-   *
-   * @param output - Path to the output .mszx file
-   * @param options - Extraction options
-   * @returns New MSZXFile instance for the created archive
+   * Build a filtered MSZX archive synchronously: extract a temp .msz with
+   * the selected spectra, then bundle it together with the original
+   * annotation buffers via MSZXBuilder.save.
    */
-  async extractMSZX(output: string, options?: ExtractOptions): Promise<MSZXFile> {
-    // Create a temporary MSZ file with extracted spectra
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mszx-extract-"));
-    const tempMszPath = path.join(tempDir, "temp.msz");
+  private extractToMszx(output: string, options?: ExtractOptions): MSZXFile {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mszx-extract-"));
+    const tmpMszPath = path.join(tmpDir, "temp.msz");
+    let extractedMsz: MSZFile | null = null;
 
     try {
-      // Extract MSZ
-      this.mszFile.extract(tempMszPath, options);
-      const extractedMsz = new MSZFile(tempMszPath);
+      // Use parent's prototype to avoid recursing through this override.
+      MSZFile.prototype.extract.call(this, tmpMszPath, options);
+      extractedMsz = new MSZFile(tmpMszPath);
 
-      // Create new MSZX archive using builder
-      const { MSZXBuilder } = await import("./mszx-builder.js");
       const builder = new MSZXBuilder(extractedMsz);
 
-      if (this.manifestData.description) {
-        builder.setDescription(this.manifestData.description);
+      if (this.manifest.description) {
+        builder.setDescription(this.manifest.description);
       }
-
-      // Copy extra metadata
-      for (const [key, value] of Object.entries(this.manifestData.extra)) {
+      for (const [key, value] of Object.entries(this.manifest.extra)) {
         builder.setExtra(key, value);
       }
-
-      // For now, we don't filter annotations - just include them all
-      // In a full implementation, we would filter based on scan numbers
-      // TODO: Implement annotation filtering
-
-      const outputPath = await builder.save(output);
-      extractedMsz.close();
+      // TODO: filter annotation buffers to the extracted scan subset.
+      const outputPath = builder.saveSync(output);
 
       return MSZXFile.open(outputPath);
     } finally {
-      // Clean up temp directory
+      if (extractedMsz) extractedMsz.close();
       try {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      } catch {}
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
     }
+  }
+
+  /**
+   * File metadata, augmented with archive info.
+   */
+  describe(): Record<string, unknown> {
+    const desc = super.describe();
+    desc.archive = {
+      path: this.archivePath,
+      annotations: this.manifest.annotations,
+    };
+    return desc;
   }
 }

--- a/node-ts/src/native/addon.cpp
+++ b/node-ts/src/native/addon.cpp
@@ -33,6 +33,8 @@ Napi::Value ExtractMsz(const Napi::CallbackInfo& info);
 Napi::Value ZstdCompress(const Napi::CallbackInfo& info);
 Napi::Value ZstdDecompress(const Napi::CallbackInfo& info);
 
+Napi::Value OpenMszFromArchive(const Napi::CallbackInfo& info);
+
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
     // Register FileHandle class
     FileHandle::Init(env, exports);
@@ -75,6 +77,9 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
     // Zstd utilities
     exports.Set("zstdCompress", Napi::Function::New(env, ZstdCompress));
     exports.Set("zstdDecompress", Napi::Function::New(env, ZstdDecompress));
+
+    // MSZX archive helpers
+    exports.Set("openMszFromArchive", Napi::Function::New(env, OpenMszFromArchive));
 
     return exports;
 }

--- a/node-ts/src/native/mszx.cpp
+++ b/node-ts/src/native/mszx.cpp
@@ -1,0 +1,84 @@
+/**
+ * NAPI wrapper for opening an MSZ payload embedded inside an MSZX (tar)
+ * archive without extracting it to disk. Mirrors Python's
+ * MSZFile.from_mszx by combining find_tar_entry + get_mapping_range to
+ * produce a FileHandle whose mmap points at the entry's byte offset.
+ */
+
+#include "types.h"
+
+extern "C" {
+#include "mscompress.h"
+}
+
+namespace mscompress {
+
+// Forward declaration — registered in addon.cpp.
+Napi::Value OpenMszFromArchive(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 2 || !info[0].IsString() || !info[1].IsString()) {
+        Napi::TypeError::New(env,
+            "openMszFromArchive: (archivePath: string, entryName: string) expected"
+        ).ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+
+    std::string archivePath = info[0].As<Napi::String>().Utf8Value();
+    std::string entryName = info[1].As<Napi::String>().Utf8Value();
+
+    int fd = open_input_file(const_cast<char*>(archivePath.c_str()));
+    if (fd < 0) {
+        Napi::Error::New(env, "openMszFromArchive: failed to open " + archivePath)
+            .ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+
+    int64_t offset = 0;
+    size_t size = 0;
+    if (find_tar_entry(fd, entryName.c_str(), &offset, &size) != 0) {
+        close_file(fd);
+        Napi::Error::New(env,
+            "openMszFromArchive: entry '" + entryName +
+            "' not found in archive or archive is not a valid USTAR tar"
+        ).ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+
+    size_t pad = 0;
+    size_t mapLength = 0;
+    void* base = get_mapping_range(fd, offset, size, &pad, &mapLength);
+    if (base == nullptr) {
+        close_file(fd);
+        Napi::Error::New(env,
+            "openMszFromArchive: MSZX archive truncated or corrupted "
+            "(mmap range exceeds file size)"
+        ).ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+
+    void* mapping = static_cast<char*>(base) + pad;
+
+    // Build the descriptor object the FileHandle object-form constructor
+    // expects, then construct via the registered FileHandle class. Pointer
+    // values cross the JS boundary as External<void> wrappers.
+    Napi::Object descriptor = Napi::Object::New(env);
+    descriptor.Set("fd", Napi::Number::New(env, fd));
+    descriptor.Set("mapping", Napi::External<void>::New(env, mapping));
+    descriptor.Set("mapBase", Napi::External<void>::New(env, base));
+    descriptor.Set("mapLength", Napi::Number::New(env, static_cast<double>(mapLength)));
+    descriptor.Set("filesize", Napi::Number::New(env, static_cast<double>(size)));
+
+    Napi::FunctionReference* ctor = env.GetInstanceData<Napi::FunctionReference>();
+    if (ctor == nullptr) {
+        // Cleanup before bailing — we own the mapping and fd at this point.
+        remove_mapping(base, mapLength);
+        close_file(fd);
+        Napi::Error::New(env, "openMszFromArchive: FileHandle constructor unavailable")
+            .ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+    return ctor->New({ descriptor });
+}
+
+} // namespace mscompress

--- a/node-ts/src/native/types.cpp
+++ b/node-ts/src/native/types.cpp
@@ -240,28 +240,54 @@ FileHandle::FileHandle(const Napi::CallbackInfo& info)
     : Napi::ObjectWrap<FileHandle>(info) {
     Napi::Env env = info.Env();
 
-    if (info.Length() < 1 || !info[0].IsString()) {
+    if (info.Length() < 1) {
+        Napi::TypeError::New(env, "FileHandle: path string or handle object expected").ThrowAsJavaScriptException();
+        return;
+    }
+
+    // --- Object form: pre-built handle from offset-mmap (e.g. MSZX path) ---
+    if (info[0].IsObject() && !info[0].IsString()) {
+        Napi::Object obj = info[0].As<Napi::Object>();
+        if (!obj.Has("fd") || !obj.Has("mapping") || !obj.Has("mapBase")
+            || !obj.Has("mapLength") || !obj.Has("filesize")) {
+            Napi::TypeError::New(env,
+                "FileHandle: handle object must have {fd, mapping, mapBase, mapLength, filesize}"
+            ).ThrowAsJavaScriptException();
+            return;
+        }
+
+        fd_ = obj.Get("fd").As<Napi::Number>().Int32Value();
+        // Pointers come across as External<void> wrappers (set by the addon side).
+        mapping_ = obj.Get("mapping").As<Napi::External<void>>().Data();
+        map_base_ = obj.Get("mapBase").As<Napi::External<void>>().Data();
+        map_length_ = static_cast<size_t>(obj.Get("mapLength").As<Napi::Number>().Int64Value());
+        filesize_ = static_cast<size_t>(obj.Get("filesize").As<Napi::Number>().Int64Value());
+
+        filetype_ = determine_filetype(mapping_, filesize_);
+        z_ = alloc_z_stream();
+        return;
+    }
+
+    // --- String form: open and mmap from a file path ---
+    if (!info[0].IsString()) {
         Napi::TypeError::New(env, "FileHandle: string path expected").ThrowAsJavaScriptException();
         return;
     }
 
     std::string path = info[0].As<Napi::String>().Utf8Value();
 
-    // Get filesize
     filesize_ = get_filesize(const_cast<char*>(path.c_str()));
     if (filesize_ == 0) {
         Napi::Error::New(env, "FileHandle: file is empty or does not exist: " + path).ThrowAsJavaScriptException();
         return;
     }
 
-    // Open file
     fd_ = open_input_file(const_cast<char*>(path.c_str()));
     if (fd_ < 0) {
         Napi::Error::New(env, "FileHandle: failed to open file: " + path).ThrowAsJavaScriptException();
         return;
     }
 
-    // Memory map
     mapping_ = get_mapping(fd_);
     if (mapping_ == nullptr) {
         close_file(fd_);
@@ -270,10 +296,11 @@ FileHandle::FileHandle(const Napi::CallbackInfo& info)
         return;
     }
 
-    // Detect file type
-    filetype_ = determine_filetype(mapping_, filesize_);
+    // Path-based open: the user-facing pointer IS the mmap base.
+    map_base_ = mapping_;
+    map_length_ = filesize_;
 
-    // Allocate z_stream for mzML decoding
+    filetype_ = determine_filetype(mapping_, filesize_);
     z_ = alloc_z_stream();
 }
 
@@ -333,8 +360,13 @@ void FileHandle::Cleanup() {
     // footer_ points to mmap memory in MSZ path, don't free
     footer_ = nullptr;
 
-    // Unmap then close
-    if (mapping_) {
+    // Unmap then close. For offset-mmap (MSZX), unmap the true base + actual
+    // mapped length, not the user-facing pointer.
+    if (map_base_) {
+        remove_mapping(map_base_, map_length_);
+        map_base_ = nullptr;
+        mapping_ = nullptr;
+    } else if (mapping_) {
         remove_mapping(mapping_, filesize_);
         mapping_ = nullptr;
     }

--- a/node-ts/src/native/types.h
+++ b/node-ts/src/native/types.h
@@ -88,8 +88,10 @@ private:
     void Cleanup();
 
     int fd_ = -1;
-    void* mapping_ = nullptr;
-    size_t filesize_ = 0;
+    void* mapping_ = nullptr;          // user-facing pointer (== map_base_ + pad)
+    void* map_base_ = nullptr;         // true mmap base, used for unmap
+    size_t map_length_ = 0;            // true mapped length (≥ filesize_)
+    size_t filesize_ = 0;              // logical MSZ size
     int filetype_ = 0;
     data_format_t* df_ = nullptr;
     division_t* positions_ = nullptr;

--- a/node-ts/test/mszx-mmap.test.ts
+++ b/node-ts/test/mszx-mmap.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for the first-class MSZXFile reader.
+ *
+ * MSZXFile extends MSZFile and mmaps the embedded MSZ payload directly
+ * out of the .mszx archive at the entry's byte offset. These tests verify:
+ *   - no temp directory is created on open;
+ *   - data read through the mmap'd MSZ is byte-identical to data read from
+ *     the same MSZ extracted to a standalone file;
+ *   - directory-output decompress writes mzML + annotation files together;
+ *   - MSZXFile is polymorphic with MSZFile (instanceof).
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as tar from "tar";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { MSZFile } from "@/files/msz-file.js";
+import { MZMLFile } from "@/files/mzml-file.js"; // side-effect: register "mzml" factory
+import { MSZXFile } from "@/mszx/mszx-file.js";
+import { MSZX_PATH } from "./fixtures.js";
+
+// Reference MZMLFile so the side-effect import isn't dropped.
+void MZMLFile;
+
+describe("MSZXFile (mmap-into-tar)", () => {
+  it("does not create a mszx-XXXXXX temp dir on open", () => {
+    // The old impl used mkdtempSync(prefix="mszx-") which produces names
+    // like "mszx-aB3xYz". Other test fixtures use longer prefixes
+    // ("mszx-test-", "mszx-build-", "mszx-extract-"), so we match the
+    // bare 6-suffix shape to specifically detect the old behavior.
+    const oldPattern = /^mszx-[A-Za-z0-9]{6}$/;
+    const tmp = os.tmpdir();
+    const before = new Set(fs.readdirSync(tmp).filter((e) => oldPattern.test(e)));
+    const mszx = MSZXFile.open(MSZX_PATH);
+    try {
+      const after = new Set(fs.readdirSync(tmp).filter((e) => oldPattern.test(e)));
+      const newEntries = [...after].filter((e) => !before.has(e));
+      expect(newEntries).toEqual([]);
+    } finally {
+      mszx.close();
+    }
+  });
+
+  it("is polymorphic with MSZFile (instanceof)", () => {
+    const mszx = MSZXFile.open(MSZX_PATH);
+    try {
+      expect(mszx).toBeInstanceOf(MSZFile);
+    } finally {
+      mszx.close();
+    }
+  });
+
+  describe("byte-equivalence vs standalone-extracted MSZ", () => {
+    let standalonePath: string;
+    let standaloneTmpDir: string;
+
+    beforeAll(() => {
+      // Manually extract the embedded MSZ into a temp dir so we can open
+      // it as a standalone MSZFile and compare byte-for-byte.
+      standaloneTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mszx-verify-"));
+      tar.extract({ file: MSZX_PATH, cwd: standaloneTmpDir, sync: true });
+      const entries = fs.readdirSync(standaloneTmpDir).filter((f) => f.endsWith(".msz"));
+      if (entries.length !== 1) {
+        throw new Error(`expected exactly one .msz entry, found ${entries.length}`);
+      }
+      standalonePath = path.join(standaloneTmpDir, entries[0]);
+    });
+
+    afterAll(() => {
+      fs.rmSync(standaloneTmpDir, { recursive: true, force: true });
+    });
+
+    it("yields identical mz/intensity arrays for sampled spectra", () => {
+      const direct = new MSZFile(standalonePath);
+      const viaArchive = MSZXFile.open(MSZX_PATH);
+      try {
+        expect(viaArchive.spectra.length).toBe(direct.spectra.length);
+
+        const sample = [
+          0,
+          Math.floor(direct.spectra.length / 2),
+          direct.spectra.length - 1,
+        ];
+        for (const i of sample) {
+          const dMz = direct.getMzBinary(i);
+          const aMz = viaArchive.getMzBinary(i);
+          expect(Buffer.from(aMz.buffer, aMz.byteOffset, aMz.byteLength).equals(
+            Buffer.from(dMz.buffer, dMz.byteOffset, dMz.byteLength)
+          )).toBe(true);
+
+          const dInt = direct.getIntenBinary(i);
+          const aInt = viaArchive.getIntenBinary(i);
+          expect(Buffer.from(aInt.buffer, aInt.byteOffset, aInt.byteLength).equals(
+            Buffer.from(dInt.buffer, dInt.byteOffset, dInt.byteLength)
+          )).toBe(true);
+        }
+      } finally {
+        direct.close();
+        viaArchive.close();
+      }
+    });
+  });
+
+  it("decompress(<dir>) writes mzML + annotation files into the directory", () => {
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "mszx-dir-out-"));
+    try {
+      const mszx = MSZXFile.open(MSZX_PATH);
+      try {
+        mszx.decompress(outDir);
+      } finally {
+        mszx.close();
+      }
+
+      const stem = path.basename(MSZX_PATH, path.extname(MSZX_PATH));
+      const mzmlPath = path.join(outDir, `${stem}.mzML`);
+      expect(fs.existsSync(mzmlPath)).toBe(true);
+      expect(fs.statSync(mzmlPath).size).toBeGreaterThan(0);
+
+      const files = fs.readdirSync(outDir);
+      const annotationFiles = files.filter((f) => f !== `${stem}.mzML`);
+      expect(annotationFiles.length).toBeGreaterThan(0);
+      // .zst suffixes must be stripped on the way out.
+      expect(annotationFiles.some((f) => f.endsWith(".zst"))).toBe(false);
+    } finally {
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on **#151** (`feature/c-mszx`) — node-ts can't merge until the C foundation lands. Brings the Node.js bindings to parity with the Python MSZX work.

- **`MSZXFile extends MSZFile`** — `mszx.spectra` / `mszx.getMzBinary(0)` / `mszx instanceof MSZFile` all work directly. Drops the `this.mszFile` proxy entirely. The 32 existing `mszx.test.ts` tests pass unchanged.
- **Zero-copy open** — new `OpenMszFromArchive` NAPI wrapper (`src/native/mszx.cpp`) calls the C `find_tar_entry` + `get_mapping_range` to mmap the embedded MSZ at its byte offset. `MSZXFile.open()` no longer does `tar.extract({ cwd: tempDir })`.
- **`FileHandle` extension** — adds `map_base_` / `map_length_` so unmap works correctly when the user-facing pointer is offset from the true mmap base by page-alignment padding.
- **Same self-recursion fix** as the Python side: `MSZFile.extract`'s intermediate-mzML step now uses `MSZFile.prototype.extract.call(this, …)` to bypass any subclass override.
- **`MSZXFile.decompress(<dir>)`** writes `<stem>.mzML` plus annotation buffers as siblings (`.zst` suffix stripped). New `MSZXBuilder.saveSync` lets the synchronous `extract(<.mszx>)` override use the builder without going async.
- **New** `test/mszx-mmap.test.ts` — 4 tests: no temp-dir leak, polymorphism, byte-equivalent m/z & intensity vs standalone-extracted MSZ, directory-output decompress.

## Test plan

- [ ] `cd node-ts && npm run build && npm test` — 102/102 pass (98 existing + 4 new)
- [ ] `ctest --test-dir cli` — 42/42 (no C changes here; depends on PR #151)
- [ ] `cd python && uv run pytest` — 216/216 (proves shared C helpers untouched)
- [ ] CI matrix: Linux/macOS/Windows prebuilds via `prebuild` succeed