### PR TITLE
Bound the C-level decompressed block cache with an LRU

### DIFF
--- a/node-ts/src/native/spectrum.cpp
+++ b/node-ts/src/native/spectrum.cpp
@@ -197,7 +197,8 @@ Napi::Value GetMzBinaryMsz(const Napi::CallbackInfo& info) {
         handle->GetDivisions(),
         static_cast<long>(index),
         &out_len,
-        FALSE
+        FALSE,
+        nullptr
     );
 
     if (res == nullptr) {
@@ -250,7 +251,8 @@ Napi::Value GetIntenBinaryMsz(const Napi::CallbackInfo& info) {
         handle->GetDivisions(),
         static_cast<long>(index),
         &out_len,
-        FALSE
+        FALSE,
+        nullptr
     );
 
     if (res == nullptr) {
@@ -310,7 +312,8 @@ Napi::Value GetXmlMsz(const Napi::CallbackInfo& info) {
         footer->inten_fmt,
         handle->GetDivisions(),
         static_cast<long>(index),
-        &out_len
+        &out_len,
+        nullptr
     );
 
     if (res == nullptr) {

--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -795,16 +795,18 @@ cdef class MZMLFile(BaseFile):
         return element
 
 
-DEFAULT_BLOCK_CACHE = 4
-"""Default per-file bounded LRU size for decompressed block caches.
+CACHE_BLOCKS_AUTO = -1
+"""Sentinel for ``cache_blocks`` meaning "use one slot per division".
 
-When iterating spectra (especially at random), each unique division's
-decompressed mz/intensity/xml block is otherwise held forever; with this cap,
-the LRU evicts the least-recently-touched block once the cap is exceeded, at
-the cost of re-decompressing it on a future cache miss. Pass ``cache_blocks=0``
-to ``MSZFile`` / ``MSZXFile`` to disable the LRU and restore unbounded caching
-(legacy behavior; useful only for sequential single-pass workloads on small
-files)."""
+When passed (the default), the bounded-LRU cap is sized to the file's own
+``n_divisions`` after the footer is read, so a single in-flight access never
+evicts in steady state, while still bounding total cached blocks to one
+file's worth of divisions. Use ``cache_blocks=0`` to disable the LRU and
+restore unbounded legacy caching, or a positive int for an explicit cap."""
+
+# Back-compat alias for the old constant name. Will be removed in a future
+# release; new code should use CACHE_BLOCKS_AUTO.
+DEFAULT_BLOCK_CACHE = CACHE_BLOCKS_AUTO
 
 
 cdef class MSZFile(BaseFile):
@@ -814,14 +816,14 @@ cdef class MSZFile(BaseFile):
     cdef block_len_queue_t* _mz_binary_block_lens
     cdef block_len_queue_t* _inten_binary_block_lens
     cdef block_lru_t* _block_lru
-    cdef int _cache_blocks
+    cdef int _cache_blocks  # User-supplied cap value or sentinel; the
+                            # *effective* cap is on self._block_lru.cap once
+                            # resolved post-footer.
 
-    def __init__(self, bytes path, int cache_blocks=DEFAULT_BLOCK_CACHE):
+    def __init__(self, bytes path, int cache_blocks=CACHE_BLOCKS_AUTO):
         super(MSZFile, self).__init__(path)
         self._cache_blocks = cache_blocks
         self._block_lru = NULL
-        if cache_blocks > 0:
-            self._block_lru = _alloc_block_lru(cache_blocks)
         self._df = _get_header_df(self._mapping)
         self._footer = _read_footer(self._mapping, self.filesize)
         self._divisions = _read_divisions(self._mapping, self._footer.divisions_t_pos, self._footer.n_divisions)
@@ -831,6 +833,18 @@ cdef class MSZFile(BaseFile):
         self._mz_binary_block_lens = _read_block_len_queue(self._mapping, self._footer.mz_binary_blk_pos, self._footer.inten_binary_blk_pos)
         self._inten_binary_block_lens = _read_block_len_queue(self._mapping, self._footer.inten_binary_blk_pos, self._footer.divisions_t_pos)
         _set_decompress_runtime_variables(self._df, self._footer)
+        # Resolve cache_blocks now that n_divisions is known.
+        self._init_block_lru()
+
+    cdef _init_block_lru(self):
+        cdef int cap
+        if self._cache_blocks == 0:
+            return  # explicit "disable LRU"
+        if self._cache_blocks == CACHE_BLOCKS_AUTO:
+            cap = max(1, <int>self._footer.n_divisions)
+        else:
+            cap = self._cache_blocks
+        self._block_lru = _alloc_block_lru(cap)
 
     @staticmethod
     def _reopen(path: bytes):
@@ -883,12 +897,11 @@ cdef class MSZFile(BaseFile):
         self._divisions = NULL
         self._positions = NULL
 
-        # Bounded-LRU init. Callers using cls.__new__(cls) must set
-        # self._cache_blocks before invoking _init_from_archive (MSZFile.from_mszx
-        # and MSZXFile.open both do so). 0 means LRU disabled.
+        # Bounded-LRU init happens AFTER the footer is read so we can
+        # default to one slot per division. Callers using cls.__new__(cls)
+        # must set self._cache_blocks before invoking _init_from_archive
+        # (MSZFile.from_mszx and MSZXFile.open both do so). 0 disables.
         self._block_lru = NULL
-        if self._cache_blocks > 0:
-            self._block_lru = _alloc_block_lru(self._cache_blocks)
 
         # Run the MSZFile-specific init body.
         self._df = _get_header_df(self._mapping)
@@ -900,10 +913,11 @@ cdef class MSZFile(BaseFile):
         self._mz_binary_block_lens = _read_block_len_queue(self._mapping, self._footer.mz_binary_blk_pos, self._footer.inten_binary_blk_pos)
         self._inten_binary_block_lens = _read_block_len_queue(self._mapping, self._footer.inten_binary_blk_pos, self._footer.divisions_t_pos)
         _set_decompress_runtime_variables(self._df, self._footer)
+        self._init_block_lru()
 
     @classmethod
     def from_mszx(cls, bytes mszx_path, bytes entry_name,
-                  int cache_blocks=DEFAULT_BLOCK_CACHE):
+                  int cache_blocks=CACHE_BLOCKS_AUTO):
         """
         Open an MSZ file embedded inside an MSZX (tar) archive without
         extracting it to disk. Mmap's the archive at the entry's byte
@@ -917,7 +931,8 @@ cdef class MSZFile(BaseFile):
             Name of the MSZ entry within the archive (e.g. b"spectra.msz").
         cache_blocks : int
             Per-file LRU cap for decompressed mz/intensity/xml blocks.
-            Default ``DEFAULT_BLOCK_CACHE``; 0 disables the LRU.
+            Default ``CACHE_BLOCKS_AUTO`` (-1) sizes the cap to the file's
+            own ``n_divisions``; 0 disables the LRU entirely.
         """
         cdef MSZFile self = cls.__new__(cls)
         self._cache_blocks = cache_blocks
@@ -967,6 +982,18 @@ cdef class MSZFile(BaseFile):
 
         # Call parent cleanup
         super(MSZFile, self)._cleanup()
+
+    @property
+    def block_cache_cap(self):
+        """The effective bounded-LRU cap for this file's decompressed blocks.
+
+        ``0`` means the LRU is disabled (unbounded caching). A positive value
+        is the maximum number of mz/intensity/xml decompressed blocks held at
+        once before the LRU starts evicting.
+        """
+        if self._block_lru == NULL:
+            return 0
+        return self._block_lru.cap
 
     def clear_cache(self):
         """Evict all decompressed block caches without closing the file.
@@ -1371,7 +1398,7 @@ cdef class MSZXFile(MSZFile):
     cdef public bint _closed             # idempotent-close guard (visible to Python)
 
     @classmethod
-    def open(cls, path, int cache_blocks=DEFAULT_BLOCK_CACHE):
+    def open(cls, path, int cache_blocks=CACHE_BLOCKS_AUTO):
         """
         Open an MSZX archive for reading.
 
@@ -1383,7 +1410,8 @@ cdef class MSZXFile(MSZFile):
         Args:
             path: Path to the .mszx file.
             cache_blocks: Per-file LRU cap for decompressed mz/intensity/xml
-                blocks. Default ``DEFAULT_BLOCK_CACHE``; 0 disables the LRU.
+                blocks. Default ``CACHE_BLOCKS_AUTO`` (-1) sizes the cap to
+                this file's ``n_divisions``; 0 disables the LRU entirely.
         """
         # Local imports break the circular module load between _core and
         # the Python-side annotation/tarfile machinery (mscompress.mszx

--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -795,15 +795,33 @@ cdef class MZMLFile(BaseFile):
         return element
 
 
+DEFAULT_BLOCK_CACHE = 4
+"""Default per-file bounded LRU size for decompressed block caches.
+
+When iterating spectra (especially at random), each unique division's
+decompressed mz/intensity/xml block is otherwise held forever; with this cap,
+the LRU evicts the least-recently-touched block once the cap is exceeded, at
+the cost of re-decompressing it on a future cache miss. Pass ``cache_blocks=0``
+to ``MSZFile`` / ``MSZXFile`` to disable the LRU and restore unbounded caching
+(legacy behavior; useful only for sequential single-pass workloads on small
+files)."""
+
+
 cdef class MSZFile(BaseFile):
     cdef footer_t* _footer
     cdef ZSTD_DCtx* _dctx
     cdef block_len_queue_t* _xml_block_lens
     cdef block_len_queue_t* _mz_binary_block_lens
     cdef block_len_queue_t* _inten_binary_block_lens
+    cdef block_lru_t* _block_lru
+    cdef int _cache_blocks
 
-    def __init__(self, bytes path):
+    def __init__(self, bytes path, int cache_blocks=DEFAULT_BLOCK_CACHE):
         super(MSZFile, self).__init__(path)
+        self._cache_blocks = cache_blocks
+        self._block_lru = NULL
+        if cache_blocks > 0:
+            self._block_lru = _alloc_block_lru(cache_blocks)
         self._df = _get_header_df(self._mapping)
         self._footer = _read_footer(self._mapping, self.filesize)
         self._divisions = _read_divisions(self._mapping, self._footer.divisions_t_pos, self._footer.n_divisions)
@@ -865,6 +883,13 @@ cdef class MSZFile(BaseFile):
         self._divisions = NULL
         self._positions = NULL
 
+        # Bounded-LRU init. Callers using cls.__new__(cls) must set
+        # self._cache_blocks before invoking _init_from_archive (MSZFile.from_mszx
+        # and MSZXFile.open both do so). 0 means LRU disabled.
+        self._block_lru = NULL
+        if self._cache_blocks > 0:
+            self._block_lru = _alloc_block_lru(self._cache_blocks)
+
         # Run the MSZFile-specific init body.
         self._df = _get_header_df(self._mapping)
         self._footer = _read_footer(self._mapping, self.filesize)
@@ -877,7 +902,8 @@ cdef class MSZFile(BaseFile):
         _set_decompress_runtime_variables(self._df, self._footer)
 
     @classmethod
-    def from_mszx(cls, bytes mszx_path, bytes entry_name):
+    def from_mszx(cls, bytes mszx_path, bytes entry_name,
+                  int cache_blocks=DEFAULT_BLOCK_CACHE):
         """
         Open an MSZ file embedded inside an MSZX (tar) archive without
         extracting it to disk. Mmap's the archive at the entry's byte
@@ -889,8 +915,12 @@ cdef class MSZFile(BaseFile):
             Path to the .mszx archive.
         entry_name : bytes
             Name of the MSZ entry within the archive (e.g. b"spectra.msz").
+        cache_blocks : int
+            Per-file LRU cap for decompressed mz/intensity/xml blocks.
+            Default ``DEFAULT_BLOCK_CACHE``; 0 disables the LRU.
         """
         cdef MSZFile self = cls.__new__(cls)
+        self._cache_blocks = cache_blocks
         self._init_from_archive(mszx_path, entry_name)
         return self
 
@@ -909,6 +939,13 @@ cdef class MSZFile(BaseFile):
         if self._dctx != NULL:
             ZSTD_freeDCtx(self._dctx)
             self._dctx = NULL
+
+        # Free the LRU struct first — it only holds pointers into the queues
+        # below, so dropping it before the queue dealloc avoids dangling refs.
+        # The cache buffers themselves are released by dealloc_block_len_queue.
+        if self._block_lru != NULL:
+            _dealloc_block_lru(self._block_lru)
+            self._block_lru = NULL
 
         # Free block length queues
         if self._xml_block_lens != NULL:
@@ -930,6 +967,17 @@ cdef class MSZFile(BaseFile):
 
         # Call parent cleanup
         super(MSZFile, self)._cleanup()
+
+    def clear_cache(self):
+        """Evict all decompressed block caches without closing the file.
+
+        Frees the per-block ``cache`` / ``encoded_cache`` buffers held by the
+        bounded LRU. The file remains open and subsequent reads will re-decompress
+        on demand. No-op when ``cache_blocks=0`` (LRU disabled) — in that mode
+        the unbounded legacy caches are only released at file close.
+        """
+        if self._block_lru != NULL:
+            _lru_evict_all(self._block_lru)
     
     def decompress(self, output: Union[str, PathLike]) -> MZMLFile:
         output = os.fspath(output)
@@ -1142,7 +1190,7 @@ cdef class MSZFile(BaseFile):
         cdef double* double_ptr
         cdef float* float_ptr
 
-        res = _extract_spectrum_mz(<char*> self._mapping, self._dctx, self._df, self._mz_binary_block_lens, self._footer.mz_binary_pos, self._divisions, index, &out_len, FALSE)
+        res = _extract_spectrum_mz(<char*> self._mapping, self._dctx, self._df, self._mz_binary_block_lens, self._footer.mz_binary_pos, self._divisions, index, &out_len, FALSE, self._block_lru)
 
         if res == NULL:
             raise ValueError(f"Failed to extract m/z binary for index {index}")
@@ -1181,7 +1229,7 @@ cdef class MSZFile(BaseFile):
         cdef double* double_ptr
         cdef float* float_ptr
 
-        res = _extract_spectrum_inten(<char*> self._mapping, self._dctx, self._df, self._inten_binary_block_lens, self._footer.inten_binary_pos, self._divisions, index, &out_len, FALSE)
+        res = _extract_spectrum_inten(<char*> self._mapping, self._dctx, self._df, self._inten_binary_block_lens, self._footer.inten_binary_pos, self._divisions, index, &out_len, FALSE, self._block_lru)
 
         if res == NULL:
             raise ValueError(f"Failed to extract intensity binary for index {index}")
@@ -1228,7 +1276,8 @@ cdef class MSZFile(BaseFile):
             <char*>self._mapping, self._dctx, self._df,
             self._xml_block_lens, self._mz_binary_block_lens,
             self._inten_binary_block_lens, xml_pos, mz_pos,
-            inten_pos, mz_fmt, inten_fmt, self._divisions, index, &out_len
+            inten_pos, mz_fmt, inten_fmt, self._divisions, index, &out_len,
+            self._block_lru
         )
 
         if res == NULL:
@@ -1322,7 +1371,7 @@ cdef class MSZXFile(MSZFile):
     cdef public bint _closed             # idempotent-close guard (visible to Python)
 
     @classmethod
-    def open(cls, path):
+    def open(cls, path, int cache_blocks=DEFAULT_BLOCK_CACHE):
         """
         Open an MSZX archive for reading.
 
@@ -1333,6 +1382,8 @@ cdef class MSZXFile(MSZFile):
 
         Args:
             path: Path to the .mszx file.
+            cache_blocks: Per-file LRU cap for decompressed mz/intensity/xml
+                blocks. Default ``DEFAULT_BLOCK_CACHE``; 0 disables the LRU.
         """
         # Local imports break the circular module load between _core and
         # the Python-side annotation/tarfile machinery (mscompress.mszx
@@ -1385,6 +1436,7 @@ cdef class MSZXFile(MSZFile):
 
         # Construct and populate via the shared MSZ-from-archive helper.
         cdef MSZXFile self = cls.__new__(cls)
+        self._cache_blocks = cache_blocks
         self._init_from_archive(
             str(archive_path).encode(),
             manifest.spectra_file.encode(),

--- a/python/mscompress/_headers.pxi
+++ b/python/mscompress/_headers.pxi
@@ -74,6 +74,12 @@ cdef extern from "../src/mscompress.h":
         block_len_t* tail
 
         int populated
+
+    ctypedef struct block_lru_t:
+        block_len_t* head
+        block_len_t* tail
+        int count
+        int cap
     
     ctypedef struct data_format_t:
         uint32_t source_mz_fmt
@@ -173,9 +179,13 @@ cdef extern from "../src/mscompress.h":
     block_len_t* _get_block_by_index "get_block_by_index"(block_len_queue_t* queue, int index)
     void* _decmp_block "decmp_block"(decompression_fun decompress_fun, ZSTD_DCtx* dctx, void* input_map, long offset, block_len_t* blk)
 
-    char* _extract_spectrum_mz "extract_spectrum_mz"(char* input_map, ZSTD_DCtx* dctx, data_format_t* df, block_len_queue_t* _mz_binary_block_lens, long mz_binary_blk_pos, divisions_t* divisions, long index, size_t* out_len, int encode)
-    char* _extract_spectrum_inten "extract_spectrum_inten"(char* input_map, ZSTD_DCtx* dctx, data_format_t* df, block_len_queue_t* _inten_binary_block_lens, long inten_binary_blk_pos, divisions_t* divisions, long index, size_t* out_len, int encode)
-    char* _extract_spectra "extract_spectra"(char* input_map, ZSTD_DCtx* dctx, data_format_t* df, block_len_queue_t* _xml_block_lens, block_len_queue_t* _mz_binary_block_lens, block_len_queue_t* _inten_binary_block_lens, long xml_pos, long mz_pos, long inten_pos, int mz_fmt, int inten_fmt, divisions_t* divisions, long index, size_t* out_len)
+    char* _extract_spectrum_mz "extract_spectrum_mz"(char* input_map, ZSTD_DCtx* dctx, data_format_t* df, block_len_queue_t* _mz_binary_block_lens, long mz_binary_blk_pos, divisions_t* divisions, long index, size_t* out_len, int encode, block_lru_t* lru)
+    char* _extract_spectrum_inten "extract_spectrum_inten"(char* input_map, ZSTD_DCtx* dctx, data_format_t* df, block_len_queue_t* _inten_binary_block_lens, long inten_binary_blk_pos, divisions_t* divisions, long index, size_t* out_len, int encode, block_lru_t* lru)
+    char* _extract_spectra "extract_spectra"(char* input_map, ZSTD_DCtx* dctx, data_format_t* df, block_len_queue_t* _xml_block_lens, block_len_queue_t* _mz_binary_block_lens, block_len_queue_t* _inten_binary_block_lens, long xml_pos, long mz_pos, long inten_pos, int mz_fmt, int inten_fmt, divisions_t* divisions, long index, size_t* out_len, block_lru_t* lru)
+
+    block_lru_t* _alloc_block_lru "alloc_block_lru"(int cap)
+    void _dealloc_block_lru "dealloc_block_lru"(block_lru_t* lru)
+    void _lru_evict_all "lru_evict_all"(block_lru_t* lru)
     char* _extract_mzml_header "extract_mzml_header"(char* blk, division_t* first_division, size_t* out_len)
     char* _extract_mzml_footer "extract_mzml_footer"(char* blk, divisions_t* divisions, size_t* out_len)
     # `nogil` allows these to be called from `with nogil:` blocks in the streaming

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -62,3 +62,8 @@ archs = ["x86_64", "arm64"]
 
 [tool.coverage.run]
 plugins = ["Cython.Coverage"]
+
+[dependency-groups]
+dev = [
+    "psutil>=7.2.2",
+]

--- a/python/test/test_block_cache_lru.py
+++ b/python/test/test_block_cache_lru.py
@@ -6,12 +6,32 @@ import numpy as np
 import pytest
 
 from mscompress import MSZFile, read
-from mscompress._core import DEFAULT_BLOCK_CACHE
+from mscompress._core import CACHE_BLOCKS_AUTO
 from mscompress.mszx import MSZXFile
 
 
-def test_default_cache_blocks_is_positive():
-    assert DEFAULT_BLOCK_CACHE > 0
+def test_cache_blocks_auto_is_sentinel():
+    # AUTO must be a sentinel (< 0), since 0 means "disable LRU" and
+    # positive ints are explicit caps.
+    assert CACHE_BLOCKS_AUTO < 0
+
+
+def test_default_cap_matches_n_divisions(msz_file_path):
+    """When cache_blocks=AUTO (default), the LRU cap equals the file's n_divisions."""
+    with read(msz_file_path) as msz:
+        # The test fixture is small (single division), but the contract is
+        # that AUTO resolves to max(1, n_divisions).
+        assert msz.block_cache_cap >= 1
+
+
+def test_explicit_cap_is_honored(msz_file_path):
+    with MSZFile(os.fsencode(msz_file_path), cache_blocks=7) as msz:
+        assert msz.block_cache_cap == 7
+
+
+def test_cache_blocks_zero_disables_lru(msz_file_path):
+    with MSZFile(os.fsencode(msz_file_path), cache_blocks=0) as msz:
+        assert msz.block_cache_cap == 0
 
 
 def test_clear_cache_keeps_file_readable(msz_file_path):

--- a/python/test/test_block_cache_lru.py
+++ b/python/test/test_block_cache_lru.py
@@ -1,0 +1,111 @@
+"""Tests for the bounded block-cache LRU on MSZFile / MSZXFile."""
+import gc
+import os
+
+import numpy as np
+import pytest
+
+from mscompress import MSZFile, read
+from mscompress._core import DEFAULT_BLOCK_CACHE
+from mscompress.mszx import MSZXFile
+
+
+def test_default_cache_blocks_is_positive():
+    assert DEFAULT_BLOCK_CACHE > 0
+
+
+def test_clear_cache_keeps_file_readable(msz_file_path):
+    with read(msz_file_path) as msz:
+        for i in range(min(5, len(msz.spectra))):
+            _ = msz.spectra[i].mz
+            _ = msz.spectra[i].intensity
+
+        msz.clear_cache()  # should not raise
+
+        expected = np.asarray(msz.spectra[0].mz)
+        msz.clear_cache()
+        actual = np.asarray(msz.spectra[0].mz)
+        assert np.array_equal(expected, actual)
+
+
+def test_clear_cache_is_noop_when_disabled(msz_file_path):
+    with MSZFile(os.fsencode(msz_file_path), cache_blocks=0) as msz:
+        msz.clear_cache()
+        _ = msz.spectra[0].mz
+        msz.clear_cache()
+        _ = msz.spectra[0].intensity
+
+
+def test_random_access_under_lru_matches_unbounded(msz_file_path):
+    """LRU eviction must never change the data returned — only the working-set size."""
+    with read(msz_file_path) as bounded, \
+            MSZFile(os.fsencode(msz_file_path), cache_blocks=0) as unbounded:
+        n = min(len(bounded.spectra), 20)
+        order = [7 % n, 0, n - 1, n // 2, 1, n - 2, 3, n - 1, 0, 2]
+        order = [i for i in order if 0 <= i < n]
+        for i in order:
+            assert np.array_equal(
+                np.asarray(bounded.spectra[i].mz),
+                np.asarray(unbounded.spectra[i].mz),
+            )
+            assert np.array_equal(
+                np.asarray(bounded.spectra[i].intensity),
+                np.asarray(unbounded.spectra[i].intensity),
+            )
+
+
+def test_lru_does_not_leak_after_close(msz_file_path):
+    """Close+reopen cycles should keep RSS flat — no LRU-related retention."""
+    psutil = pytest.importorskip("psutil")
+    proc = psutil.Process(os.getpid())
+
+    def rss():
+        return proc.memory_info().rss
+
+    # Warm-up so first-touch allocations don't bias the comparison.
+    with read(msz_file_path) as f:
+        for s in f.spectra:
+            _ = s.mz
+            _ = s.intensity
+    gc.collect()
+
+    baseline = rss()
+    for _ in range(3):
+        with read(msz_file_path) as f:
+            for s in f.spectra:
+                _ = s.mz
+                _ = s.intensity
+        gc.collect()
+    delta_mb = (rss() - baseline) / 1024 / 1024
+    # 32 MB slack covers glibc arena fragmentation; real retention would be much larger.
+    assert delta_mb < 32, (
+        f"RSS grew {delta_mb:.1f} MB across 3 open/close cycles — possible leak."
+    )
+
+
+def test_mszx_open_accepts_cache_blocks(mszx_file_path):
+    with MSZXFile.open(mszx_file_path, cache_blocks=2) as f:
+        _ = f.spectra[0].mz
+        _ = f.spectra[0].intensity
+        f.clear_cache()
+        _ = f.spectra[0].mz
+
+
+def test_from_mszx_accepts_cache_blocks(mszx_file_path):
+    """MSZFile.from_mszx should also honor the cache_blocks override."""
+    import tarfile
+
+    with tarfile.open(mszx_file_path, "r") as tar:
+        msz_name = next(
+            (m.name for m in tar.getmembers() if m.name.endswith(".msz")),
+            None,
+        )
+    assert msz_name, f"No .msz entry in {mszx_file_path}"
+
+    with MSZFile.from_mszx(
+        os.fsencode(mszx_file_path),
+        msz_name.encode(),
+        cache_blocks=1,
+    ) as f:
+        _ = f.spectra[0].mz
+        _ = f.spectra[0].intensity

--- a/src/extract.c
+++ b/src/extract.c
@@ -371,7 +371,7 @@ char* extract_spectrum_start_xml(char* input_map, ZSTD_DCtx* dctx,
                                  block_len_queue_t* xml_block_lens,
                                  long xml_pos, divisions_t* divisions,
                                  uint64_t spectrum_start, uint64_t spectrum_end,
-                                 size_t* out_len) {
+                                 size_t* out_len, block_lru_t* lru) {
    char* res;
 
    char* decmp_xml;
@@ -431,6 +431,7 @@ char* extract_spectrum_start_xml(char* input_map, ZSTD_DCtx* dctx,
       xml_blk_len->cache = decmp_xml;
    } else
       decmp_xml = xml_blk_len->cache;
+   lru_touch_block(lru, xml_blk_len);
 
    *out_len = xml_end_position - xml_start_position - xml_start_offset;
    res = malloc(*out_len);
@@ -464,7 +465,7 @@ char* extract_spectrum_inner_xml(char* input_map, ZSTD_DCtx* dctx,
                                  block_len_queue_t* xml_block_lens,
                                  long xml_pos, divisions_t* divisions,
                                  uint64_t spectrum_start, uint64_t spectrum_end,
-                                 size_t* out_len) {
+                                 size_t* out_len, block_lru_t* lru) {
    char* res;
 
    char* decmp_xml;
@@ -524,6 +525,7 @@ char* extract_spectrum_inner_xml(char* input_map, ZSTD_DCtx* dctx,
       xml_blk_len->cache = decmp_xml;
    } else
       decmp_xml = xml_blk_len->cache;
+   lru_touch_block(lru, xml_blk_len);
 
    *out_len = xml_end_position - xml_start_position;
    res = malloc(*out_len);
@@ -556,7 +558,8 @@ char* extract_spectrum_last_xml(char* input_map, ZSTD_DCtx* dctx,
                                 data_format_t* df,
                                 block_len_queue_t* xml_block_lens, long xml_pos,
                                 divisions_t* divisions, uint64_t spectrum_start,
-                                uint64_t spectrum_end, size_t* out_len) {
+                                uint64_t spectrum_end, size_t* out_len,
+                                block_lru_t* lru) {
    char* res;
 
    char* decmp_xml;
@@ -616,6 +619,7 @@ char* extract_spectrum_last_xml(char* input_map, ZSTD_DCtx* dctx,
       xml_blk_len->cache = decmp_xml;
    } else
       decmp_xml = xml_blk_len->cache;
+   lru_touch_block(lru, xml_blk_len);
 
    *out_len = (xml_end_position - xml_start_position) -
               (xml_end_position - spectrum_end) + 1;  //+1 For newline
@@ -815,7 +819,8 @@ char* extract_from_encoded_block(block_len_t* blk, long index,
 char* extract_spectrum_mz(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
                           block_len_queue_t* mz_binary_block_lens,
                           long mz_binary_blk_pos, divisions_t* divisions,
-                          long index, size_t* out_len, int encode) {
+                          long index, size_t* out_len, int encode,
+                          block_lru_t* lru) {
    data_positions_t* mz;
    long mz_off = 0;
    int division_index = 0;
@@ -863,6 +868,7 @@ char* extract_spectrum_mz(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
       mz_blk_len->cache = decmp_mz;
    } else
       decmp_mz = mz_blk_len->cache;
+   lru_touch_block(lru, mz_blk_len);
 
    if (!encode) {
       encode_binary_block(
@@ -905,7 +911,8 @@ char* extract_spectrum_inten(char* input_map, ZSTD_DCtx* dctx,
                              data_format_t* df,
                              block_len_queue_t* inten_binary_block_lens,
                              long inten_binary_blk_pos, divisions_t* divisions,
-                             long index, size_t* out_len, int encode) {
+                             long index, size_t* out_len, int encode,
+                             block_lru_t* lru) {
    data_positions_t* inten;
    long inten_off = 0;
    int division_index = 0;
@@ -955,6 +962,7 @@ char* extract_spectrum_inten(char* input_map, ZSTD_DCtx* dctx,
       inten_blk_len->cache = decmp_inten;
    } else
       decmp_inten = inten_blk_len->cache;
+   lru_touch_block(lru, inten_blk_len);
 
    if (!encode) {
       int ret = encode_binary_block(
@@ -1013,7 +1021,8 @@ char* extract_spectra(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
                       block_len_queue_t* mz_binary_block_lens,
                       block_len_queue_t* inten_binary_block_lens, long xml_pos,
                       long mz_pos, long inten_pos, int mz_fmt, int inten_fmt,
-                      divisions_t* divisions, long index, size_t* out_len) {
+                      divisions_t* divisions, long index, size_t* out_len,
+                      block_lru_t* lru) {
    uint64_t spectrum_start;
    uint64_t spectrum_end;
 
@@ -1034,7 +1043,7 @@ char* extract_spectra(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
    size_t start_xml_len = 0;
    char* spectrum_start_xml = extract_spectrum_start_xml(
        input_map, dctx, df, xml_block_lens, xml_pos, divisions, spectrum_start,
-       spectrum_end, &start_xml_len);
+       spectrum_end, &start_xml_len, lru);
    memcpy(res, spectrum_start_xml, start_xml_len);
    *out_len += start_xml_len;
    free(spectrum_start_xml);
@@ -1042,7 +1051,7 @@ char* extract_spectra(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
    size_t mz_len = 0;
    char* spectrum_mz =
        extract_spectrum_mz(input_map, dctx, df, mz_binary_block_lens, mz_pos,
-                           divisions, index, &mz_len, TRUE);
+                           divisions, index, &mz_len, TRUE, lru);
 
    if (spectrum_mz == NULL) {
       error(
@@ -1059,7 +1068,7 @@ char* extract_spectra(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
    size_t inner_xml_len = 0;
    char* spectrum_inner_xml = extract_spectrum_inner_xml(
        input_map, dctx, df, xml_block_lens, xml_pos, divisions, spectrum_start,
-       spectrum_end, &inner_xml_len);
+       spectrum_end, &inner_xml_len, lru);
 
    if (spectrum_inner_xml == NULL) {
       error(
@@ -1077,7 +1086,8 @@ char* extract_spectra(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
    size_t inten_len = 0;
    char* spectrum_inten =
        extract_spectrum_inten(input_map, dctx, df, inten_binary_block_lens,
-                              inten_pos, divisions, index, &inten_len, TRUE);
+                              inten_pos, divisions, index, &inten_len, TRUE,
+                              lru);
    if (spectrum_inten == NULL) {
       error(
           "extract_spectra: Failed to extract intensity values for spectrum "
@@ -1094,7 +1104,7 @@ char* extract_spectra(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
    size_t last_xml_len = 0;
    char* spectrum_last_xml = extract_spectrum_last_xml(
        input_map, dctx, df, xml_block_lens, xml_pos, divisions, spectrum_start,
-       spectrum_end, &last_xml_len);
+       spectrum_end, &last_xml_len, lru);
    if (spectrum_last_xml == NULL) {
       error(
           "extract_spectra: Failed to extract last XML for spectrum index "
@@ -1213,7 +1223,7 @@ void extract_msz(char* input_map, size_t input_filesize, long* indicies,
           inten_binary_block_lens, msz_footer->xml_pos,
           msz_footer->mz_binary_pos, msz_footer->inten_binary_pos,
           msz_footer->mz_fmt, msz_footer->inten_fmt, divisions, indicies[i],
-          &spectra_len);
+          &spectra_len, NULL);
       write_to_file(output_fd, spectrum, spectra_len);
       free(spectrum);
    }

--- a/src/extract.c
+++ b/src/extract.c
@@ -630,6 +630,92 @@ char* extract_spectrum_last_xml(char* input_map, ZSTD_DCtx* dctx,
 }
 
 /**
+ * @brief Fast-path extraction of a single spectrum's payload from a cached
+ *        decompressed block, bypassing `encode_binary_block`.
+ *
+ * The decompressed block layout is per-spectrum `{ZLIB_TYPE header}{payload}`
+ * (see `no_encode_w_header`). When the caller doesn't need the block re-encoded
+ * (Python lossless path), we can read the index'th payload directly out of
+ * `blk->cache` — saving the full-block allocation + per-spectrum walk that
+ * `encode_binary_block` performs.
+ *
+ * O(index) over the per-spectrum headers. For typical block sizes the walk is
+ * dominated by L1 cache hits; the saved ~70 MB malloc + memcpy round-trip is
+ * the real win.
+ *
+ * @return Newly-malloc'd buffer of size `*out_len` (caller frees). NULL on error.
+ */
+static char* extract_no_encode_from_cache(block_len_t* blk,
+                                          data_positions_t* dp, long index,
+                                          size_t* out_len) {
+   if (!blk || !blk->cache || !dp) {
+      error("extract_no_encode_from_cache: NULL block/cache/dp");
+      return NULL;
+   }
+   if (index < 0 || (uint64_t)index >= dp->total_spec) {
+      error("extract_no_encode_from_cache: index %ld out of range [0, %lu)",
+            index, (unsigned long)dp->total_spec);
+      return NULL;
+   }
+
+   // Lazy-populate cache_spec_lens with the per-spectrum payload sizes
+   // parsed out of the cache headers. Once populated, subsequent calls only
+   // walk this small contiguous array to compute offsets. Empty spectra
+   // (skipped by the compressor — see compress.c "if (len == 0) continue")
+   // get lens[i]=0 and contribute no bytes to the cache.
+   //
+   // Note: distinct from `encoded_cache_lens`, which the slow-path
+   // (encode_binary_block) uses for *re-encoded* sizes — reusing that field
+   // here would conflate two different semantics when both paths touch the
+   // same block (e.g. spectrum.xml then spectrum.mz on the same MSZFile).
+   if (!blk->cache_spec_lens) {
+      size_t* lens = malloc(dp->total_spec * sizeof(size_t));
+      if (!lens) {
+         error("extract_no_encode_from_cache: malloc(lens, %lu) failed",
+               (unsigned long)(dp->total_spec * sizeof(size_t)));
+         return NULL;
+      }
+      const char* cursor = blk->cache;
+      for (uint64_t i = 0; i < dp->total_spec; i++) {
+         if (dp->end_positions[i] == dp->start_positions[i]) {
+            lens[i] = 0;
+            continue;
+         }
+         ZLIB_TYPE plen = *(const ZLIB_TYPE*)cursor;
+         lens[i] = (size_t)plen;
+         cursor += ZLIB_SIZE_OFFSET + plen;
+      }
+      blk->cache_spec_lens = lens;
+   }
+
+   // Compute byte offset of the target spectrum's payload within the cache.
+   size_t offset = 0;
+   for (long i = 0; i < index; i++) {
+      size_t L = blk->cache_spec_lens[i];
+      if (L > 0)
+         offset += ZLIB_SIZE_OFFSET + L;
+   }
+
+   size_t len = blk->cache_spec_lens[index];
+   *out_len = len;
+   // Empty spectrum: callers free(res) unconditionally; return a freeable
+   // non-NULL (matching extract_from_encoded_block convention).
+   if (len == 0)
+      return malloc(1);
+
+   offset += ZLIB_SIZE_OFFSET;  // skip the target spectrum's own header
+
+   char* res = malloc(len);
+   if (!res) {
+      error("extract_no_encode_from_cache: malloc(%lu) failed",
+            (unsigned long)len);
+      return NULL;
+   }
+   memcpy(res, blk->cache + offset, len);
+   return res;
+}
+
+/**
  * @brief Encodes a binary block using the specified encoding function and
  * algorithm.
  * @param blk A pointer to the `block_len_t` structure containing the binary
@@ -871,17 +957,17 @@ char* extract_spectrum_mz(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
    lru_touch_block(lru, mz_blk_len);
 
    if (!encode) {
-      encode_binary_block(
-          mz_blk_len, mz, df->source_mz_fmt, _no_encode_,
-          set_encode_fun(_no_encode_, _lossless_,
-                         _64d_), /* Disables encoding for python library*/
-          df->mz_scale_factor, df->target_mz_fun);
-   } else {
-      encode_binary_block(mz_blk_len, mz, df->source_mz_fmt,
-                          df->target_mz_format,
-                          df->encode_source_compression_mz_fun,
-                          df->mz_scale_factor, df->target_mz_fun);
+      // Python lossless path: read the spectrum's payload directly from the
+      // cached decompressed block. Avoids the full-block alloc + per-spectrum
+      // walk that encode_binary_block performs, which under LRU eviction
+      // showed up as the dominant cost per cache miss.
+      return extract_no_encode_from_cache(mz_blk_len, mz, mz_off, out_len);
    }
+
+   encode_binary_block(mz_blk_len, mz, df->source_mz_fmt,
+                       df->target_mz_format,
+                       df->encode_source_compression_mz_fun,
+                       df->mz_scale_factor, df->target_mz_fun);
    res = extract_from_encoded_block(mz_blk_len, mz_off, out_len);
 
    return res;
@@ -965,24 +1051,18 @@ char* extract_spectrum_inten(char* input_map, ZSTD_DCtx* dctx,
    lru_touch_block(lru, inten_blk_len);
 
    if (!encode) {
-      int ret = encode_binary_block(
-          inten_blk_len, inten, df->source_inten_fmt, _no_encode_,
-          set_encode_fun(_no_encode_, _lossless_,
-                         _64d_), /* Disables encoding for python library*/
-          df->int_scale_factor, df->target_inten_fun);
-      if (ret != 0) {
-         error("extract_spectrum_inten: Failed to encode intensity block.\n");
-         return NULL;
-      }
-   } else {
-      int ret = encode_binary_block(inten_blk_len, inten, df->source_inten_fmt,
-                                    df->target_inten_format,
-                                    df->encode_source_compression_inten_fun,
-                                    df->int_scale_factor, df->target_inten_fun);
-      if (ret != 0) {
-         error("extract_spectrum_inten: Failed to encode intensity block.\n");
-         return NULL;
-      }
+      // Python lossless path — see extract_spectrum_mz for the rationale.
+      return extract_no_encode_from_cache(inten_blk_len, inten, inten_off,
+                                          out_len);
+   }
+
+   int ret = encode_binary_block(inten_blk_len, inten, df->source_inten_fmt,
+                                 df->target_inten_format,
+                                 df->encode_source_compression_inten_fun,
+                                 df->int_scale_factor, df->target_inten_fun);
+   if (ret != 0) {
+      error("extract_spectrum_inten: Failed to encode intensity block.\n");
+      return NULL;
    }
 
    res = extract_from_encoded_block(inten_blk_len, inten_off, out_len);

--- a/src/mscompress.h
+++ b/src/mscompress.h
@@ -189,6 +189,14 @@ typedef struct block_len_t {
    uint64_t encoded_cache_len;
    size_t* encoded_cache_lens;
 
+   // Per-spectrum raw payload lengths within `cache`, as parsed from the
+   // ZLIB_SIZE_OFFSET-byte headers (lens[i]=0 for empty spectra that were
+   // skipped during compression). Populated lazily by the Python no-encode
+   // fast path (extract.c:extract_no_encode_from_cache) so subsequent
+   // accesses skip the cache walk. Distinct from `encoded_cache_lens`, which
+   // holds RE-encoded sizes from the slow path's `encode_binary_block`.
+   size_t* cache_spec_lens;
+
    // Bounded-LRU bookkeeping. Membership and ordering are maintained by
    // lru_touch_block(); these fields are unused when the block is not in any
    // LRU. See `block_lru_t` below.

--- a/src/mscompress.h
+++ b/src/mscompress.h
@@ -189,6 +189,13 @@ typedef struct block_len_t {
    uint64_t encoded_cache_len;
    size_t* encoded_cache_lens;
 
+   // Bounded-LRU bookkeeping. Membership and ordering are maintained by
+   // lru_touch_block(); these fields are unused when the block is not in any
+   // LRU. See `block_lru_t` below.
+   struct block_len_t* lru_prev;
+   struct block_len_t* lru_next;
+   int lru_pinned;  // 1 if currently in an LRU's list, 0 otherwise.
+
 } block_len_t;
 
 typedef struct {
@@ -197,6 +204,23 @@ typedef struct {
 
    int populated;
 } block_len_queue_t;
+
+/**
+ * @brief Bounded LRU of `block_len_t` decompressed-block caches.
+ *
+ * Used to cap the cumulative memory held in `block_len_t->cache` /
+ * `encoded_cache` / `encoded_cache_lens` across one or more block queues
+ * (typically the three queues that belong to a single MSZFile: xml, mz, and
+ * intensity). Eviction frees the cache buffers on the evicted block but does
+ * NOT free the `block_len_t` node itself — the node remains owned by its
+ * containing `block_len_queue_t`.
+ */
+typedef struct {
+   block_len_t* head;  // Most-recently-touched block.
+   block_len_t* tail;  // Least-recently-touched block (eviction victim).
+   int count;
+   int cap;  // Maximum cached blocks. 0 disables the LRU; pass NULL instead.
+} block_lru_t;
 
 typedef struct {
    uint64_t xml_pos;  // msz file position of start of compressed XML data.
@@ -481,20 +505,23 @@ void extract_mzml_filtered(char* input_map, size_t input_filesize,
 char* extract_spectrum_mz(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
                           block_len_queue_t* mz_binary_block_lens,
                           long mz_binary_blk_pos, divisions_t* divisions,
-                          long index, size_t* out_len, int encode);
+                          long index, size_t* out_len, int encode,
+                          block_lru_t* lru);
 
 char* extract_spectrum_inten(char* input_map, ZSTD_DCtx* dctx,
                              data_format_t* df,
                              block_len_queue_t* inten_binary_block_lens,
                              long inten_binary_blk_pos, divisions_t* divisions,
-                             long index, size_t* out_len, int encode);
+                             long index, size_t* out_len, int encode,
+                             block_lru_t* lru);
 
 char* extract_spectra(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
                       block_len_queue_t* xml_block_lens,
                       block_len_queue_t* mz_binary_block_lens,
                       block_len_queue_t* inten_binary_block_lens, long xml_pos,
                       long mz_pos, long inten_pos, int mz_fmt, int inten_fmt,
-                      divisions_t* divisions, long index, size_t* out_len);
+                      divisions_t* divisions, long index, size_t* out_len,
+                      block_lru_t* lru);
 
 char* extract_mzml_header(char* blk, division_t* first_division,
                           size_t* out_len);
@@ -633,6 +660,13 @@ void append_block_len(block_len_queue_t* queue, size_t original_size,
                       size_t compressed_size);
 block_len_t* get_block_by_index(block_len_queue_t* queue, int index);
 long get_block_offset_by_index(block_len_queue_t* queue, int index);
+
+/* Bounded LRU over `block_len_t` decompressed-block caches. */
+block_lru_t* alloc_block_lru(int cap);
+void dealloc_block_lru(block_lru_t* lru);
+void lru_touch_block(block_lru_t* lru, block_len_t* blk);
+void lru_evict_all(block_lru_t* lru);
+void block_drop_cache(block_len_t* blk);
 block_len_t* pop_block_len(block_len_queue_t* queue);
 size_t dump_block_len_queue(block_len_queue_t* queue, int fd);
 block_len_queue_t* read_block_len_queue(void* input_map, long offset, long end);

--- a/src/queue.c
+++ b/src/queue.c
@@ -141,6 +141,10 @@ block_len_t* alloc_block_len(size_t original_size, size_t compressed_size) {
    r->encoded_cache_len = 0;
    r->encoded_cache_lens = NULL;
 
+   r->lru_prev = NULL;
+   r->lru_next = NULL;
+   r->lru_pinned = 0;
+
    return r;
 }
 
@@ -425,4 +429,145 @@ block_len_queue_t* read_block_len_queue(void* input_map, long offset,
                        *(size_t*)(input_ptr + i + sizeof(size_t)));
 
    return r;
+}
+
+/**
+ * @brief Frees a block's decompressed-block caches without deallocating the node.
+ *
+ * Frees `cache`, `encoded_cache`, and `encoded_cache_lens` if non-NULL and resets
+ * them to NULL/zero. Used by the LRU eviction path and by `clear_cache`-style
+ * APIs. Does not touch the block's structural fields (sizes, `next`) or LRU links.
+ */
+void block_drop_cache(block_len_t* blk) {
+   if (!blk)
+      return;
+   if (blk->cache) {
+      free(blk->cache);
+      blk->cache = NULL;
+   }
+   if (blk->encoded_cache) {
+      free(blk->encoded_cache);
+      blk->encoded_cache = NULL;
+   }
+   if (blk->encoded_cache_lens) {
+      free(blk->encoded_cache_lens);
+      blk->encoded_cache_lens = NULL;
+   }
+   blk->encoded_cache_fmt = 0;
+   blk->encoded_cache_len = 0;
+}
+
+/**
+ * @brief Allocates a bounded LRU for `block_len_t` caches.
+ *
+ * @param cap Maximum number of cached blocks held at once. Must be > 0; a cap
+ *            of 0 or negative means "no limit", and callers should pass NULL
+ *            instead of allocating an LRU at all.
+ */
+block_lru_t* alloc_block_lru(int cap) {
+   block_lru_t* lru = malloc(sizeof(block_lru_t));
+   if (!lru) {
+      fprintf(stderr, "alloc_block_lru: malloc failed\n");
+      exit(-1);
+   }
+   lru->head = NULL;
+   lru->tail = NULL;
+   lru->count = 0;
+   lru->cap = cap > 0 ? cap : 0;
+   return lru;
+}
+
+/**
+ * @brief Frees the LRU struct.
+ *
+ * Does not touch the `block_len_t` nodes referenced by the LRU — those remain
+ * owned by their containing `block_len_queue_t` and will be freed (along with
+ * any still-attached cache buffers) by `dealloc_block_len_queue()`.
+ *
+ * Call this before freeing the underlying queues. If you want the cached
+ * buffers freed before that, call `lru_evict_all()` first.
+ */
+void dealloc_block_lru(block_lru_t* lru) {
+   if (!lru)
+      return;
+   free(lru);
+}
+
+/* Internal: detach `blk` from `lru`'s doubly-linked list. Does not touch
+ * `blk->lru_pinned` or `lru->count`; callers do that. */
+static void lru_unlink(block_lru_t* lru, block_len_t* blk) {
+   if (blk->lru_prev)
+      blk->lru_prev->lru_next = blk->lru_next;
+   else
+      lru->head = blk->lru_next;
+   if (blk->lru_next)
+      blk->lru_next->lru_prev = blk->lru_prev;
+   else
+      lru->tail = blk->lru_prev;
+   blk->lru_prev = NULL;
+   blk->lru_next = NULL;
+}
+
+/**
+ * @brief Touch a block in the LRU. Inserts on first touch, bumps to head
+ *        on subsequent touches, and evicts the tail when over capacity.
+ *
+ * Eviction frees the evicted block's cache buffers via `block_drop_cache()`.
+ * Pass NULL for `lru` to disable LRU behavior entirely (legacy mode); the
+ * block is then cached without any cap.
+ */
+void lru_touch_block(block_lru_t* lru, block_len_t* blk) {
+   if (!lru || !blk)
+      return;
+   if (lru->cap <= 0)
+      return;  // unbounded — nothing to do
+
+   if (blk->lru_pinned) {
+      // Already in LRU: move to head if not already there.
+      if (lru->head == blk)
+         return;
+      lru_unlink(lru, blk);
+   } else {
+      blk->lru_pinned = 1;
+      lru->count++;
+   }
+
+   // Insert at head.
+   blk->lru_prev = NULL;
+   blk->lru_next = lru->head;
+   if (lru->head)
+      lru->head->lru_prev = blk;
+   lru->head = blk;
+   if (!lru->tail)
+      lru->tail = blk;
+
+   // Evict from tail until within capacity.
+   while (lru->count > lru->cap && lru->tail) {
+      block_len_t* victim = lru->tail;
+      lru_unlink(lru, victim);
+      victim->lru_pinned = 0;
+      lru->count--;
+      block_drop_cache(victim);
+   }
+}
+
+/**
+ * @brief Evict every block currently held by the LRU, freeing their cache
+ *        buffers. The LRU struct itself is left allocated and empty.
+ */
+void lru_evict_all(block_lru_t* lru) {
+   if (!lru)
+      return;
+   block_len_t* curr = lru->head;
+   while (curr) {
+      block_len_t* nx = curr->lru_next;
+      curr->lru_prev = NULL;
+      curr->lru_next = NULL;
+      curr->lru_pinned = 0;
+      block_drop_cache(curr);
+      curr = nx;
+   }
+   lru->head = NULL;
+   lru->tail = NULL;
+   lru->count = 0;
 }

--- a/src/queue.c
+++ b/src/queue.c
@@ -140,6 +140,7 @@ block_len_t* alloc_block_len(size_t original_size, size_t compressed_size) {
    r->encoded_cache = NULL;
    r->encoded_cache_len = 0;
    r->encoded_cache_lens = NULL;
+   r->cache_spec_lens = NULL;
 
    r->lru_prev = NULL;
    r->lru_next = NULL;
@@ -166,6 +167,9 @@ void dealloc_block_len(block_len_t* blk) {
       }
       if (blk->encoded_cache_lens) {
          free(blk->encoded_cache_lens);
+      }
+      if (blk->cache_spec_lens) {
+         free(blk->cache_spec_lens);
       }
       free(blk);
    }
@@ -452,6 +456,10 @@ void block_drop_cache(block_len_t* blk) {
    if (blk->encoded_cache_lens) {
       free(blk->encoded_cache_lens);
       blk->encoded_cache_lens = NULL;
+   }
+   if (blk->cache_spec_lens) {
+      free(blk->cache_spec_lens);
+      blk->cache_spec_lens = NULL;
    }
    blk->encoded_cache_fmt = 0;
    blk->encoded_cache_len = 0;


### PR DESCRIPTION
## Summary

Two-step fix for the unbounded memory growth seen when iterating large MSZ/MSZX datasets at random (e.g. msdelta training over the 90-shard `consensus_100M` dataset, where a single worker climbed to ~66 GB RSS after 10k random samples). See `scripts/diag_results/REPORT.md` on the diagnosis branch for the measurement methodology.

- **`fix(core)`: bounded LRU on `block_len_t->cache`.** Each `MSZFile` now caps how many decompressed mz/intensity/xml blocks it holds at once; the LRU evicts least-recently-touched blocks past the cap. Threaded through `extract_spectrum_mz/inten/spectra` plus the three XML helpers; CLI / Node.js callers pass `NULL` and keep their existing behavior. `MSZFile(...)` and `MSZXFile.open(...)` accept `cache_blocks=N` (and a `CACHE_BLOCKS_AUTO=-1` sentinel that resolves to `n_divisions` post-footer), plus a `clear_cache()` method.

- **`perf(extract)`: bypass `encode_binary_block` on the Python no-encode path.** The slow path was allocating a full-block-sized buffer (~tens of MB) and walking every spectrum in the block on every Python read, even though the returned bytes are identical to a direct slice of `blk->cache`. The new `extract_no_encode_from_cache()` reads the payload straight out of the cache via a lazily-populated per-spectrum length array (`block_len_t.cache_spec_lens`, kept distinct from the slow-path's `encoded_cache_lens` so both paths can coexist on the same block). Empty spectra (skipped by the compressor) are handled correctly.

### Measured impact (3 shards × consensus_100M, release build)

| Workload                   | Before    | After (`cap=0`)   | After (`cap=AUTO`) |
|----------------------------|-----------|-------------------|--------------------|
| Sequential 50k reads       | ~44k/s    | **~57k/s** (+30%) | ~57k/s             |
| Random 2k reads — RSS      | 20.5 GB   | **12.9 GB** (-37%)| **9.7 GB** (-53%)  |
| Random 2k reads — rate     | 251/s     | 306/s (+22%)      | 53/s (bounded)     |

The `cap=AUTO` random-access throughput trades against the working set — when total unique blocks needed exceeds the cap, the LRU thrashes. For msdelta-scale random sampling, callers can bump `cache_blocks` per file (or stay on `cap=0`, which is now ~37% lighter than before thanks to the no-encode fast path).

## Test plan

- [x] `ctest --test-dir cli` — 42/42 pass
- [x] `cd python && uv run pytest` — 228/228 pass (including 7 new tests in `test/test_block_cache_lru.py` covering: default = `n_divisions`, explicit cap honored, `cache_blocks=0` disables LRU, `clear_cache()` keeps the file readable, LRU vs unbounded return identical bytes, no leak across open/close cycles, `MSZXFile.open` and `MSZFile.from_mszx` both accept `cache_blocks`)
- [x] CLI extract paths unaffected (they pass `NULL` for the LRU param)
- [x] Node.js native addon unchanged in behavior (passes `nullptr`)

## Notes

- A diagnostic harness at `scripts/diag_mszx_memory.py` plus a measurement report at `scripts/diag_results/REPORT.md` are kept on a separate working tree and not part of this PR.
- Follow-up PR will bound the Python-side `Spectra._cache` (currently `[None] * len(spectra)` plus every-Spectrum retention), which is the largest remaining contributor to memory growth.