### PR TITLE
perf(python): bound Spectra object cache with an LRU dict

### DIFF
--- a/python/mscompress/__init__.py
+++ b/python/mscompress/__init__.py
@@ -13,6 +13,7 @@ from mscompress._core import (
     MSZFile,
     Spectrum,
     Spectra,
+    CACHE_SPECTRA_AUTO,
     get_num_threads,
     get_filesize,
     list_algorithms,

--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -414,9 +414,8 @@ cdef class Division:
 
 
 cdef class MZMLFile(BaseFile):
-    def __init__(self, bytes path, int cache_spectra=CACHE_SPECTRA_AUTO):
+    def __init__(self, bytes path):
         super(MZMLFile, self).__init__(path)
-        self._cache_spectra = cache_spectra
         if self._mapping is NULL:
              raise RuntimeError("File mapping is NULL. Filesize might be 0.")
         self._df = _pattern_detect(<char*> self._mapping)
@@ -825,9 +824,8 @@ cdef class MSZFile(BaseFile):
     cdef block_len_queue_t* _mz_binary_block_lens
     cdef block_len_queue_t* _inten_binary_block_lens
 
-    def __init__(self, bytes path, int cache_spectra=CACHE_SPECTRA_AUTO):
+    def __init__(self, bytes path):
         super(MSZFile, self).__init__(path)
-        self._cache_spectra = cache_spectra
         self._df = _get_header_df(self._mapping)
         self._footer = _read_footer(self._mapping, self.filesize)
         self._divisions = _read_divisions(self._mapping, self._footer.divisions_t_pos, self._footer.n_divisions)
@@ -882,6 +880,7 @@ cdef class MSZFile(BaseFile):
         self.filesize = sz
         self._opened_from_archive = True
         self._spectra = None
+        self._cache_spectra = CACHE_SPECTRA_AUTO  # read() may override
         self._arguments = RuntimeArguments()
         self._z = _alloc_z_stream()
         self.output_fd = -1
@@ -901,8 +900,7 @@ cdef class MSZFile(BaseFile):
         _set_decompress_runtime_variables(self._df, self._footer)
 
     @classmethod
-    def from_mszx(cls, bytes mszx_path, bytes entry_name,
-                  int cache_spectra=CACHE_SPECTRA_AUTO):
+    def from_mszx(cls, bytes mszx_path, bytes entry_name):
         """
         Open an MSZ file embedded inside an MSZX (tar) archive without
         extracting it to disk. Mmap's the archive at the entry's byte
@@ -914,13 +912,8 @@ cdef class MSZFile(BaseFile):
             Path to the .mszx archive.
         entry_name : bytes
             Name of the MSZ entry within the archive (e.g. b"spectra.msz").
-        cache_spectra : int
-            Per-file LRU cap for cached ``Spectrum`` Python objects. Default
-            ``CACHE_SPECTRA_AUTO`` (-1) resolves to a bundled default; 0
-            restores the legacy unbounded cache. Forwarded to ``Spectra``.
         """
         cdef MSZFile self = cls.__new__(cls)
-        self._cache_spectra = cache_spectra
         self._init_from_archive(mszx_path, entry_name)
         return self
 
@@ -1352,7 +1345,7 @@ cdef class MSZXFile(MSZFile):
     cdef public bint _closed             # idempotent-close guard (visible to Python)
 
     @classmethod
-    def open(cls, path, int cache_spectra=CACHE_SPECTRA_AUTO):
+    def open(cls, path):
         """
         Open an MSZX archive for reading.
 
@@ -1363,9 +1356,6 @@ cdef class MSZXFile(MSZFile):
 
         Args:
             path: Path to the .mszx file.
-            cache_spectra: Per-file LRU cap for cached ``Spectrum`` Python
-                objects. Default ``CACHE_SPECTRA_AUTO`` (-1) resolves to a
-                bundled default; 0 restores the legacy unbounded cache.
         """
         # Local imports break the circular module load between _core and
         # the Python-side annotation/tarfile machinery (mscompress.mszx
@@ -1418,7 +1408,6 @@ cdef class MSZXFile(MSZFile):
 
         # Construct and populate via the shared MSZ-from-archive helper.
         cdef MSZXFile self = cls.__new__(cls)
-        self._cache_spectra = cache_spectra
         self._init_from_archive(
             str(archive_path).encode(),
             manifest.spectra_file.encode(),
@@ -1661,8 +1650,10 @@ cdef class BaseFile:
     cdef divisions_t* _divisions
     cdef division_t* _positions
     cdef Spectra _spectra
-    cdef int _cache_spectra    # Cap forwarded to Spectra; CACHE_SPECTRA_AUTO
-                               # (-1) by default. Set by subclass constructors.
+    cdef public int _cache_spectra  # Cap forwarded to Spectra; CACHE_SPECTRA_AUTO
+                                    # (-1) by default. Set by read() before the
+                                    # first .spectra access; public so the
+                                    # pure-Python read() factory can assign it.
     cdef RuntimeArguments _arguments
     cdef z_stream* _z
     cdef int output_fd
@@ -1679,7 +1670,7 @@ cdef class BaseFile:
         self._map_length = self.filesize
         self._opened_from_archive = False
         self._spectra = None
-        self._cache_spectra = CACHE_SPECTRA_AUTO  # subclass may override
+        self._cache_spectra = CACHE_SPECTRA_AUTO  # read() may override
         self._arguments = RuntimeArguments()
         self._z = _alloc_z_stream()
         self.output_fd = -1

--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -47,6 +47,28 @@ _set_error_callback(_python_error_handler)
 _set_warning_callback(_python_warning_handler)
 
 
+# ---------------------------------------------------------------------------
+# Spectrum-object cache sizing. Defined above any class that uses them as
+# default-arg values because Cython evaluates def-default values at
+# class-definition time, not at call time.
+# ---------------------------------------------------------------------------
+
+CACHE_SPECTRA_AUTO = -1
+"""Sentinel for ``cache_spectra`` meaning "use the bundled default".
+
+When passed (the default), ``Spectra`` keeps the last ``_DEFAULT_CACHE_SPECTRA``
+returned ``Spectrum`` objects in a bounded LRU. Repeated access to a cached
+index hands back the same ``Spectrum`` instance (so its lazily-loaded ``mz`` /
+``intensity`` / ``xml`` payloads survive). Pass ``cache_spectra=N`` for an
+explicit cap, or ``cache_spectra=0`` to disable eviction (legacy: the cache
+grows unboundedly, one entry per ever-accessed index)."""
+
+_DEFAULT_CACHE_SPECTRA = 128
+# Big enough that contiguous .mz/.intensity/.xml accesses on the same Spectrum
+# stay hot and typical ML batch sizes don't thrash; small enough that random
+# sampling can't pin tens of thousands of Spectrum objects.
+
+
 def _pipe_stream(c_func, args, chunk_size=1_048_576):
     """
     Pipe-based streaming bridge between C fd-oriented writes and Python iterators.
@@ -392,8 +414,9 @@ cdef class Division:
 
 
 cdef class MZMLFile(BaseFile):
-    def __init__(self, bytes path):
+    def __init__(self, bytes path, int cache_spectra=CACHE_SPECTRA_AUTO):
         super(MZMLFile, self).__init__(path)
+        self._cache_spectra = cache_spectra
         if self._mapping is NULL:
              raise RuntimeError("File mapping is NULL. Filesize might be 0.")
         self._df = _pattern_detect(<char*> self._mapping)
@@ -802,8 +825,9 @@ cdef class MSZFile(BaseFile):
     cdef block_len_queue_t* _mz_binary_block_lens
     cdef block_len_queue_t* _inten_binary_block_lens
 
-    def __init__(self, bytes path):
+    def __init__(self, bytes path, int cache_spectra=CACHE_SPECTRA_AUTO):
         super(MSZFile, self).__init__(path)
+        self._cache_spectra = cache_spectra
         self._df = _get_header_df(self._mapping)
         self._footer = _read_footer(self._mapping, self.filesize)
         self._divisions = _read_divisions(self._mapping, self._footer.divisions_t_pos, self._footer.n_divisions)
@@ -877,7 +901,8 @@ cdef class MSZFile(BaseFile):
         _set_decompress_runtime_variables(self._df, self._footer)
 
     @classmethod
-    def from_mszx(cls, bytes mszx_path, bytes entry_name):
+    def from_mszx(cls, bytes mszx_path, bytes entry_name,
+                  int cache_spectra=CACHE_SPECTRA_AUTO):
         """
         Open an MSZ file embedded inside an MSZX (tar) archive without
         extracting it to disk. Mmap's the archive at the entry's byte
@@ -889,8 +914,13 @@ cdef class MSZFile(BaseFile):
             Path to the .mszx archive.
         entry_name : bytes
             Name of the MSZ entry within the archive (e.g. b"spectra.msz").
+        cache_spectra : int
+            Per-file LRU cap for cached ``Spectrum`` Python objects. Default
+            ``CACHE_SPECTRA_AUTO`` (-1) resolves to a bundled default; 0
+            restores the legacy unbounded cache. Forwarded to ``Spectra``.
         """
         cdef MSZFile self = cls.__new__(cls)
+        self._cache_spectra = cache_spectra
         self._init_from_archive(mszx_path, entry_name)
         return self
 
@@ -1322,7 +1352,7 @@ cdef class MSZXFile(MSZFile):
     cdef public bint _closed             # idempotent-close guard (visible to Python)
 
     @classmethod
-    def open(cls, path):
+    def open(cls, path, int cache_spectra=CACHE_SPECTRA_AUTO):
         """
         Open an MSZX archive for reading.
 
@@ -1333,6 +1363,9 @@ cdef class MSZXFile(MSZFile):
 
         Args:
             path: Path to the .mszx file.
+            cache_spectra: Per-file LRU cap for cached ``Spectrum`` Python
+                objects. Default ``CACHE_SPECTRA_AUTO`` (-1) resolves to a
+                bundled default; 0 restores the legacy unbounded cache.
         """
         # Local imports break the circular module load between _core and
         # the Python-side annotation/tarfile machinery (mscompress.mszx
@@ -1385,6 +1418,7 @@ cdef class MSZXFile(MSZFile):
 
         # Construct and populate via the shared MSZ-from-archive helper.
         cdef MSZXFile self = cls.__new__(cls)
+        self._cache_spectra = cache_spectra
         self._init_from_archive(
             str(archive_path).encode(),
             manifest.spectra_file.encode(),
@@ -1627,6 +1661,8 @@ cdef class BaseFile:
     cdef divisions_t* _divisions
     cdef division_t* _positions
     cdef Spectra _spectra
+    cdef int _cache_spectra    # Cap forwarded to Spectra; CACHE_SPECTRA_AUTO
+                               # (-1) by default. Set by subclass constructors.
     cdef RuntimeArguments _arguments
     cdef z_stream* _z
     cdef int output_fd
@@ -1643,6 +1679,7 @@ cdef class BaseFile:
         self._map_length = self.filesize
         self._opened_from_archive = False
         self._spectra = None
+        self._cache_spectra = CACHE_SPECTRA_AUTO  # subclass may override
         self._arguments = RuntimeArguments()
         self._z = _alloc_z_stream()
         self.output_fd = -1
@@ -1729,7 +1766,12 @@ cdef class BaseFile:
     @property
     def spectra(self):
         if self._spectra is None:
-            self._spectra = Spectra(self, DataFormat.from_ptr(self._df), Division.from_ptr(self._positions))
+            self._spectra = Spectra(
+                self,
+                DataFormat.from_ptr(self._df),
+                Division.from_ptr(self._positions),
+                cap=self._cache_spectra,
+            )
         return self._spectra
     
     @property
@@ -1938,21 +1980,34 @@ cdef class Spectra:
 
     __len__(self) -> int:
         Returns the total number of spectra.
+
+    clear_cache(self):
+        Drop all cached ``Spectrum`` objects (and any payloads they lazily loaded).
+
+    cache_cap (property):
+        The effective LRU cap. 0 means unbounded; positive ints are the maximum
+        number of ``Spectrum`` objects held at once.
     """
     cdef BaseFile _f
     cdef object _df
     cdef object _positions
-    cdef object _cache  # Store computed spectra
+    cdef object _cache  # dict[size_t, Spectrum] — insertion-ordered LRU
+    cdef int _cap       # 0 = unbounded; positive = bounded
     cdef int _index
     cdef size_t length
     cdef object _transform
 
-    def __init__(self, BaseFile f, DataFormat df, Division positions):
+    def __init__(self, BaseFile f, DataFormat df, Division positions,
+                 int cap=CACHE_SPECTRA_AUTO):
         self._f = f
         self._df = df
         self._positions = positions
         self.length = self._df.source_total_spec
-        self._cache = [None] * self.length  # Initialize cache
+        self._cache = {}
+        if cap == CACHE_SPECTRA_AUTO:
+            self._cap = _DEFAULT_CACHE_SPECTRA
+        else:
+            self._cap = cap if cap > 0 else 0
         self._index = 0
         self._transform = None
 
@@ -1972,10 +2027,49 @@ cdef class Spectra:
         if index >= self.length:
             raise IndexError("Spectra index out of range")
 
-        if self._cache[index] is None:
-            self._cache[index] = self._compute_spectrum(index)
+        # LRU hit: bump to most-recently-used by reinserting at the dict tail.
+        # Python 3.7+ dicts preserve insertion order, which gives LRU ordering
+        # for free (oldest = first iter, newest = last insertion).
+        if index in self._cache:
+            sp = self._cache.pop(index)
+            self._cache[index] = sp
+            return sp
 
-        return self._cache[index]
+        sp = self._compute_spectrum(index)
+        self._cache[index] = sp
+
+        # Evict oldest while over cap. cap=0 means unbounded — never evict.
+        if self._cap > 0:
+            while len(self._cache) > self._cap:
+                oldest = next(iter(self._cache))
+                del self._cache[oldest]
+
+        return sp
+
+    @property
+    def cache_cap(self):
+        """The effective LRU cap. 0 means unbounded; positive ints are the
+        maximum number of ``Spectrum`` objects held at once."""
+        return self._cap
+
+    @property
+    def cache_size(self):
+        """Number of ``Spectrum`` objects currently held in the cache."""
+        return len(self._cache)
+
+    def _has_cached(self, size_t index):
+        """True if ``index`` is currently resident in the object cache.
+        Primarily for tests/introspection; does not affect LRU ordering."""
+        return index in self._cache
+
+    def clear_cache(self):
+        """Drop all cached ``Spectrum`` objects.
+
+        Subsequent ``spectra[i]`` calls construct fresh objects and re-fetch
+        their ``mz`` / ``intensity`` / ``xml`` lazily. The file stays open.
+        Does not touch any C-level block cache.
+        """
+        self._cache.clear()
 
     cdef Spectrum _compute_spectrum(self, size_t index):
         if self._positions.ret_times is not None:
@@ -2012,7 +2106,7 @@ cdef class Spectra:
             )
         self._transform = transform
         # Invalidate cache so spectra are recomputed with new transform
-        self._cache = [None] * self.length
+        self._cache.clear()
 
     def with_transform(self, transform):
         """Return a new Spectra instance with the given transform applied.
@@ -2026,7 +2120,7 @@ cdef class Spectra:
         Returns:
             A new Spectra instance with the transform set.
         """
-        new = Spectra(self._f, self._df, self._positions)
+        new = Spectra(self._f, self._df, self._positions, cap=self._cap)
         new.set_transform(transform)
         return new
 

--- a/python/mscompress/utils.py
+++ b/python/mscompress/utils.py
@@ -3,17 +3,25 @@ from os import PathLike
 import tarfile
 from pathlib import Path
 from typing import Literal, Optional
-from mscompress._core import MZMLFile, MSZFile
+from mscompress._core import MZMLFile, MSZFile, CACHE_SPECTRA_AUTO
 from mscompress.mszx import MSZXFile
 from typing import Union
 
 
-def read(path: Union[str, PathLike, bytes]) -> Union[MZMLFile, MSZFile, MSZXFile]:
+def read(
+    path: Union[str, PathLike, bytes],
+    *,
+    cache_spectra: int = CACHE_SPECTRA_AUTO,
+) -> Union[MZMLFile, MSZFile, MSZXFile]:
     """
     Read and parse mzML, MSZ, or MSZX files.
-    
+
     Args:
         path (Union[str, PathLike, bytes]): Path to the file to read.
+        cache_spectra (int): Per-file LRU cap for cached ``Spectrum`` objects.
+            ``CACHE_SPECTRA_AUTO`` (-1, default) uses the bundled default;
+            ``0`` disables eviction (legacy unbounded); ``N > 0`` sets an
+            explicit cap. Forwarded to the underlying file constructor.
     Returns:
         Union[MZMLFile, MSZFile, MSZXFile]: Parsed file object.
     """
@@ -42,13 +50,19 @@ def read(path: Union[str, PathLike, bytes]) -> Union[MZMLFile, MSZFile, MSZXFile
     path_bytes = path_str.encode('utf-8')
 
     if filetype == "mzML":
-        return MZMLFile(path_bytes)
+        f = MZMLFile(path_bytes)
     elif filetype == "msz":
-        return MSZFile(path_bytes)
+        f = MSZFile(path_bytes)
     elif filetype == "mszx":
-        return MSZXFile.open(path_str)
+        f = MSZXFile.open(path_str)
     else:
         raise OSError(f"Could not determine file type for: {path_str}")
+
+    # Set before the first `.spectra` access so the Spectra LRU is built with
+    # this cap. The file constructors deliberately don't expose this knob;
+    # read() is the single entry point for it.
+    f._cache_spectra = cache_spectra
+    return f
 
 
 def detect_filetype(path: Union[str, Path]) -> Optional[Literal["mzML", "msz", "mszx"]]:

--- a/python/test/test_spectra_object_cache.py
+++ b/python/test/test_spectra_object_cache.py
@@ -1,0 +1,121 @@
+"""
+Coverage for the bounded Spectra object cache (cache_spectra / Spectra LRU).
+
+Replaces the old `[None] * len` placeholder list with an insertion-ordered
+LRU dict so random access can't pin one Spectrum object per ever-touched index.
+"""
+import os
+
+import numpy as np
+import pytest
+
+from mscompress import read
+from mscompress._core import CACHE_SPECTRA_AUTO, _DEFAULT_CACHE_SPECTRA, MSZFile
+
+SRC = os.path.join(os.path.dirname(__file__), "..", "..", "test", "data", "test.mzML")
+
+
+@pytest.fixture()
+def msz(tmp_path):
+    out = tmp_path / "lossless.msz"
+    with read(SRC) as f:
+        f.compress(str(out))
+    return str(out)
+
+
+def test_auto_is_sentinel():
+    assert CACHE_SPECTRA_AUTO == -1
+
+
+def test_default_cap_positive(msz):
+    with read(msz) as f:
+        assert f.spectra.cache_cap == _DEFAULT_CACHE_SPECTRA
+        assert f.spectra.cache_cap > 0
+
+
+def test_explicit_cap_honored(msz):
+    with MSZFile(os.fsencode(msz), cache_spectra=4) as f:
+        assert f.spectra.cache_cap == 4
+
+
+def test_zero_disables_eviction(msz):
+    with MSZFile(os.fsencode(msz), cache_spectra=0) as f:
+        sp = f.spectra
+        assert sp.cache_cap == 0
+        n = min(20, len(sp))
+        for i in range(n):
+            _ = sp[i]
+        # Unbounded: every distinct index retained.
+        assert sp.cache_size == n
+
+
+def test_bounded_cap_evicts(msz):
+    with MSZFile(os.fsencode(msz), cache_spectra=4) as f:
+        sp = f.spectra
+        for i in range(min(12, len(sp))):
+            _ = sp[i]
+        assert sp.cache_size <= 4
+
+
+def test_lru_hit_bumps_to_mru(msz):
+    with MSZFile(os.fsencode(msz), cache_spectra=3) as f:
+        sp = f.spectra
+        a, b, c = sp[0], sp[1], sp[2]      # cache: {0,1,2}
+        _ = sp[0]                           # touch 0 -> MRU; order {1,2,0}
+        _ = sp[3]                           # insert 3, evict oldest (1)
+        assert not sp._has_cached(1)
+        assert sp._has_cached(0) and sp._has_cached(2) and sp._has_cached(3)
+
+
+def test_same_instance_returned_on_hit(msz):
+    with MSZFile(os.fsencode(msz), cache_spectra=8) as f:
+        sp = f.spectra
+        assert sp[0] is sp[0]
+
+
+def test_values_match_across_eviction(msz):
+    """Tight cap (forces eviction) returns identical data to unbounded."""
+    with MSZFile(os.fsencode(msz), cache_spectra=2) as bounded, \
+         MSZFile(os.fsencode(msz), cache_spectra=0) as unbounded:
+        n = min(20, len(bounded.spectra))
+        for i in range(n):
+            assert np.array_equal(
+                np.asarray(bounded.spectra[i].mz),
+                np.asarray(unbounded.spectra[i].mz),
+            )
+            assert np.array_equal(
+                np.asarray(bounded.spectra[i].intensity),
+                np.asarray(unbounded.spectra[i].intensity),
+            )
+
+
+def test_clear_cache(msz):
+    with read(msz) as f:
+        sp = f.spectra
+        _ = sp[0]
+        assert sp.cache_size > 0
+        sp.clear_cache()
+        assert sp.cache_size == 0
+        # Still usable.
+        assert np.asarray(sp[0].mz).shape[0] >= 0
+
+
+def test_iteration_completes_under_tight_cap(msz):
+    with MSZFile(os.fsencode(msz), cache_spectra=2) as f:
+        count = sum(1 for _ in f.spectra)
+        assert count == len(f.spectra)
+
+
+def test_set_transform_invalidates(msz):
+    with read(msz) as f:
+        sp = f.spectra
+        _ = sp[0]
+        assert sp.cache_size > 0
+        sp.set_transform(None)
+        assert sp.cache_size == 0
+
+
+def test_with_transform_preserves_cap(msz):
+    with MSZFile(os.fsencode(msz), cache_spectra=7) as f:
+        sp2 = f.spectra.with_transform(None)
+        assert sp2.cache_cap == 7

--- a/python/test/test_spectra_object_cache.py
+++ b/python/test/test_spectra_object_cache.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 from mscompress import read
-from mscompress._core import CACHE_SPECTRA_AUTO, _DEFAULT_CACHE_SPECTRA, MSZFile
+from mscompress._core import CACHE_SPECTRA_AUTO, _DEFAULT_CACHE_SPECTRA
 
 SRC = os.path.join(os.path.dirname(__file__), "..", "..", "test", "data", "test.mzML")
 
@@ -34,12 +34,12 @@ def test_default_cap_positive(msz):
 
 
 def test_explicit_cap_honored(msz):
-    with MSZFile(os.fsencode(msz), cache_spectra=4) as f:
+    with read(msz, cache_spectra=4) as f:
         assert f.spectra.cache_cap == 4
 
 
 def test_zero_disables_eviction(msz):
-    with MSZFile(os.fsencode(msz), cache_spectra=0) as f:
+    with read(msz, cache_spectra=0) as f:
         sp = f.spectra
         assert sp.cache_cap == 0
         n = min(20, len(sp))
@@ -50,7 +50,7 @@ def test_zero_disables_eviction(msz):
 
 
 def test_bounded_cap_evicts(msz):
-    with MSZFile(os.fsencode(msz), cache_spectra=4) as f:
+    with read(msz, cache_spectra=4) as f:
         sp = f.spectra
         for i in range(min(12, len(sp))):
             _ = sp[i]
@@ -58,7 +58,7 @@ def test_bounded_cap_evicts(msz):
 
 
 def test_lru_hit_bumps_to_mru(msz):
-    with MSZFile(os.fsencode(msz), cache_spectra=3) as f:
+    with read(msz, cache_spectra=3) as f:
         sp = f.spectra
         a, b, c = sp[0], sp[1], sp[2]      # cache: {0,1,2}
         _ = sp[0]                           # touch 0 -> MRU; order {1,2,0}
@@ -68,15 +68,15 @@ def test_lru_hit_bumps_to_mru(msz):
 
 
 def test_same_instance_returned_on_hit(msz):
-    with MSZFile(os.fsencode(msz), cache_spectra=8) as f:
+    with read(msz, cache_spectra=8) as f:
         sp = f.spectra
         assert sp[0] is sp[0]
 
 
 def test_values_match_across_eviction(msz):
     """Tight cap (forces eviction) returns identical data to unbounded."""
-    with MSZFile(os.fsencode(msz), cache_spectra=2) as bounded, \
-         MSZFile(os.fsencode(msz), cache_spectra=0) as unbounded:
+    with read(msz, cache_spectra=2) as bounded, \
+         read(msz, cache_spectra=0) as unbounded:
         n = min(20, len(bounded.spectra))
         for i in range(n):
             assert np.array_equal(
@@ -101,7 +101,7 @@ def test_clear_cache(msz):
 
 
 def test_iteration_completes_under_tight_cap(msz):
-    with MSZFile(os.fsencode(msz), cache_spectra=2) as f:
+    with read(msz, cache_spectra=2) as f:
         count = sum(1 for _ in f.spectra)
         assert count == len(f.spectra)
 
@@ -116,6 +116,6 @@ def test_set_transform_invalidates(msz):
 
 
 def test_with_transform_preserves_cap(msz):
-    with MSZFile(os.fsencode(msz), cache_spectra=7) as f:
+    with read(msz, cache_spectra=7) as f:
         sp2 = f.spectra.with_transform(None)
         assert sp2.cache_cap == 7


### PR DESCRIPTION
## Summary
Salvaged from #160 (the rest of #160 — the per-file block LRU — is dropped; see #PRC). Bounds the Python-side `Spectra` object cache, which previously pre-allocated `[None] * len` on construction and retained every returned `Spectrum` forever.

On a 1.2M-spectrum shard that placeholder list is ~10 MB before any data is touched (~7 GB across 90 shards × 8 workers), and the cache then grew with every distinct index accessed.

## Change
Replace the list with a bounded insertion-ordered LRU dict:
- `cache_spectra=CACHE_SPECTRA_AUTO` (-1, **default**) → `_DEFAULT_CACHE_SPECTRA=128`
- `cache_spectra=0` → legacy unbounded
- `cache_spectra=N>0` → explicit cap

Cache hits bump to MRU via pop+reinsert (py3.7+ dict order = LRU). Adds `Spectra.cache_cap` / `cache_size` / `clear_cache()`.

## API surface
The cache cap is configured **only** through the `read()` factory, as a keyword-only argument:

```python
read(path, *, cache_spectra=CACHE_SPECTRA_AUTO)
```

The file constructors (`MZMLFile`/`MSZFile.__init__`, `MSZFile.from_mszx`, `MSZXFile.open`) keep their original signatures — the knob is not threaded through them. `read()` sets `BaseFile._cache_spectra` (now `cdef public`) after construction and before the first `.spectra` access; `_init_from_archive` defaults it to `CACHE_SPECTRA_AUTO` since the archive paths bypass `__init__`. Direct constructor use gets the AUTO default.

## Note on impact
Throughput is unchanged (the expensive work is the C-side block decompress). The concrete win is eliminating the `[None]*N` placeholder. This is the smallest of the three changes — independent of the block-cache work.

## Tests
`pytest` 230 passed; new `test_spectra_object_cache.py` (cap honored, eviction, LRU-MRU bump, value-equality across eviction, clear, transform invalidation) constructs via `read(..., cache_spectra=N)`.
