### PR TITLE
fix(python): release GIL during compress()/decompress() to avoid worker deadlock

### DIFF
--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -457,7 +457,20 @@ cdef class MZMLFile(BaseFile):
         self._validate_scale_factors()
         self._prepare_divisions()
         self.output_fd = self._prepare_output_fd(output)
-        cdef int rv = _compress_mzml(<char*> self._mapping, self.filesize, self._arguments.get_ptr(), self._df, self._divisions, self.output_fd)
+        cdef int rv
+        cdef char* mapping = <char*> self._mapping
+        cdef size_t filesize = self.filesize
+        cdef Arguments* args = self._arguments.get_ptr()
+        cdef data_format_t* df = self._df
+        cdef divisions_t* divisions = self._divisions
+        cdef int fd = self.output_fd
+        # Release the GIL so worker threads can re-enter Python via the
+        # error/warning callbacks (declared `with gil`). Without this, a worker
+        # that hits a base64 decode failure (or any other warning path) blocks
+        # in PyGILState_Ensure while the main thread is parked in pthread_join,
+        # producing an unrecoverable deadlock.
+        with nogil:
+            rv = _compress_mzml(mapping, filesize, args, df, divisions, fd)
         _flush(self.output_fd)
         _close_file(self.output_fd)
         self.output_fd = -1
@@ -837,7 +850,16 @@ cdef class MSZFile(BaseFile):
     def decompress(self, output: Union[str, PathLike]) -> MZMLFile:
         output = os.fspath(output)
         self.output_fd = self._prepare_output_fd(output)
-        cdef int rv = _decompress_msz(<char*>self._mapping, self.filesize, self._arguments.get_ptr(), self.output_fd)
+        cdef int rv
+        cdef char* mapping = <char*>self._mapping
+        cdef size_t filesize = self.filesize
+        cdef Arguments* args = self._arguments.get_ptr()
+        cdef int fd = self.output_fd
+        # Release the GIL so worker threads can re-enter Python via the
+        # error/warning callbacks. See MZMLFile.compress for the deadlock
+        # this avoids.
+        with nogil:
+            rv = _decompress_msz(mapping, filesize, args, fd)
         _flush(self.output_fd)
         _close_file(self.output_fd)
         self.output_fd = -1

