### PR TITLE
perf(core): resolve MSZ spectrum metadata lazily

### DIFF
--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -959,14 +959,22 @@ cdef class MSZFile(BaseFile):
     cdef block_len_queue_t* _inten_binary_block_lens
     cdef BlockCache _block_cache   # shared/owned decompressed-block cache;
                                    # None disables bounding (legacy unbounded)
+    # Prefix sum of per-division spectrum counts (length n_divisions+1) used to
+    # resolve a global spectrum index -> (division, local index) WITHOUT
+    # materializing the flattened per-spectrum position arrays. _positions (the
+    # flattened division) is now built lazily, only if .positions/.describe()
+    # are accessed. This is the ~22.6 GB/90-shard metadata saving.
+    cdef long* _div_spec_offsets
 
     def __init__(self, bytes path):
         super(MSZFile, self).__init__(path)
         self._block_cache = _coerce_cache(None)  # read() may override
+        self._div_spec_offsets = NULL
         self._df = _get_header_df(self._mapping)
         self._footer = _read_footer(self._mapping, self.filesize)
         self._divisions = _read_divisions(self._mapping, self._footer.divisions_t_pos, self._footer.n_divisions)
-        self._positions = _flatten_divisions(self._divisions)
+        self._positions = NULL  # built lazily via _ensure_positions()
+        self._build_offsets()
         self._dctx = _alloc_dctx()
         self._xml_block_lens = _read_block_len_queue(self._mapping, self._footer.xml_blk_pos, self._footer.mz_binary_blk_pos)
         self._mz_binary_block_lens = _read_block_len_queue(self._mapping, self._footer.mz_binary_blk_pos, self._footer.inten_binary_blk_pos)
