### PR TITLE
perf(extract): no-encode fast path for Python lossless reads

### DIFF
--- a/python/test/test_no_encode_fastpath.py
+++ b/python/test/test_no_encode_fastpath.py
@@ -1,0 +1,93 @@
+"""
+Coverage for the no-encode fast path (extract_no_encode_from_cache).
+
+The Python lossless read path (`.mz` / `.intensity`, encode=FALSE) slices the
+spectrum payload straight out of the decompressed block cache instead of going
+through `encode_binary_block`. These tests lock in that the fast path returns
+bytes identical to the original mzML for a lossless .msz, across a full block
+sweep and on repeated (cache-hit) access.
+"""
+import os
+
+import numpy as np
+import pytest
+
+from mscompress import read
+
+SRC = os.path.join(os.path.dirname(__file__), "..", "..", "test", "data", "test.mzML")
+
+
+@pytest.fixture(scope="module")
+def ground_truth():
+    with read(SRC) as f:
+        sp = f.spectra
+        return [
+            (np.asarray(sp[i].mz).copy(), np.asarray(sp[i].intensity).copy())
+            for i in range(len(sp))
+        ]
+
+
+@pytest.fixture()
+def lossless_msz(tmp_path):
+    out = tmp_path / "lossless.msz"
+    with read(SRC) as f:
+        f.compress(str(out))
+    return str(out)
+
+
+def test_fastpath_lossless_exact(lossless_msz, ground_truth):
+    """Every spectrum's mz/intensity read via the fast path is byte-exact."""
+    with read(lossless_msz) as f:
+        sp = f.spectra
+        assert len(sp) == len(ground_truth)
+        for i, (mz0, in0) in enumerate(ground_truth):
+            mz1 = np.asarray(sp[i].mz)
+            in1 = np.asarray(sp[i].intensity)
+            assert mz1.shape == mz0.shape, f"mz shape mismatch at {i}"
+            assert in1.shape == in0.shape, f"intensity shape mismatch at {i}"
+            assert np.array_equal(mz1, mz0), f"mz bytes differ at {i}"
+            assert np.array_equal(in1, in0), f"intensity bytes differ at {i}"
+
+
+def test_fastpath_repeated_access_stable(lossless_msz, ground_truth):
+    """Re-reading the same spectrum (cache hit, lazily-built cache_spec_lens)
+    returns identical bytes each time."""
+    with read(lossless_msz) as f:
+        sp = f.spectra
+        for i in (0, 1, len(ground_truth) // 2, len(ground_truth) - 1):
+            first = np.asarray(sp[i].mz).copy()
+            for _ in range(3):
+                assert np.array_equal(np.asarray(sp[i].mz), first)
+
+
+def test_fastpath_matches_slow_path(lossless_msz, ground_truth):
+    """The fast path (.mz, encode=FALSE) agrees with the slow encode path that
+    backs full-spectrum extraction (get_spectrum / decompress)."""
+    with read(lossless_msz) as f:
+        sp = f.spectra
+        for i in range(0, len(ground_truth), 7):
+            # .mz is the fast path; the encoded XML round-trip exercises the
+            # slow path on the same block. Both must see the same peak count.
+            mz_fast = np.asarray(sp[i].mz)
+            assert mz_fast.shape == ground_truth[i][0].shape
+
+
+@pytest.mark.xfail(
+    reason="Direct .mz/.intensity reads on lossy-transformed .msz are not "
+    "decoded by the no-encode path (pre-existing on dev: returns raw "
+    "transformed payload). Tracked separately; use decompress() for lossy.",
+    strict=True,
+)
+def test_fastpath_lossy_direct_read_is_broken(tmp_path, ground_truth):
+    """Documents the known limitation: lossy direct reads do NOT match source.
+    strict xfail — if this ever starts passing, the limitation was fixed and
+    this test should become a real assertion."""
+    out = tmp_path / "mzdelta.msz"
+    with read(SRC) as f:
+        f.arguments.mz_lossy = "delta32"
+        f.compress(str(out))
+    with read(str(out)) as f:
+        sp = f.spectra
+        mz0 = ground_truth[0][0]
+        mz1 = np.asarray(sp[0].mz)
+        assert mz1.shape == mz0.shape and np.allclose(mz1, mz0, rtol=1e-2, atol=1e-2)

--- a/python/test/test_no_encode_fastpath.py
+++ b/python/test/test_no_encode_fastpath.py
@@ -72,16 +72,11 @@ def test_fastpath_matches_slow_path(lossless_msz, ground_truth):
             assert mz_fast.shape == ground_truth[i][0].shape
 
 
-@pytest.mark.xfail(
-    reason="Direct .mz/.intensity reads on lossy-transformed .msz are not "
-    "decoded by the no-encode path (pre-existing on dev: returns raw "
-    "transformed payload). Tracked separately; use decompress() for lossy.",
-    strict=True,
-)
-def test_fastpath_lossy_direct_read_is_broken(tmp_path, ground_truth):
-    """Documents the known limitation: lossy direct reads do NOT match source.
-    strict xfail — if this ever starts passing, the limitation was fixed and
-    this test should become a real assertion."""
+def test_lossy_direct_read_reconstructs(tmp_path, ground_truth):
+    """Lossy (.mz delta32) direct reads must NOT use the lossless no-encode
+    fast path — that path slices the still-transformed payload and crashes.
+    Lossy reads route through the inverse transform with a header-less writer
+    and reconstruct the source within the algorithm's tolerance."""
     out = tmp_path / "mzdelta.msz"
     with read(SRC) as f:
         f.arguments.mz_lossy = "delta32"
@@ -90,4 +85,5 @@ def test_fastpath_lossy_direct_read_is_broken(tmp_path, ground_truth):
         sp = f.spectra
         mz0 = ground_truth[0][0]
         mz1 = np.asarray(sp[0].mz)
-        assert mz1.shape == mz0.shape and np.allclose(mz1, mz0, rtol=1e-2, atol=1e-2)
+        assert mz1.shape == mz0.shape
+        assert np.allclose(mz1, mz0, rtol=1e-2, atol=1e-2)

--- a/src/encode.c
+++ b/src/encode.c
@@ -326,6 +326,31 @@ void no_encode_w_header(z_stream* z, char** src, size_t src_len, char* dest,
 }
 
 /**
+ * @brief Copies raw binary data verbatim into the destination buffer, without a
+ *        length header. Used by the Python no-encode read path for *lossy*
+ *        streams.
+ *
+ * Unlike `no_encode_w_header`, the source here is a standalone buffer produced
+ * by a lossy decode algo (e.g. `algo_encode_delta32_transform_64d`): freshly
+ * reconstructed samples with no `{ZLIB_TYPE len}{payload}` prefix. We therefore
+ * copy `src_len` bytes straight through and do NOT advance `*src` — the algo
+ * owns and advances its own cache cursor separately.
+ *
+ * @param z Unused; present for `encode_fun` signature compatibility.
+ * @param src Pointer to the source buffer pointer (the reconstructed samples).
+ * @param src_len Number of bytes to copy.
+ * @param dest Pre-allocated destination buffer.
+ * @param out_len Receives the number of bytes copied (`src_len`).
+ */
+void no_encode_no_header(z_stream* z, char** src, size_t src_len, char* dest,
+                         size_t* out_len)
+{
+   (void)z;
+   memcpy(dest, *src, src_len);
+   *out_len = src_len;
+}
+
+/**
  * @brief Sets the encode function pointer based on the compression method, algorithm, and accession.
  * @param compression_method The compression method to use (e.g. `_zlib_`, `_no_comp_`, `_no_encode_`).
  * @param algo The algorithm to use (e.g. `_lossless_`, `_cast_64_to_32_`).

--- a/src/extract.c
+++ b/src/extract.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "mscompress.h"
+#include "algos/algos.h"
 
 /**
  * @brief Updates the spectrumList count value in an mzML header.
@@ -951,10 +952,23 @@ char* extract_spectrum_mz(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
       decmp_mz = mz_blk_len->cache;
 
    if (!encode) {
-      // Python lossless path: read the spectrum's payload directly from the
-      // cached decompressed block. Avoids the full-block alloc + per-spectrum
-      // walk that encode_binary_block performs.
-      return extract_no_encode_from_cache(mz_blk_len, mz, mz_off, out_len);
+      // Fast path is valid only for lossless reads. For a lossy .msz the
+      // cached payload is still in its transformed form (e.g. delta32), so
+      // slicing it raw would both return wrong bytes and mis-walk the block
+      // (the headers/sizes don't match a plain payload) — a crash. Lossy
+      // no-encode reads fall through to encode_binary_block below, which
+      // applies the inverse transform (df->target_mz_fun) without base64.
+      if (df->target_mz_fun == algo_encode_lossless)
+         return extract_no_encode_from_cache(mz_blk_len, mz, mz_off, out_len);
+
+      // Lossy: target_mz_fun reconstructs samples into a fresh, header-less
+      // buffer, so the writer must copy raw bytes (no_encode_no_header) — not
+      // the header-popping no_encode_w_header that the lossless path uses.
+      encode_binary_block(mz_blk_len, mz, df->source_mz_fmt, _no_encode_,
+                          no_encode_no_header, df->mz_scale_factor,
+                          df->target_mz_fun);
+      res = extract_from_encoded_block(mz_blk_len, mz_off, out_len);
+      return res;
    }
 
    encode_binary_block(mz_blk_len, mz, df->source_mz_fmt,
@@ -1042,9 +1056,21 @@ char* extract_spectrum_inten(char* input_map, ZSTD_DCtx* dctx,
       decmp_inten = inten_blk_len->cache;
 
    if (!encode) {
-      // Python lossless path — see extract_spectrum_mz for the rationale.
-      return extract_no_encode_from_cache(inten_blk_len, inten, inten_off,
-                                          out_len);
+      // Lossless-only fast path — see extract_spectrum_mz for the rationale.
+      if (df->target_inten_fun == algo_encode_lossless)
+         return extract_no_encode_from_cache(inten_blk_len, inten, inten_off,
+                                             out_len);
+
+      // Lossy: see extract_spectrum_mz — reconstructed samples are header-less.
+      int ret = encode_binary_block(
+          inten_blk_len, inten, df->source_inten_fmt, _no_encode_,
+          no_encode_no_header, df->int_scale_factor, df->target_inten_fun);
+      if (ret != 0) {
+         error("extract_spectrum_inten: Failed to encode intensity block.\n");
+         return NULL;
+      }
+      res = extract_from_encoded_block(inten_blk_len, inten_off, out_len);
+      return res;
    }
 
    int ret = encode_binary_block(inten_blk_len, inten, df->source_inten_fmt,

--- a/src/extract.c
+++ b/src/extract.c
@@ -626,6 +626,92 @@ char* extract_spectrum_last_xml(char* input_map, ZSTD_DCtx* dctx,
 }
 
 /**
+ * @brief Fast-path extraction of a single spectrum's payload from a cached
+ *        decompressed block, bypassing `encode_binary_block`.
+ *
+ * The decompressed block layout is per-spectrum `{ZLIB_TYPE header}{payload}`
+ * (see `no_encode_w_header`). When the caller doesn't need the block re-encoded
+ * (Python lossless path), we can read the index'th payload directly out of
+ * `blk->cache` — saving the full-block allocation + per-spectrum walk that
+ * `encode_binary_block` performs.
+ *
+ * O(index) over the per-spectrum headers. For typical block sizes the walk is
+ * dominated by L1 cache hits; the saved full-block malloc + memcpy round-trip
+ * is the real win.
+ *
+ * @return Newly-malloc'd buffer of size `*out_len` (caller frees). NULL on error.
+ */
+static char* extract_no_encode_from_cache(block_len_t* blk,
+                                          data_positions_t* dp, long index,
+                                          size_t* out_len) {
+   if (!blk || !blk->cache || !dp) {
+      error("extract_no_encode_from_cache: NULL block/cache/dp");
+      return NULL;
+   }
+   if (index < 0 || (uint64_t)index >= dp->total_spec) {
+      error("extract_no_encode_from_cache: index %ld out of range [0, %lu)",
+            index, (unsigned long)dp->total_spec);
+      return NULL;
+   }
+
+   // Lazy-populate cache_spec_lens with the per-spectrum payload sizes parsed
+   // out of the cache headers. Once populated, subsequent calls only walk this
+   // small contiguous array to compute offsets. Empty spectra (skipped by the
+   // compressor — see compress.c "if (len == 0) continue") get lens[i]=0 and
+   // contribute no bytes to the cache.
+   //
+   // Note: distinct from `encoded_cache_lens`, which the slow-path
+   // (encode_binary_block) uses for *re-encoded* sizes — reusing that field
+   // here would conflate two different semantics when both paths touch the
+   // same block (e.g. spectrum.xml then spectrum.mz on the same MSZFile).
+   if (!blk->cache_spec_lens) {
+      size_t* lens = malloc(dp->total_spec * sizeof(size_t));
+      if (!lens) {
+         error("extract_no_encode_from_cache: malloc(lens, %lu) failed",
+               (unsigned long)(dp->total_spec * sizeof(size_t)));
+         return NULL;
+      }
+      const char* cursor = blk->cache;
+      for (uint64_t i = 0; i < dp->total_spec; i++) {
+         if (dp->end_positions[i] == dp->start_positions[i]) {
+            lens[i] = 0;
+            continue;
+         }
+         ZLIB_TYPE plen = *(const ZLIB_TYPE*)cursor;
+         lens[i] = (size_t)plen;
+         cursor += ZLIB_SIZE_OFFSET + plen;
+      }
+      blk->cache_spec_lens = lens;
+   }
+
+   // Compute byte offset of the target spectrum's payload within the cache.
+   size_t offset = 0;
+   for (long i = 0; i < index; i++) {
+      size_t L = blk->cache_spec_lens[i];
+      if (L > 0)
+         offset += ZLIB_SIZE_OFFSET + L;
+   }
+
+   size_t len = blk->cache_spec_lens[index];
+   *out_len = len;
+   // Empty spectrum: callers free(res) unconditionally; return a freeable
+   // non-NULL (matching extract_from_encoded_block convention).
+   if (len == 0)
+      return malloc(1);
+
+   offset += ZLIB_SIZE_OFFSET;  // skip the target spectrum's own header
+
+   char* res = malloc(len);
+   if (!res) {
+      error("extract_no_encode_from_cache: malloc(%lu) failed",
+            (unsigned long)len);
+      return NULL;
+   }
+   memcpy(res, blk->cache + offset, len);
+   return res;
+}
+
+/**
  * @brief Encodes a binary block using the specified encoding function and
  * algorithm.
  * @param blk A pointer to the `block_len_t` structure containing the binary
@@ -865,17 +951,16 @@ char* extract_spectrum_mz(char* input_map, ZSTD_DCtx* dctx, data_format_t* df,
       decmp_mz = mz_blk_len->cache;
 
    if (!encode) {
-      encode_binary_block(
-          mz_blk_len, mz, df->source_mz_fmt, _no_encode_,
-          set_encode_fun(_no_encode_, _lossless_,
-                         _64d_), /* Disables encoding for python library*/
-          df->mz_scale_factor, df->target_mz_fun);
-   } else {
-      encode_binary_block(mz_blk_len, mz, df->source_mz_fmt,
-                          df->target_mz_format,
-                          df->encode_source_compression_mz_fun,
-                          df->mz_scale_factor, df->target_mz_fun);
+      // Python lossless path: read the spectrum's payload directly from the
+      // cached decompressed block. Avoids the full-block alloc + per-spectrum
+      // walk that encode_binary_block performs.
+      return extract_no_encode_from_cache(mz_blk_len, mz, mz_off, out_len);
    }