--- a/python/test/test_corrupt_base64.py
+++ b/python/test/test_corrupt_base64.py
@@ -6,10 +6,12 @@ has an invalid character injected into its m/z base64 data. mscompress should
 handle this gracefully (empty array) instead of crashing.
 """
 
+import multiprocessing
+
 import numpy as np
 import pytest
 
-from mscompress import read, MZMLFile
+from mscompress import MSZFile, MZMLFile, read
 
 
 def test_read_corrupt_base64_mzml(corrupt_base64_mzml_path):
@@ -54,3 +56,74 @@ def test_dense_sequential_access_no_crash(corrupt_base64_mzml_path):
         inten = mzml.get_inten_binary(i)
         assert isinstance(mz, np.ndarray)
         assert isinstance(inten, np.ndarray)
+
+
+def _compress_in_subprocess(input_path: str, output_path: str) -> None:
+    """Run compress() in a child process so the parent can enforce a timeout."""
+    from mscompress import MZMLFile as _MZMLFile
+
+    with _MZMLFile(input_path.encode("utf-8")) as mzml:
+        mzml.compress(output_path)
+
+
+def test_compress_corrupt_base64_does_not_deadlock(corrupt_base64_mzml_path, tmp_path):
+    """compress() must return on a corrupt-base64 input, not deadlock.
+
+    Before the fix in fix/compress-gil-deadlock-corrupt-base64, MZMLFile.compress()
+    held the GIL during _compress_mzml(). Worker threads that hit the
+    `decode_base64 failed` warning blocked in PyGILState_Ensure while the main
+    thread was parked in pthread_join — an unrecoverable deadlock. We run
+    compress() in a subprocess with a wall-clock budget so a regression fails
+    the test instead of hanging CI.
+    """
+    output_path = tmp_path / "corrupt_roundtrip.msz"
+
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(
+        target=_compress_in_subprocess,
+        args=(corrupt_base64_mzml_path, str(output_path)),
+    )
+    proc.start()
+    proc.join(timeout=60)
+
+    if proc.is_alive():
+        proc.terminate()
+        proc.join(timeout=5)
+        if proc.is_alive():
+            proc.kill()
+            proc.join()
+        pytest.fail(
+            "MZMLFile.compress() deadlocked on corrupt-base64 input "
+            "(GIL/pthread_join regression — see fix/compress-gil-deadlock-corrupt-base64)."
+        )
+
+    assert proc.exitcode == 0, f"compress subprocess exited with {proc.exitcode}"
+    assert output_path.exists(), "compress() did not produce an output file"
+    assert output_path.stat().st_size > 0, "compress() produced an empty output file"
+
+
+def test_compress_corrupt_base64_roundtrip(corrupt_base64_mzml_path, tmp_path):
+    """After compress(), the MSZ should open and report the expected spectrum count."""
+    output_path = tmp_path / "corrupt_roundtrip.msz"
+
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(
+        target=_compress_in_subprocess,
+        args=(corrupt_base64_mzml_path, str(output_path)),
+    )
+    proc.start()
+    proc.join(timeout=60)
+
+    if proc.is_alive():
+        proc.terminate()
+        proc.join(timeout=5)
+        if proc.is_alive():
+            proc.kill()
+            proc.join()
+        pytest.fail("compress() deadlocked; cannot verify roundtrip.")
+
+    assert proc.exitcode == 0
+    assert output_path.exists()
+
+    with MSZFile(str(output_path).encode("utf-8")) as msz:
+        assert msz.format.source_total_spec == 5


### PR DESCRIPTION
## Summary

- `MZMLFile.compress()` and `MSZFile.decompress()` called `_compress_mzml` / `_decompress_msz` without releasing the GIL. Worker threads hitting any `with gil` callback (e.g. the `decode_base64 failed` warning on corrupt-base64 inputs) blocked in `PyGILState_Ensure` while the main thread was parked in `pthread_join` — an unrecoverable deadlock.
- Wrap both call sites in `with nogil:`, mirroring the streaming variants (`_compress_to_fd`, `_decompress_to_fd`) that already handled this correctly.
- Add subprocess-gated regression tests against the existing `corrupt_base64.mzML` fixture so a regression fails the test instead of hanging CI.

## Root cause

`_python_warning_handler` / `_python_error_handler` in `_core.pyx` are declared `noexcept with gil`. When invoked from a worker thread that does not hold the GIL, Cython emits `PyGILState_Ensure()`. Because `compress()` entered `_compress_mzml` while still holding the GIL, every worker that called `warning(...)` blocked there, and the main thread waiting on `pthread_join` could never release the GIL — matching exactly the `futex_wait_queue` / 0% CPU / single-warning behaviour reported on PXD000065 mzMLs.

## Test plan

- [x] `uv run pytest test/test_corrupt_base64.py -v` — 7 passed, including the new `test_compress_corrupt_base64_does_not_deadlock` and `test_compress_corrupt_base64_roundtrip`.
- [x] Full Python suite: `uv run pytest` — 215 passed, 0 failed.
- [x] CI green on Linux/macOS/Windows wheels.

## Notes for reviewers

- The new tests use `multiprocessing.spawn` with a 60s wall-clock timeout so a re-introduction of the deadlock fails the test cleanly rather than hanging the runner.
- The underlying error-recovery in `decode_base64` / `cmp_binary_routine` (proceeding with `len=0` after a failed decode) is **not** changed by this PR; that's a separate concern worth its own ticket.
- The same latent deadlock pattern existed in `MSZFile.decompress()`; fixed alongside even though it hasn't been reported in the wild yet.