@@ -986,6 +994,56 @@ cdef class MSZFile(BaseFile):
         is the only public entry point for the knob. Must be called before any
         spectrum/block access so no blocks are attached under the old cache."""
         self._block_cache = _coerce_cache(cache)
+
+    cdef void _build_offsets(self):
+        """Build the per-division spectrum-count prefix sum so a global index
+        resolves to (division, local) in O(log n_divisions) without flattening
+        the per-spectrum position arrays into one contiguous heap copy."""
+        cdef int n = self._divisions.n_divisions
+        self._div_spec_offsets = <long*>malloc(sizeof(long) * (n + 1))
+        if self._div_spec_offsets == NULL:
+            raise MemoryError("MSZFile._build_offsets: malloc failed")
+        cdef long acc = 0
+        cdef int i
+        for i in range(n):
+            self._div_spec_offsets[i] = acc
+            acc += self._divisions.divisions[i].mz.total_spec
+        self._div_spec_offsets[n] = acc
+
+    cdef int _resolve_division(self, size_t index, size_t* local) except -1:
+        """Resolve a global spectrum index to its division index, writing the
+        in-division offset to *local. Binary search over the prefix sum."""
+        cdef int lo = 0
+        cdef int hi = self._divisions.n_divisions - 1
+        cdef int mid
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if <size_t>self._div_spec_offsets[mid] <= index:
+                lo = mid
+            else:
+                hi = mid - 1
+        local[0] = index - <size_t>self._div_spec_offsets[lo]
+        return lo
+
+    cdef int _spectrum_meta(self, size_t index, uint32_t* scan,
+                            uint16_t* ms_level, float* ret_time,
+                            bint* has_rt) except -1:
+        """Per-spectrum metadata for the given global index, read straight from
+        the mmap-backed per-division scan/ms_level arrays (no flattened copy).
+        MSZ stores no per-spectrum retention times, so has_rt is always 0."""
+        cdef size_t local = 0
+        cdef int d = self._resolve_division(index, &local)
+        cdef division_t* div = self._divisions.divisions[d]
+        scan[0] = div.scans[local]
+        ms_level[0] = div.ms_levels[local]
+        has_rt[0] = False
+        return 0
+
+    cdef void _ensure_positions(self):
+        """Materialize the flattened position arrays on demand (only when
+        .positions / describe() need a contiguous Division). Cached thereafter."""
+        if self._positions == NULL:
+            self._positions = _flatten_divisions(self._divisions)
 
     @staticmethod
     def _reopen(path: bytes):
@@ -1061,12 +1119,14 @@ cdef class MSZFile(BaseFile):
         self._df = NULL
         self._divisions = NULL
         self._positions = NULL
+        self._div_spec_offsets = NULL
 
         # Run the MSZFile-specific init body.
         self._df = _get_header_df(self._mapping)
         self._footer = _read_footer(self._mapping, self.filesize)
         self._divisions = _read_divisions(self._mapping, self._footer.divisions_t_pos, self._footer.n_divisions)
-        self._positions = _flatten_divisions(self._divisions)
+        self._positions = NULL  # built lazily via _ensure_positions()
+        self._build_offsets()
         self._dctx = _alloc_dctx()
         self._xml_block_lens = _read_block_len_queue(self._mapping, self._footer.xml_blk_pos, self._footer.mz_binary_blk_pos)
         self._mz_binary_block_lens = _read_block_len_queue(self._mapping, self._footer.mz_binary_blk_pos, self._footer.inten_binary_blk_pos)
@@ -1106,6 +1166,11 @@ cdef class MSZFile(BaseFile):
         if self._dctx != NULL:
             ZSTD_freeDCtx(self._dctx)
             self._dctx = NULL
+
+        # Free the division prefix-sum table.
+        if self._div_spec_offsets != NULL:
+            free(self._div_spec_offsets)
+            self._div_spec_offsets = NULL
 
         # Detach this file's blocks from the shared cache BEFORE freeing the
         # queues, or the shared LRU would retain dangling pointers into freed
@@ -1869,6 +1934,33 @@ cdef class BaseFile:
         self._divisions = NULL
         self._positions = NULL
 
+    cdef void _ensure_positions(self):
+        """Ensure self._positions (the flattened Division) is materialized.
+
+        Default: a no-op — subclasses whose _positions is populated at open
+        (e.g. MZMLFile from scan_mzml) need nothing. MSZFile overrides this to
+        flatten lazily, since it now resolves spectrum metadata without the
+        flattened arrays."""
+        pass
+
+    cdef int _spectrum_meta(self, size_t index, uint32_t* scan,
+                            uint16_t* ms_level, float* ret_time,
+                            bint* has_rt) except -1:
+        """Per-spectrum metadata (scan number, MS level, retention time) for a
+        global index. Default reads from the flat self._positions division;
+        MSZFile overrides to read from the mmap-backed per-division arrays
+        without flattening. has_rt=0 means no retention time (caller uses NaN)."""
+        if self._positions == NULL:
+            raise RuntimeError("_spectrum_meta: positions unavailable")
+        scan[0] = self._positions.scans[index]
+        ms_level[0] = self._positions.ms_levels[index]
+        if self._positions.ret_times != NULL:
+            ret_time[0] = self._positions.ret_times[index]
+            has_rt[0] = True
+        else:
+            has_rt[0] = False
+        return 0
+
 
     def __enter__(self):
         # Only open if not already open (e.g., from __init__)
@@ -1947,16 +2039,24 @@ cdef class BaseFile:
     @property
     def spectra(self):
         if self._spectra is None:
+            # Spectra resolves per-spectrum metadata via _spectrum_meta(), so it
+            # does NOT need the flattened Division. Pass it only if already
+            # materialized (MZMLFile); MSZFile keeps _positions lazy/NULL here.
+            positions_div = (Division.from_ptr(self._positions)
+                             if self._positions != NULL else None)
             self._spectra = Spectra(
                 self,
                 DataFormat.from_ptr(self._df),
-                Division.from_ptr(self._positions),
+                positions_div,
                 cap=self._cache_spectra,
             )
         return self._spectra
-    
+
     @property
     def positions(self):
+        # Materializes the flattened Division on demand (MSZFile). For mzML it
+        # is already populated, so this is a no-op there.
+        self._ensure_positions()
         return Division.from_ptr(self._positions)
 
     @property
@@ -1990,6 +2090,7 @@ cdef class BaseFile:
         raise NotImplementedError("This method should be overridden in subclasses")
 
     def describe(self) -> dict:
+        self._ensure_positions()
         return {
             "path": self.path,
             "filesize": self.filesize,
@@ -2253,15 +2354,20 @@ cdef class Spectra:
         self._cache.clear()
 
     cdef Spectrum _compute_spectrum(self, size_t index):
-        if self._positions.ret_times is not None:
-            retention_time = self._positions.ret_times[index]
-        else:
-            retention_time = nan("1")
+        # Pull metadata via the file's resolver instead of a flattened position
+        # array. For MSZ this reads the mmap-backed per-division scan/ms_level
+        # arrays directly (no 22.6 GB/90-shard flatten); for mzML it reads the
+        # scan division populated at open.
+        cdef uint32_t scan = 0
+        cdef uint16_t ms_level = 0
+        cdef float ret_time = 0.0
+        cdef bint has_rt = False
+        self._f._spectrum_meta(index, &scan, &ms_level, &ret_time, &has_rt)
         return Spectrum(
             index=index,
-            scan=self._positions.scans[index],
-            ms_level=self._positions.ms_levels[index],
-            retention_time=retention_time,
+            scan=scan,
+            ms_level=ms_level,
+            retention_time=(ret_time if has_rt else nan("1")),
             file=self._f,
             transform=self._transform
         )

--- a/python/mscompress/datasets/torch.py
+++ b/python/mscompress/datasets/torch.py
@@ -1,10 +1,29 @@
-"""PyTorch DataLoaders for MSCompress datasets."""
+"""PyTorch DataLoaders for MSCompress datasets.
+
+Designed for multi-worker ``DataLoader`` use over large multi-shard datasets:
+
+- No per-spectrum index is materialized. A file is located from a global index
+  by binary search over a per-file prefix sum (O(n_files) memory, not
+  O(n_spectra)).
+- Files are opened lazily and per-process. ``MSCompressDataset.__init__`` only
+  reads each file's spectrum count (footer) and closes it again, so the parent
+  process holds no open handles — each ``DataLoader`` worker opens its own when
+  it first touches a shard.
+- All shards opened within one worker share a single byte-budgeted
+  ``BlockCache`` (see ``cache_bytes``), so the worker's decompressed-block
+  memory is bounded regardless of how many shards it samples. Under N workers,
+  size for ``RAM_target / N``.
+"""
+import bisect
+import os
+from pathlib import Path
+from typing import Union, Optional, List, Dict, Any
+
 import mscompress
 from mscompress.mszx import MSZXFile
 from mscompress.annotations.psms import BasePSMReader
 from mscompress.types import AnnotationFormat
-from typing import Union, Optional, List, Dict, Any
-from pathlib import Path
+
 try:
     import torch
     from torch.utils.data import Dataset
@@ -13,115 +32,223 @@ except ImportError as e:
         "PyTorch is required to use this module. Please install it via 'pip install torch'."
     ) from e
 
+_SUFFIXES = {".msz", ".mszx", ".mzml"}
+
+
+def _spectrum_to_tuple(spectrum, readers):
+    mz = torch.from_numpy(spectrum.mz)
+    intensity = torch.from_numpy(spectrum.intensity)
+    if readers:
+        annotations_dict: Dict[Any, Any] = {}
+        scan_number = spectrum.scan
+        for annotation_format, reader_list in readers.items():
+            format_psms = []
+            for reader in reader_list:
+                format_psms.extend(reader.get_by_scan(scan_number))
+            annotations_dict[annotation_format] = format_psms
+        return (mz, intensity, annotations_dict)
+    return (mz, intensity)
+
 
 class MSCompressDatasetMember:
-    def __init__(self, path: Union[str, Path], load_annotations: Optional[List[AnnotationFormat]] = None):
+    """A single MSZ/MSZX/mzML file. Opens lazily and per-process so it is safe
+    to construct in the parent and use from forked ``DataLoader`` workers."""
+
+    def __init__(
+        self,
+        path: Union[str, Path],
+        load_annotations: Optional[List[AnnotationFormat]] = None,
+        cache=None,
+    ):
         self._path = Path(path)
-        self._handle = mscompress.read(str(self._path))
         self._load_annotations: List[AnnotationFormat] = load_annotations or []
+        self._cache = cache  # None | 0 | int byte-budget | BlockCache (shared)
+        self._pid = None
+        self._handle = None
         self._annotation_readers: Dict[AnnotationFormat, List[BasePSMReader]] = {}
-        
-        # Load requested annotations if handle is MSZXFile
-        if isinstance(self._handle, MSZXFile) and self._load_annotations:
-            for annotation_format in self._load_annotations:
-                readers = self._handle.get_annotation_readers_by_format(annotation_format)
-                if readers:
-                    self._annotation_readers[annotation_format] = readers
-    
+        self._count: Optional[int] = None
+
     @property
     def path(self):
         return self._path
-    
+
+    def _resolve_cache(self):
+        # A bare int budget becomes a private per-process BlockCache; None/0/an
+        # explicit (shared) BlockCache are forwarded to read() as-is.
+        if isinstance(self._cache, int) and not isinstance(self._cache, bool) and self._cache > 0:
+            return mscompress.BlockCache(self._cache)
+        return self._cache
+
+    def _ensure_open(self):
+        pid = os.getpid()
+        if self._handle is None or self._pid != pid:
+            # New process (forked worker) or first use: open a fresh handle.
+            self._pid = pid
+            self._handle = mscompress.read(str(self._path), cache=self._resolve_cache())
+            self._annotation_readers = {}
+            if isinstance(self._handle, MSZXFile) and self._load_annotations:
+                for annotation_format in self._load_annotations:
+                    readers = self._handle.get_annotation_readers_by_format(annotation_format)
+                    if readers:
+                        self._annotation_readers[annotation_format] = readers
+        return self._handle
+
     def __len__(self) -> int:
-        """Return the number of spectra in the dataset member."""
-        return len(self._handle.spectra)
+        if self._count is None:
+            self._count = len(self._ensure_open().spectra)
+        return self._count
 
-    def __getitem__(
-            self,
-            index
-        ) -> Union[
-            tuple[torch.Tensor, torch.Tensor],
-            tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]
-        ]:
-        """Get spectrum by index in the MSZ/mzML file."""
-        spectrum = self._handle.spectra[index]
-        # Convert to tensors
-        mz = torch.from_numpy(spectrum.mz)
-        intensity = torch.from_numpy(spectrum.intensity)
+    def __getitem__(self, index):
+        handle = self._ensure_open()
+        return _spectrum_to_tuple(handle.spectra[index], self._annotation_readers)
 
-        # If annotations are loaded, include them in the return value
-        if self._annotation_readers:
-            annotations_dict = {}
-            scan_number = spectrum.scan
-            
-            for annotation_format, readers in self._annotation_readers.items():
-                # Get PSMs for this scan number from all readers of this format
-                format_psms = []
-                for reader in readers:
-                    psms = reader.get_by_scan(scan_number)
-                    format_psms.extend(psms)
-                annotations_dict[annotation_format] = format_psms
-            
-            return (mz, intensity, annotations_dict)
-        
-        return (mz, intensity)
+    def close(self):
+        if self._handle is not None:
+            try:
+                self._handle._cleanup()
+            except Exception:
+                pass
+            self._handle = None
+            self._annotation_readers = {}
 
 
 class MSCompressDataset(Dataset):
     def __init__(
-            self,
-            path: Union[str, Path],
-            load_annotations: Optional[List[AnnotationFormat]] = None
-        ):
-        """
-        Initialize the MSCompress dataset.
-        
+        self,
+        path: Union[str, Path],
+        load_annotations: Optional[List[AnnotationFormat]] = None,
+        cache_bytes: Optional[int] = None,
+        max_open_files: Optional[int] = None,
+    ):
+        """Map-style dataset over one file or a directory of files.
+
         Args:
-            path (Union[str, Path]): Path to a msz, mszx, or mzML file, or a directory containing such files.
-            load_annotations (Optional[List[AnnotationFormat]]): List of annotation formats to load from MSZX files.
-                Only applicable for MSZX files. Annotations will be returned in __getitem__ if present.
+            path: A .msz/.mszx/.mzML file, or a directory of such files.
+            load_annotations: Annotation formats to surface (MSZX only).
+            cache_bytes: Per-worker decompressed-block cache budget, shared
+                across all shards a worker opens. ``None`` (default) uses the
+                mscompress process-default BlockCache; ``0`` disables bounding
+                (legacy unbounded); a positive int sets the budget in bytes.
+                Under N DataLoader workers each worker gets its own, so size for
+                ``RAM_target / N``.
+            max_open_files: Optional cap on how many shard handles a worker
+                keeps open at once (LRU-evicted). ``None`` keeps all open.
         """