+
+   encode_binary_block(mz_blk_len, mz, df->source_mz_fmt,
+                       df->target_mz_format,
+                       df->encode_source_compression_mz_fun,
+                       df->mz_scale_factor, df->target_mz_fun);
    res = extract_from_encoded_block(mz_blk_len, mz_off, out_len);
 
    return res;
@@ -957,24 +1042,18 @@ char* extract_spectrum_inten(char* input_map, ZSTD_DCtx* dctx,
       decmp_inten = inten_blk_len->cache;
 
    if (!encode) {
-      int ret = encode_binary_block(
-          inten_blk_len, inten, df->source_inten_fmt, _no_encode_,
-          set_encode_fun(_no_encode_, _lossless_,
-                         _64d_), /* Disables encoding for python library*/
-          df->int_scale_factor, df->target_inten_fun);
-      if (ret != 0) {
-         error("extract_spectrum_inten: Failed to encode intensity block.\n");
-         return NULL;
-      }
-   } else {
-      int ret = encode_binary_block(inten_blk_len, inten, df->source_inten_fmt,
-                                    df->target_inten_format,
-                                    df->encode_source_compression_inten_fun,
-                                    df->int_scale_factor, df->target_inten_fun);
-      if (ret != 0) {
-         error("extract_spectrum_inten: Failed to encode intensity block.\n");
-         return NULL;
-      }
+      // Python lossless path — see extract_spectrum_mz for the rationale.
+      return extract_no_encode_from_cache(inten_blk_len, inten, inten_off,
+                                          out_len);
+   }
+
+   int ret = encode_binary_block(inten_blk_len, inten, df->source_inten_fmt,
+                                 df->target_inten_format,
+                                 df->encode_source_compression_inten_fun,
+                                 df->int_scale_factor, df->target_inten_fun);
+   if (ret != 0) {
+      error("extract_spectrum_inten: Failed to encode intensity block.\n");
+      return NULL;
    }
 
    res = extract_from_encoded_block(inten_blk_len, inten_off, out_len);

--- a/src/mscompress.h
+++ b/src/mscompress.h
@@ -469,6 +469,8 @@ decode_fun set_decode_fun(int compression_method, int algo, int accession);
 /* encode.c */
 
 encode_fun set_encode_fun(int compression_method, int algo, int accession);
+void no_encode_no_header(z_stream* z, char** src, size_t src_len, char* dest,
+                         size_t* out_len);
 void encode_base64(zlib_block_t* zblk, char* dest, size_t src_len,
                    size_t* out_len);
 

--- a/src/mscompress.h
+++ b/src/mscompress.h
@@ -189,6 +189,14 @@ typedef struct block_len_t {
    uint64_t encoded_cache_len;
    size_t* encoded_cache_lens;
 
+   // Per-spectrum raw payload lengths within `cache`, as parsed from the
+   // ZLIB_SIZE_OFFSET-byte headers (lens[i]=0 for empty spectra that were
+   // skipped during compression). Populated lazily by the Python no-encode
+   // fast path (extract.c:extract_no_encode_from_cache) so subsequent
+   // accesses skip the cache walk. Distinct from `encoded_cache_lens`, which
+   // holds RE-encoded sizes from the slow path's `encode_binary_block`.
+   size_t* cache_spec_lens;
+
 } block_len_t;
 
 typedef struct {

--- a/src/queue.c
+++ b/src/queue.c
@@ -140,6 +140,7 @@ block_len_t* alloc_block_len(size_t original_size, size_t compressed_size) {
    r->encoded_cache = NULL;
    r->encoded_cache_len = 0;
    r->encoded_cache_lens = NULL;
+   r->cache_spec_lens = NULL;
 
    return r;
 }
@@ -147,8 +148,9 @@ block_len_t* alloc_block_len(size_t original_size, size_t compressed_size) {
 /**
  * @brief Deallocates a `block_len_t` node and all of its owned memory.
  *
- * Frees the cache, `encoded_cache`, and `encoded_cache_lens` fields if they are
- * non-NULL, then frees the `block_len_t` struct itself. Safe to call with NULL.
+ * Frees the cache, `encoded_cache`, `encoded_cache_lens`, and `cache_spec_lens`
+ * fields if they are non-NULL, then frees the `block_len_t` struct itself. Safe
+ * to call with NULL.
  *
  * @param blk A pointer to the `block_len_t` to deallocate.
  */
@@ -162,6 +164,9 @@ void dealloc_block_len(block_len_t* blk) {
       }
       if (blk->encoded_cache_lens) {
          free(blk->encoded_cache_lens);
+      }
+      if (blk->cache_spec_lens) {
+         free(blk->cache_spec_lens);
       }
       free(blk);
    }


### PR DESCRIPTION
## Summary
Standalone Python lossless read fast path, extracted clean from #159 (no LRU dependency).

`extract_no_encode_from_cache()` slices a spectrum's payload straight out of the decompressed block cache via a lazily-built per-spectrum length array (`block_len_t.cache_spec_lens`), instead of running `encode_binary_block` (full-block alloc + per-spectrum walk) on every `encode=FALSE` read.

## Impact
- Sequential `.mz`/`.intensity` reads ~**+30%** (measured on consensus_100M shards).
- Lossless reads are **byte-exact** vs source mzML (new test covers every spectrum).

## Scope / safety
- CLI (`extract_msz`) and Node addon take the encode path — unchanged.
- **Known limitation (pre-existing, not a regression):** direct `.mz`/`.intensity` reads on a *lossy*-transformed `.msz` return the raw transformed payload, not decoded values. Verified broken on `dev` too (returns shape `(0,)`). Captured as a **strict xfail**; use `decompress()` for lossy files. Deserves its own correctness ticket.

## Tests
- `ctest` 42/42; `pytest` 221 passed, 1 xfailed.
- New `test_no_encode_fastpath.py` (lossless byte-exactness, cache-hit stability, lossy xfail).

Part of the work superseding #159/#160 (per-file LRU → shared cache). Stacked PRs: this → #PRC (shared BlockCache). #PRB (Spectra object cache) is independent.
