### PR TITLE
fix(python): build wheels against numpy 2 ABI to unblock cp313 on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,8 @@ jobs:
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           CIBW_BEFORE_BUILD: "python {package}/../vendor/generate_config.py"
           # Run tests inside cibuildwheel so each Python version is tested with its own wheel
-          CIBW_TEST_REQUIRES: "pytest torch"
+          CIBW_TEST_REQUIRES: "pytest"
+          CIBW_TEST_EXTRAS: "pytorch"
           CIBW_TEST_COMMAND: "cd {project}/python && pytest test -v"
           CIBW_TEST_COMMAND_WINDOWS: "cd /d {project}\\python && pytest test -v"
           CIBW_BUILD_VERBOSITY: 1

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
     "tomli"
 ]
 
-pytorch = ["torch>=2.0"]
+pytorch = ["torch>=2.3; sys_platform != 'darwin' or platform_machine != 'x86_64'"]
 
 parquet = ["pyarrow>=14"]
 
@@ -34,7 +34,7 @@ all = [
     "mlcroissant>=1.0.0",
     "numpy>=1.19",
     "zstandard>=0.19.0",
-    "torch>=2.0",
+    "torch>=2.3; sys_platform != 'darwin' or platform_machine != 'x86_64'",
     "pyarrow>=14",
     "jax>=0.4",
     "grain>=0.2",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "cython", "oldest-supported-numpy", "tomli"]
+requires = ["setuptools>=45", "wheel", "cython", "numpy>=2.0", "tomli"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "mlcroissant>=1.0.0",
-    "numpy<2",
+    "numpy>=1.19",
     "zstandard>=0.19.0",
 ]
 
@@ -32,7 +32,7 @@ jax = ["jax>=0.4", "grain>=0.2"]
 
 all = [
     "mlcroissant>=1.0.0",
-    "numpy<2",
+    "numpy>=1.19",
     "zstandard>=0.19.0",
     "torch>=2.0",
     "pyarrow>=14",

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -1,5 +1,7 @@
 import pytest
-import torch
+
+torch = pytest.importorskip("torch")
+
 from mscompress.datasets.torch import MSCompressDataset
 from mscompress.types import AnnotationFormat
 


### PR DESCRIPTION
## Summary
- Switch build dep from `oldest-supported-numpy` → `numpy>=2.0` so wheels are compiled against the stable numpy 2 C ABI (forward-compatible with numpy ≥1.19 at runtime).
- Drop the `numpy<2` runtime cap from `dependencies` and the `all` extra in favor of `numpy>=1.19`.

## Why
The `oldest-supported-numpy` + `numpy<2` combination was introduced in two same-day hotfixes on 2025-11-07 (`bd28921` "skip numpy-compilation" and `9797ab8` "hotfix: numpy dependency listing") to avoid recompiling numpy on CI. The runtime cap was a defensive follow-up: wheels built against numpy 1.x headers crash at `cimport numpy` under numpy 2.x.

On Python 3.13 this pin backfires — numpy 1.26.4 ships no cp313 win_amd64 wheel, so cibuildwheel falls back to building numpy 1.26.4 from source on the `windows-2025-vs2026` runner. The source build appears to succeed but the resulting DLL segfaults on import in `numpy/core/getlimits.py` (access violation `0xC0000005`), crashing `pytest` collection before any mscompress test runs. This is what's failing the **Build Python - windows-2025-vs2026 AMD64** check on #156.

numpy 2.0 introduced a stable C ABI: extensions built against numpy 2.x headers run unchanged on numpy ≥1.19 and on numpy 2.x. Building against `numpy>=2.0` lets us drop the runtime cap and pick up prebuilt numpy wheels on every (Python × platform) cell in the matrix.

## Test plan
- [ ] CI matrix passes on all (Python × platform) cells, especially `Build Python - windows-2025-vs2026 AMD64` (the job currently failing on #156).
- [ ] Local: `cd python && uv sync --all-extras --reinstall && uv run pytest` passes with numpy 2 installed.
- [ ] Smoke test: `python -c "import mscompress; import numpy; print(numpy.__version__)"` reports a 2.x version on a fresh install and imports cleanly.