-        
         self._path = Path(path)
         self._load_annotations: List[AnnotationFormat] = load_annotations or []
-        
-        # Initialize dataset members
-        self.members = {}
-        if self._path.is_dir():
-            for file in self._path.iterdir():
-                if file.suffix.lower() in {'.msz', '.mszx', '.mzml'}:
-                    member = MSCompressDatasetMember(file, load_annotations=self._load_annotations)
-                    self.members[file.name] = member
-        elif self._path.suffix.lower() in {'.msz', '.mszx', '.mzml'}:
-            member = MSCompressDatasetMember(self._path, load_annotations=self._load_annotations)
-            self.members[self._path.name] = member
-        else:
-            raise ValueError("Provided path is neither a valid file nor a directory containing valid files.")
+        self._cache_bytes = cache_bytes
+        self._max_open_files = max_open_files
 
-        # Build index lookup
-        self._index_lookup = {}
-        global_index = 0
-        for member in self.members.values():
-            for local_index in range(len(member)):
-                self._index_lookup[global_index] = (member, local_index)
-                global_index += 1
-        self._total_spectra = global_index
+        # Enumerate files deterministically.
+        if self._path.is_dir():
+            files = sorted(
+                p for p in self._path.iterdir() if p.suffix.lower() in _SUFFIXES
+            )
+        elif self._path.suffix.lower() in _SUFFIXES:
+            files = [self._path]
+        else:
+            raise ValueError(
+                "Provided path is neither a valid file nor a directory containing valid files."
+            )
+        if not files:
+            raise ValueError(f"No .msz/.mszx/.mzML files found in {self._path}")
+
+        self._files: List[Path] = files
+
+        # Lightweight members (lazy, no open handle) keyed by filename, kept for
+        # backward compatibility / introspection. The hot path does not use them.
+        self.members: Dict[str, MSCompressDatasetMember] = {
+            f.name: MSCompressDatasetMember(f, load_annotations=self._load_annotations)
+            for f in files
+        }
+
+        # Per-file spectrum counts + prefix sum. Reading a count opens the file
+        # (footer only) and closes it again — the parent keeps no open handles
+        # and never materializes a per-spectrum index.
+        self._offsets: List[int] = [0]
+        for f in files:
+            m = MSCompressDatasetMember(f)
+            try:
+                self._offsets.append(self._offsets[-1] + len(m))
+            finally:
+                m.close()
+        self._total_spectra = self._offsets[-1]
+
+        # Per-process lazy state (created in the worker, never inherited).
+        self._proc_pid: Optional[int] = None
+        self._proc_cache = None
+        self._handles: "Dict[int, Any]" = {}
+        self._handle_order: List[int] = []
+        self._readers: Dict[int, Dict[AnnotationFormat, List[BasePSMReader]]] = {}
 
     @property
     def path(self):
         return self._path
-    
+
     def __len__(self) -> int:
-        """Return the total number of spectra in the dataset."""
         return self._total_spectra
-    
-    def __getitem__(self, index) -> Union[tuple[torch.Tensor, torch.Tensor], tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]]:
-        """Get spectrum by index across all dataset members."""
+
+    # -- per-process handle / cache management -----------------------------
+
+    def _make_cache(self):
+        if self._cache_bytes is None:
+            return None  # mscompress process-default BlockCache
+        if self._cache_bytes == 0:
+            return 0  # disable bounding
+        return mscompress.BlockCache(int(self._cache_bytes))
+
+    def _reset_process_state(self):
+        self._proc_pid = os.getpid()
+        # One BlockCache shared by every shard this worker opens, so the
+        # worker's total decompressed-block memory obeys one budget.
+        self._proc_cache = self._make_cache()
+        self._handles = {}
+        self._handle_order = []
+        self._readers = {}
+
+    def _get_handle(self, file_index: int):
+        if self._proc_pid != os.getpid():
+            self._reset_process_state()
+
+        handle = self._handles.get(file_index)
+        if handle is not None:
+            # LRU bump.
+            self._handle_order.remove(file_index)
+            self._handle_order.append(file_index)
+            return handle
+
+        handle = mscompress.read(str(self._files[file_index]), cache=self._proc_cache)
+        readers: Dict[AnnotationFormat, List[BasePSMReader]] = {}
+        if isinstance(handle, MSZXFile) and self._load_annotations:
+            for annotation_format in self._load_annotations:
+                rs = handle.get_annotation_readers_by_format(annotation_format)
+                if rs:
+                    readers[annotation_format] = rs
+
+        self._handles[file_index] = handle
+        self._readers[file_index] = readers
+        self._handle_order.append(file_index)
+
+        if self._max_open_files and len(self._handles) > self._max_open_files:
+            evict = self._handle_order.pop(0)
+            old = self._handles.pop(evict, None)
+            self._readers.pop(evict, None)
+            if old is not None:
+                try:
+                    old._cleanup()
+                except Exception:
+                    pass
+        return handle
+
+    def __getitem__(self, index):
         if index < 0:
-            index = self._total_spectra + index
-        
-        if index not in self._index_lookup:
-            raise IndexError(f"Index {index} out of range for dataset with {self._total_spectra} spectra.")
-        
-        member, local_index = self._index_lookup[index]
-        return member[local_index]
+            index += self._total_spectra
+        if not (0 <= index < self._total_spectra):
+            raise IndexError(
+                f"Index {index} out of range for dataset with {self._total_spectra} spectra."
+            )
+        # Locate the file: largest offset <= index.
+        file_index = bisect.bisect_right(self._offsets, index) - 1
+        local_index = index - self._offsets[file_index]
+        handle = self._get_handle(file_index)
+        return _spectrum_to_tuple(handle.spectra[local_index], self._readers[file_index])

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -9,6 +9,13 @@ from mscompress.datasets.torch import MSCompressDataset, MSCompressDatasetMember
 from mscompress.types import AnnotationFormat
 
 
+def _collate(batch):
+    # Module-level so it's picklable: macOS/Windows DataLoader workers use the
+    # 'spawn' start method, which pickles collate_fn. A test-local closure
+    # raises AttributeError on spawn (passes only under fork).
+    return [b[0] for b in batch], [b[1] for b in batch]
+
+
 def test_mscompress_dataset_single_file(msz_file_path):
     dataset = MSCompressDataset(msz_file_path)
     assert len(dataset.members) == 1
@@ -90,11 +97,8 @@ def test_dataloader_multiworker(test_data_dir):
     """End-to-end: a multi-worker DataLoader iterates the whole dataset."""
     dataset = MSCompressDataset(test_data_dir, cache_bytes=8 * 1024 * 1024)
 
-    def collate(batch):
-        return [b[0] for b in batch], [b[1] for b in batch]
-
     loader = DataLoader(
-        dataset, batch_size=4, shuffle=True, num_workers=2, collate_fn=collate
+        dataset, batch_size=4, shuffle=True, num_workers=2, collate_fn=_collate
     )
     seen = 0
     for mzs, intens in loader:

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -1,66 +1,116 @@
+import os
+
 import pytest
 
 torch = pytest.importorskip("torch")
+from torch.utils.data import DataLoader
 
-from mscompress.datasets.torch import MSCompressDataset
+from mscompress.datasets.torch import MSCompressDataset, MSCompressDatasetMember
 from mscompress.types import AnnotationFormat
+
 
 def test_mscompress_dataset_single_file(msz_file_path):
     dataset = MSCompressDataset(msz_file_path)
     assert len(dataset.members) == 1
-    member = next(iter(dataset.members.values()))
-    assert len(member) > 0
-    sample = member[0]
-    assert isinstance(sample, tuple)
-    assert len(sample) == 2
+    assert len(dataset) > 0
+    sample = dataset[0]
+    assert isinstance(sample, tuple) and len(sample) == 2
     mz, intensity = sample
-    assert mz.ndim == 1
-    assert intensity.ndim == 1
+    assert mz.ndim == 1 and intensity.ndim == 1
 
 
 def test_mscompress_dataset_directory(test_data_dir):
     dataset = MSCompressDataset(test_data_dir)
     assert len(dataset.members) > 0
-    total_spectra = sum(len(member) for member in dataset.members.values())
-    assert total_spectra > 0
-    assert dataset._total_spectra == total_spectra
+    assert dataset._total_spectra == len(dataset)
+    assert len(dataset) > 0
 
-    # Test global indexing
-    global_index = 0
-    for member in dataset.members.values():
-        for local_index in range(len(member)):
-            sample = dataset._index_lookup[global_index]
-            assert sample[0] is member
-            assert sample[1] == local_index
-            global_index += 1
-    assert global_index == total_spectra
+    # Prefix-sum offsets are monotonic and cover every spectrum exactly once.
+    assert dataset._offsets[0] == 0
+    assert dataset._offsets[-1] == len(dataset)
+    assert dataset._offsets == sorted(dataset._offsets)
 
-    # Test same sample from test.mzML and test.msz (identical data)
-    mzml_member = dataset.members["test.mzML"]
-    msz_member = dataset.members["test.msz"]
-    sample_mzml = mzml_member[0]
-    sample_msz = msz_member[0]
-    assert torch.equal(sample_mzml[0], sample_msz[0])
-    assert torch.equal(sample_mzml[1], sample_msz[1])
+    # Global indexing resolves to a valid (mz, intensity) tuple for every index.
+    for g in range(len(dataset)):
+        sample = dataset[g]
+        assert isinstance(sample, tuple)
+        assert sample[0].ndim == 1 and sample[1].ndim == 1
+
+    # Negative + out-of-range indexing.
+    assert torch.equal(dataset[-1][0], dataset[len(dataset) - 1][0])
+    with pytest.raises(IndexError):
+        dataset[len(dataset)]
+
+
+def test_dataset_identical_mzml_msz(test_data_dir):
+    """test.mzML and test.msz hold identical data; first spectrum matches."""
+    mzml = MSCompressDatasetMember(os.path.join(test_data_dir, "test.mzML"))
+    msz = MSCompressDatasetMember(os.path.join(test_data_dir, "test.msz"))
+    assert torch.equal(mzml[0][0], msz[0][0])
+    assert torch.equal(mzml[0][1], msz[0][1])
+
+
+def test_parent_holds_no_open_handles(test_data_dir):
+    """Construction must not keep file handles open or build a per-spectrum
+    index — only the lightweight prefix sum and lazy members."""
+    dataset = MSCompressDataset(test_data_dir)
+    assert dataset._handles == {}
+    assert dataset._proc_cache is None
+    assert not hasattr(dataset, "_index_lookup")
+    assert len(dataset._offsets) == len(dataset._files) + 1
+
+
+def test_cache_bytes_creates_shared_worker_cache(test_data_dir):
+    from mscompress import BlockCache
+    dataset = MSCompressDataset(test_data_dir, cache_bytes=8 * 1024 * 1024)
+    _ = dataset[0]  # triggers per-process open in this (main) process
+    assert isinstance(dataset._proc_cache, BlockCache)
+    assert dataset._proc_cache.budget == 8 * 1024 * 1024
+    if len(dataset._files) > 1:
+        _ = dataset[len(dataset) - 1]
+        assert len(dataset._handles) >= 2  # multiple shards, one shared cache
+
+
+def test_cache_zero_disables(test_data_dir):
+    dataset = MSCompressDataset(test_data_dir, cache_bytes=0)
+    _ = dataset[0]
+    assert dataset._proc_cache == 0  # bounding disabled
+
+
+def test_max_open_files_evicts(test_data_dir):
+    dataset = MSCompressDataset(test_data_dir, max_open_files=1)
+    if len(dataset._files) < 2:
+        pytest.skip("need >=2 files to test eviction")
+    _ = dataset[0]
+    _ = dataset[len(dataset) - 1]
+    assert len(dataset._handles) <= 1
+
+
+def test_dataloader_multiworker(test_data_dir):
+    """End-to-end: a multi-worker DataLoader iterates the whole dataset."""
+    dataset = MSCompressDataset(test_data_dir, cache_bytes=8 * 1024 * 1024)
+
+    def collate(batch):
+        return [b[0] for b in batch], [b[1] for b in batch]
+
+    loader = DataLoader(
+        dataset, batch_size=4, shuffle=True, num_workers=2, collate_fn=collate
+    )
+    seen = 0
+    for mzs, intens in loader:
+        assert len(mzs) == len(intens)
+        seen += len(mzs)
+    assert seen == len(dataset)
 
 
 def test_mscompress_dataset_w_annotations(mszx_file_path):
     dataset = MSCompressDataset(
-        mszx_file_path,
-        load_annotations=[AnnotationFormat.PEPXML]
+        mszx_file_path, load_annotations=[AnnotationFormat.PEPXML]
     )
-    assert len(dataset.members) > 0
-    total_spectra = sum(len(member) for member in dataset.members.values())
-    assert total_spectra > 0
-    assert dataset._total_spectra == total_spectra
-
-    # Check that annotations are accessible
-    for member_name, member in dataset.members.items():
-        for i in range(len(member)):
-            sample = member[i]
-            assert isinstance(sample, tuple)
-            assert len(sample) == 3
-            mz, intensity, psm = sample
-            assert mz.ndim == 1
-            assert intensity.ndim == 1
-            assert psm is not None
+    assert len(dataset) > 0
+    for i in range(len(dataset)):
+        sample = dataset[i]
+        assert isinstance(sample, tuple) and len(sample) == 3
+        mz, intensity, psm = sample
+        assert mz.ndim == 1 and intensity.ndim == 1
+        assert psm is not None

--- a/python/test/test_lazy_division_metadata.py
+++ b/python/test/test_lazy_division_metadata.py
@@ -1,0 +1,102 @@
+"""
+Coverage for lazy division metadata (PR-D).
+
+MSZFile no longer flattens the per-spectrum position arrays into one contiguous
+heap copy at open (~22.6 GB across 90 shards). Instead it keeps a per-division
+prefix-sum table and resolves a global spectrum index to (division, local) on
+demand, reading scan/ms_level straight from the mmap-backed per-division arrays.
+The flattened `.positions` Division is built lazily, only when accessed.
+
+These tests assert the resolver returns identical metadata to the flattened
+path, including across division boundaries.
+"""
+import os
+
+import numpy as np
+import pytest
+
+from mscompress import read
+from mscompress._core import MSZFile
+
+
+@pytest.fixture()
+def msz_multi(tmp_path, mzml_file_path):
+    """Compress with many divisions so the prefix-sum resolver crosses
+    division boundaries (n_threads high -> n_divisions = n_spectra)."""
+    out = tmp_path / "multi.msz"
+    with read(mzml_file_path) as f:
+        f.arguments.threads = 8  # force several divisions
+        f.compress(str(out))
+    return str(out)
+
+
+@pytest.fixture()
+def source_meta(mzml_file_path):
+    with read(mzml_file_path) as f:
+        return [(f.spectra[i].scan, int(f.spectra[i].ms_level))
+                for i in range(len(f.spectra))]
+
+
+def test_scan_ms_level_match_source(msz_multi, source_meta):
+    with read(msz_multi) as f:
+        assert len(f.spectra) == len(source_meta)
+        for i, (scan, ms) in enumerate(source_meta):
+            assert f.spectra[i].scan == scan, f"scan mismatch at {i}"
+            assert int(f.spectra[i].ms_level) == ms, f"ms_level mismatch at {i}"
+
+
+def test_resolver_matches_flattened_positions(msz_multi):
+    """The lazy resolver and the (lazily) flattened .positions arrays agree."""
+    with read(msz_multi) as f:
+        n = len(f.spectra)
+        resolver_scans = np.array([f.spectra[i].scan for i in range(n)])
+    with read(msz_multi) as g:
+        flat = np.asarray(g.positions.scans)
+        assert flat.shape[0] == n
+        assert np.array_equal(resolver_scans, flat)
+
+
+def test_positions_lazy_then_usable(msz_multi):
+    """.positions still returns a working Division (built on demand)."""
+    with read(msz_multi) as f:
+        pos = f.positions
+        assert len(np.asarray(pos.spectra.start_positions)) == len(f.spectra)
+        assert len(np.asarray(pos.mz.start_positions)) == len(f.spectra)
+        # Idempotent: second access returns consistent data.
+        assert np.array_equal(
+            np.asarray(pos.scans), np.asarray(f.positions.scans)
+        )
+
+
+def test_iteration_metadata_consistent(msz_multi, source_meta):
+    with read(msz_multi) as f:
+        got = [(s.scan, int(s.ms_level)) for s in f.spectra]
+    assert got == source_meta
+
+
+def test_mz_intensity_still_exact(msz_multi, mzml_file_path):
+    with read(mzml_file_path) as f:
+        gt = [(np.asarray(f.spectra[i].mz).copy(),
+               np.asarray(f.spectra[i].intensity).copy())
+              for i in range(len(f.spectra))]
+    with read(msz_multi) as f:
+        for i, (mz0, in0) in enumerate(gt):
+            assert np.array_equal(np.asarray(f.spectra[i].mz), mz0)
+            assert np.array_equal(np.asarray(f.spectra[i].intensity), in0)
+
+
+def test_describe_materializes_positions(msz_multi):
+    with read(msz_multi) as f:
+        d = f.describe()
+        assert "positions" in d
+        assert d["positions"] is not None
+
+
+def test_no_leak_across_open_close(msz_multi):
+    """Open/close cycles must free the prefix-sum table and any lazy flatten."""
+    for _ in range(10):
+        with read(msz_multi) as f:
+            for i in range(len(f.spectra)):
+                _ = f.spectra[i].scan
+            _ = f.positions  # force lazy flatten too
+    # No assertion beyond "did not crash / leak"; valgrind covers the rest.


### PR DESCRIPTION
## Summary
Eliminates the ~22.6 GB of fixed index metadata that opening the 90-shard `consensus_100M` dataset allocated **before reading a single spectrum** — the largest remaining memory item after the shared block cache (#163).

> Stacked on #163. Review that first; this PR's diff is the flatten removal + lazy resolver.

## Root cause
`MSZFile` open called `flatten_divisions()`, which mallocs one contiguous division and **copies** every per-spectrum position/scan/ms_level array out of the mmap'd footer — ~245 MB/shard, ~22.6 GB across 90 shards, on the heap.

Almost none of that copy is needed on the read path:
- `get_mz/inten/xml` already walk the per-division (mmap-backed) arrays.
- Only `Spectra` needs `scan`/`ms_level` per global index; only `.positions` / `describe()` need the flattened position arrays.

## Change
- Replace the eager flatten with a per-division spectrum-count **prefix sum** (`n_divisions+1` longs). A global index resolves to `(division, local)` by binary search.
- `scan`/`ms_level` read straight from the mmap-backed per-division arrays via a new `BaseFile._spectrum_meta()` (overridden in `MSZFile`). `Spectra._compute_spectrum()` routes through it instead of indexing a flattened `Division`.
- The flattened `Division` is built **lazily** by `_ensure_positions()` only when `.positions` / `describe()` are accessed.

### Deliberately NOT changed: the `* 2` over-allocation in `alloc_dp`
It looks like free waste but it's **load-bearing by accident**: `scan_mzml()` allocates `xml_dp = alloc_dp(N*2)` then writes index `2N` after its loop, so the internal doubling is the only thing preventing a 1-element heap overflow on the **compress** path. Removing it as a "one-liner" would corrupt the heap during compression. Skipping the flatten eliminates the read-path waste anyway, so this PR leaves `alloc_dp` untouched (noted in the commit).

## Measured (90 shards, 110M spectra)
| Metric | before (#163) | after | Δ |
|---|---|---|---|
| **RSS after opening all 90 shards** | 22.57 GB | **7.64 GB** | **−14.9 GB (−66%)** |
| Open time (warm) | 8.7 s | 4.7 s | −46% |
| Random read rate | ~30/s | 30/s | unchanged |
| Sequential read rate | — | ~20k/s | no regression |

The 14.9 GB removed is the heap flatten copy. The residual ~7.6 GB is the footer's own mmap page residency (reclaimable file pages) — `madvise(MADV_RANDOM/DONTNEED)` is the next lever for that.

## Tests
`ctest` 42/42; `pytest` 248 passed, 1 xfailed. New `test_lazy_division_metadata.py` (7): scan/ms_level match source, resolver == flattened `.positions`, cross-division correctness, lazy `.positions`, `describe()` materializes, mz/intensity still byte-exact, no-leak across open/close.
