### PR TITLE
perf(datasets): lazy, per-worker MSCompressDataset for multi-worker DataLoader

### DIFF
--- a/python/mscompress/datasets/torch.py
+++ b/python/mscompress/datasets/torch.py
@@ -1,10 +1,29 @@
-"""PyTorch DataLoaders for MSCompress datasets."""
+"""PyTorch DataLoaders for MSCompress datasets.
+
+Designed for multi-worker ``DataLoader`` use over large multi-shard datasets:
+
+- No per-spectrum index is materialized. A file is located from a global index
+  by binary search over a per-file prefix sum (O(n_files) memory, not
+  O(n_spectra)).
+- Files are opened lazily and per-process. ``MSCompressDataset.__init__`` only
+  reads each file's spectrum count (footer) and closes it again, so the parent
+  process holds no open handles — each ``DataLoader`` worker opens its own when
+  it first touches a shard.
+- All shards opened within one worker share a single byte-budgeted
+  ``BlockCache`` (see ``cache_bytes``), so the worker's decompressed-block
+  memory is bounded regardless of how many shards it samples. Under N workers,
+  size for ``RAM_target / N``.
+"""
+import bisect
+import os
+from pathlib import Path
+from typing import Union, Optional, List, Dict, Any
+
 import mscompress
 from mscompress.mszx import MSZXFile
 from mscompress.annotations.psms import BasePSMReader
 from mscompress.types import AnnotationFormat
-from typing import Union, Optional, List, Dict, Any
-from pathlib import Path
+
 try:
     import torch
     from torch.utils.data import Dataset
@@ -13,115 +32,223 @@ except ImportError as e:
         "PyTorch is required to use this module. Please install it via 'pip install torch'."
     ) from e
 
+_SUFFIXES = {".msz", ".mszx", ".mzml"}
+
+
+def _spectrum_to_tuple(spectrum, readers):
+    mz = torch.from_numpy(spectrum.mz)
+    intensity = torch.from_numpy(spectrum.intensity)
+    if readers:
+        annotations_dict: Dict[Any, Any] = {}
+        scan_number = spectrum.scan
+        for annotation_format, reader_list in readers.items():
+            format_psms = []
+            for reader in reader_list:
+                format_psms.extend(reader.get_by_scan(scan_number))
+            annotations_dict[annotation_format] = format_psms
+        return (mz, intensity, annotations_dict)
+    return (mz, intensity)
+
 
 class MSCompressDatasetMember:
-    def __init__(self, path: Union[str, Path], load_annotations: Optional[List[AnnotationFormat]] = None):
+    """A single MSZ/MSZX/mzML file. Opens lazily and per-process so it is safe
+    to construct in the parent and use from forked ``DataLoader`` workers."""
+
+    def __init__(
+        self,
+        path: Union[str, Path],
+        load_annotations: Optional[List[AnnotationFormat]] = None,
+        cache=None,
+    ):
         self._path = Path(path)
-        self._handle = mscompress.read(str(self._path))
         self._load_annotations: List[AnnotationFormat] = load_annotations or []
+        self._cache = cache  # None | 0 | int byte-budget | BlockCache (shared)
+        self._pid = None
+        self._handle = None
         self._annotation_readers: Dict[AnnotationFormat, List[BasePSMReader]] = {}
-        
-        # Load requested annotations if handle is MSZXFile
-        if isinstance(self._handle, MSZXFile) and self._load_annotations:
-            for annotation_format in self._load_annotations:
-                readers = self._handle.get_annotation_readers_by_format(annotation_format)
-                if readers:
-                    self._annotation_readers[annotation_format] = readers
-    
+        self._count: Optional[int] = None
+
     @property
     def path(self):
         return self._path
-    
+
+    def _resolve_cache(self):
+        # A bare int budget becomes a private per-process BlockCache; None/0/an
+        # explicit (shared) BlockCache are forwarded to read() as-is.
+        if isinstance(self._cache, int) and not isinstance(self._cache, bool) and self._cache > 0:
+            return mscompress.BlockCache(self._cache)
+        return self._cache
+
+    def _ensure_open(self):
+        pid = os.getpid()
+        if self._handle is None or self._pid != pid:
+            # New process (forked worker) or first use: open a fresh handle.
+            self._pid = pid
+            self._handle = mscompress.read(str(self._path), cache=self._resolve_cache())
+            self._annotation_readers = {}
+            if isinstance(self._handle, MSZXFile) and self._load_annotations:
+                for annotation_format in self._load_annotations:
+                    readers = self._handle.get_annotation_readers_by_format(annotation_format)
+                    if readers:
+                        self._annotation_readers[annotation_format] = readers
+        return self._handle
+
     def __len__(self) -> int:
-        """Return the number of spectra in the dataset member."""
-        return len(self._handle.spectra)
+        if self._count is None:
+            self._count = len(self._ensure_open().spectra)
+        return self._count
 
-    def __getitem__(
-            self,
-            index
-        ) -> Union[
-            tuple[torch.Tensor, torch.Tensor],
-            tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]
-        ]:
-        """Get spectrum by index in the MSZ/mzML file."""
-        spectrum = self._handle.spectra[index]
-        # Convert to tensors
-        mz = torch.from_numpy(spectrum.mz)
-        intensity = torch.from_numpy(spectrum.intensity)
+    def __getitem__(self, index):
+        handle = self._ensure_open()
+        return _spectrum_to_tuple(handle.spectra[index], self._annotation_readers)
 
-        # If annotations are loaded, include them in the return value
-        if self._annotation_readers:
-            annotations_dict = {}
-            scan_number = spectrum.scan
-            
-            for annotation_format, readers in self._annotation_readers.items():
-                # Get PSMs for this scan number from all readers of this format
-                format_psms = []
-                for reader in readers:
-                    psms = reader.get_by_scan(scan_number)
-                    format_psms.extend(psms)
-                annotations_dict[annotation_format] = format_psms
-            
-            return (mz, intensity, annotations_dict)
-        
-        return (mz, intensity)
+    def close(self):
+        if self._handle is not None:
+            try:
+                self._handle._cleanup()
+            except Exception:
+                pass
+            self._handle = None
+            self._annotation_readers = {}
 
 
 class MSCompressDataset(Dataset):
     def __init__(
-            self,
-            path: Union[str, Path],
-            load_annotations: Optional[List[AnnotationFormat]] = None
-        ):
-        """
-        Initialize the MSCompress dataset.
-        
+        self,
+        path: Union[str, Path],
+        load_annotations: Optional[List[AnnotationFormat]] = None,
+        cache_bytes: Optional[int] = None,
+        max_open_files: Optional[int] = None,
+    ):
+        """Map-style dataset over one file or a directory of files.
+
         Args:
-            path (Union[str, Path]): Path to a msz, mszx, or mzML file, or a directory containing such files.
-            load_annotations (Optional[List[AnnotationFormat]]): List of annotation formats to load from MSZX files.
-                Only applicable for MSZX files. Annotations will be returned in __getitem__ if present.
+            path: A .msz/.mszx/.mzML file, or a directory of such files.
+            load_annotations: Annotation formats to surface (MSZX only).
+            cache_bytes: Per-worker decompressed-block cache budget, shared
+                across all shards a worker opens. ``None`` (default) uses the
+                mscompress process-default BlockCache; ``0`` disables bounding
+                (legacy unbounded); a positive int sets the budget in bytes.
+                Under N DataLoader workers each worker gets its own, so size for
+                ``RAM_target / N``.
+            max_open_files: Optional cap on how many shard handles a worker
+                keeps open at once (LRU-evicted). ``None`` keeps all open.
         """
-        
         self._path = Path(path)
         self._load_annotations: List[AnnotationFormat] = load_annotations or []
-        
-        # Initialize dataset members
-        self.members = {}
-        if self._path.is_dir():
-            for file in self._path.iterdir():
-                if file.suffix.lower() in {'.msz', '.mszx', '.mzml'}:
-                    member = MSCompressDatasetMember(file, load_annotations=self._load_annotations)
-                    self.members[file.name] = member
-        elif self._path.suffix.lower() in {'.msz', '.mszx', '.mzml'}:
-            member = MSCompressDatasetMember(self._path, load_annotations=self._load_annotations)
-            self.members[self._path.name] = member
-        else:
-            raise ValueError("Provided path is neither a valid file nor a directory containing valid files.")
+        self._cache_bytes = cache_bytes
+        self._max_open_files = max_open_files
 
-        # Build index lookup
-        self._index_lookup = {}
-        global_index = 0
-        for member in self.members.values():
-            for local_index in range(len(member)):
-                self._index_lookup[global_index] = (member, local_index)
-                global_index += 1
-        self._total_spectra = global_index
+        # Enumerate files deterministically.
+        if self._path.is_dir():
+            files = sorted(
+                p for p in self._path.iterdir() if p.suffix.lower() in _SUFFIXES
+            )
+        elif self._path.suffix.lower() in _SUFFIXES:
+            files = [self._path]
+        else:
+            raise ValueError(
+                "Provided path is neither a valid file nor a directory containing valid files."
+            )
+        if not files:
+            raise ValueError(f"No .msz/.mszx/.mzML files found in {self._path}")
+
+        self._files: List[Path] = files
+
+        # Lightweight members (lazy, no open handle) keyed by filename, kept for
+        # backward compatibility / introspection. The hot path does not use them.
+        self.members: Dict[str, MSCompressDatasetMember] = {
+            f.name: MSCompressDatasetMember(f, load_annotations=self._load_annotations)
+            for f in files
+        }
+
+        # Per-file spectrum counts + prefix sum. Reading a count opens the file
+        # (footer only) and closes it again — the parent keeps no open handles
+        # and never materializes a per-spectrum index.
+        self._offsets: List[int] = [0]
+        for f in files:
+            m = MSCompressDatasetMember(f)
+            try:
+                self._offsets.append(self._offsets[-1] + len(m))
+            finally:
+                m.close()
+        self._total_spectra = self._offsets[-1]
+
+        # Per-process lazy state (created in the worker, never inherited).
+        self._proc_pid: Optional[int] = None
+        self._proc_cache = None
+        self._handles: "Dict[int, Any]" = {}
+        self._handle_order: List[int] = []
+        self._readers: Dict[int, Dict[AnnotationFormat, List[BasePSMReader]]] = {}
 
     @property
     def path(self):
         return self._path
-    
+
     def __len__(self) -> int:
-        """Return the total number of spectra in the dataset."""
         return self._total_spectra
-    
-    def __getitem__(self, index) -> Union[tuple[torch.Tensor, torch.Tensor], tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]]:
-        """Get spectrum by index across all dataset members."""
+
+    # -- per-process handle / cache management -----------------------------
+
+    def _make_cache(self):
+        if self._cache_bytes is None:
+            return None  # mscompress process-default BlockCache
+        if self._cache_bytes == 0:
+            return 0  # disable bounding
+        return mscompress.BlockCache(int(self._cache_bytes))
+
+    def _reset_process_state(self):
+        self._proc_pid = os.getpid()
+        # One BlockCache shared by every shard this worker opens, so the
+        # worker's total decompressed-block memory obeys one budget.
+        self._proc_cache = self._make_cache()
+        self._handles = {}
+        self._handle_order = []
+        self._readers = {}
+
+    def _get_handle(self, file_index: int):
+        if self._proc_pid != os.getpid():
+            self._reset_process_state()
+
+        handle = self._handles.get(file_index)
+        if handle is not None:
+            # LRU bump.
+            self._handle_order.remove(file_index)
+            self._handle_order.append(file_index)
+            return handle
+
+        handle = mscompress.read(str(self._files[file_index]), cache=self._proc_cache)
+        readers: Dict[AnnotationFormat, List[BasePSMReader]] = {}
+        if isinstance(handle, MSZXFile) and self._load_annotations:
+            for annotation_format in self._load_annotations:
+                rs = handle.get_annotation_readers_by_format(annotation_format)
+                if rs:
+                    readers[annotation_format] = rs
+
+        self._handles[file_index] = handle
+        self._readers[file_index] = readers
+        self._handle_order.append(file_index)
+
+        if self._max_open_files and len(self._handles) > self._max_open_files:
+            evict = self._handle_order.pop(0)
+            old = self._handles.pop(evict, None)
+            self._readers.pop(evict, None)
+            if old is not None:
+                try:
+                    old._cleanup()
+                except Exception:
+                    pass
+        return handle
+
+    def __getitem__(self, index):
         if index < 0:
-            index = self._total_spectra + index
-        
-        if index not in self._index_lookup:
-            raise IndexError(f"Index {index} out of range for dataset with {self._total_spectra} spectra.")
-        
-        member, local_index = self._index_lookup[index]
-        return member[local_index]
+            index += self._total_spectra
+        if not (0 <= index < self._total_spectra):
+            raise IndexError(
+                f"Index {index} out of range for dataset with {self._total_spectra} spectra."
+            )
+        # Locate the file: largest offset <= index.
+        file_index = bisect.bisect_right(self._offsets, index) - 1
+        local_index = index - self._offsets[file_index]
+        handle = self._get_handle(file_index)
+        return _spectrum_to_tuple(handle.spectra[local_index], self._readers[file_index])

--- a/python/test/test_dataset.py
+++ b/python/test/test_dataset.py
@@ -1,66 +1,116 @@
+import os
+
 import pytest
 
 torch = pytest.importorskip("torch")
+from torch.utils.data import DataLoader
 
-from mscompress.datasets.torch import MSCompressDataset
+from mscompress.datasets.torch import MSCompressDataset, MSCompressDatasetMember
 from mscompress.types import AnnotationFormat
+
 
 def test_mscompress_dataset_single_file(msz_file_path):
     dataset = MSCompressDataset(msz_file_path)
     assert len(dataset.members) == 1
-    member = next(iter(dataset.members.values()))
-    assert len(member) > 0
-    sample = member[0]
-    assert isinstance(sample, tuple)
-    assert len(sample) == 2
+    assert len(dataset) > 0
+    sample = dataset[0]
+    assert isinstance(sample, tuple) and len(sample) == 2
     mz, intensity = sample
-    assert mz.ndim == 1
-    assert intensity.ndim == 1
+    assert mz.ndim == 1 and intensity.ndim == 1
 
 
 def test_mscompress_dataset_directory(test_data_dir):
     dataset = MSCompressDataset(test_data_dir)
     assert len(dataset.members) > 0
-    total_spectra = sum(len(member) for member in dataset.members.values())
-    assert total_spectra > 0
-    assert dataset._total_spectra == total_spectra
+    assert dataset._total_spectra == len(dataset)
+    assert len(dataset) > 0
 
-    # Test global indexing
-    global_index = 0
-    for member in dataset.members.values():
-        for local_index in range(len(member)):
-            sample = dataset._index_lookup[global_index]
-            assert sample[0] is member
-            assert sample[1] == local_index
-            global_index += 1
-    assert global_index == total_spectra
+    # Prefix-sum offsets are monotonic and cover every spectrum exactly once.
+    assert dataset._offsets[0] == 0
+    assert dataset._offsets[-1] == len(dataset)
+    assert dataset._offsets == sorted(dataset._offsets)
 
-    # Test same sample from test.mzML and test.msz (identical data)
-    mzml_member = dataset.members["test.mzML"]
-    msz_member = dataset.members["test.msz"]
-    sample_mzml = mzml_member[0]
-    sample_msz = msz_member[0]
-    assert torch.equal(sample_mzml[0], sample_msz[0])
-    assert torch.equal(sample_mzml[1], sample_msz[1])
+    # Global indexing resolves to a valid (mz, intensity) tuple for every index.
+    for g in range(len(dataset)):
+        sample = dataset[g]
+        assert isinstance(sample, tuple)
+        assert sample[0].ndim == 1 and sample[1].ndim == 1
+
+    # Negative + out-of-range indexing.
+    assert torch.equal(dataset[-1][0], dataset[len(dataset) - 1][0])
+    with pytest.raises(IndexError):
+        dataset[len(dataset)]
+
+
+def test_dataset_identical_mzml_msz(test_data_dir):
+    """test.mzML and test.msz hold identical data; first spectrum matches."""
+    mzml = MSCompressDatasetMember(os.path.join(test_data_dir, "test.mzML"))
+    msz = MSCompressDatasetMember(os.path.join(test_data_dir, "test.msz"))
+    assert torch.equal(mzml[0][0], msz[0][0])
+    assert torch.equal(mzml[0][1], msz[0][1])
+
+
+def test_parent_holds_no_open_handles(test_data_dir):
+    """Construction must not keep file handles open or build a per-spectrum
+    index — only the lightweight prefix sum and lazy members."""
+    dataset = MSCompressDataset(test_data_dir)
+    assert dataset._handles == {}
+    assert dataset._proc_cache is None
+    assert not hasattr(dataset, "_index_lookup")
+    assert len(dataset._offsets) == len(dataset._files) + 1
+
+
+def test_cache_bytes_creates_shared_worker_cache(test_data_dir):
+    from mscompress import BlockCache
+    dataset = MSCompressDataset(test_data_dir, cache_bytes=8 * 1024 * 1024)
+    _ = dataset[0]  # triggers per-process open in this (main) process
+    assert isinstance(dataset._proc_cache, BlockCache)
+    assert dataset._proc_cache.budget == 8 * 1024 * 1024
+    if len(dataset._files) > 1:
+        _ = dataset[len(dataset) - 1]
+        assert len(dataset._handles) >= 2  # multiple shards, one shared cache
+
+
+def test_cache_zero_disables(test_data_dir):
+    dataset = MSCompressDataset(test_data_dir, cache_bytes=0)
+    _ = dataset[0]
+    assert dataset._proc_cache == 0  # bounding disabled
+
+
+def test_max_open_files_evicts(test_data_dir):
+    dataset = MSCompressDataset(test_data_dir, max_open_files=1)
+    if len(dataset._files) < 2:
+        pytest.skip("need >=2 files to test eviction")
+    _ = dataset[0]
+    _ = dataset[len(dataset) - 1]
+    assert len(dataset._handles) <= 1
+
+
+def test_dataloader_multiworker(test_data_dir):
+    """End-to-end: a multi-worker DataLoader iterates the whole dataset."""
+    dataset = MSCompressDataset(test_data_dir, cache_bytes=8 * 1024 * 1024)
+
+    def collate(batch):
+        return [b[0] for b in batch], [b[1] for b in batch]
+
+    loader = DataLoader(
+        dataset, batch_size=4, shuffle=True, num_workers=2, collate_fn=collate
+    )
+    seen = 0
+    for mzs, intens in loader:
+        assert len(mzs) == len(intens)
+        seen += len(mzs)
+    assert seen == len(dataset)
 
 
 def test_mscompress_dataset_w_annotations(mszx_file_path):
     dataset = MSCompressDataset(
-        mszx_file_path,
-        load_annotations=[AnnotationFormat.PEPXML]
+        mszx_file_path, load_annotations=[AnnotationFormat.PEPXML]
     )
-    assert len(dataset.members) > 0
-    total_spectra = sum(len(member) for member in dataset.members.values())
-    assert total_spectra > 0
-    assert dataset._total_spectra == total_spectra
-
-    # Check that annotations are accessible
-    for member_name, member in dataset.members.items():
-        for i in range(len(member)):
-            sample = member[i]
-            assert isinstance(sample, tuple)
-            assert len(sample) == 3
-            mz, intensity, psm = sample
-            assert mz.ndim == 1
-            assert intensity.ndim == 1
-            assert psm is not None
+    assert len(dataset) > 0
+    for i in range(len(dataset)):
+        sample = dataset[i]
+        assert isinstance(sample, tuple) and len(sample) == 3
+        mz, intensity, psm = sample
+        assert mz.ndim == 1 and intensity.ndim == 1
+        assert psm is not None


### PR DESCRIPTION
## Summary
Makes `MSCompressDataset` usable with a multi-worker `DataLoader` over large multi-shard datasets. The old dataset undercut all the prior memory work the moment you set `num_workers>0`.

> Stacked on #165. Review the stack first.

## Problems in the old dataset
1. **`__init__` built a `{global_index: (member, local_index)}` dict with one entry per spectrum** — ~15 GB for 110M spectra — in the parent process. (Same `[None]*N` anti-pattern fixed in C by #162/#165, here in Python and heavier per entry.)
2. **It opened every shard in `__init__`** (parent process): all mmaps, dctxs, block-len queues, BlockCache. With the default `fork` start method, each worker inherits copy-on-write copies of all of it (incl. the `ZSTD_DCtx`, not meant to cross a fork; and the process-default BlockCache, which each worker then diverges into).
3. **No way to size a per-worker block-cache budget**, so the #163 budget multiplied implicitly by `num_workers`.

## Change
- Replace the per-spectrum dict with a **per-file prefix sum + `bisect`** in `__getitem__` — O(n_files) memory, O(log n_files) lookup.
- Open shards **lazily and per-process** (pid-guarded). `__init__` only reads each file's spectrum count (footer) and closes it again, so the parent holds **no** open handles; each worker opens its own on first touch.
- All shards a worker opens **share one byte-budgeted `BlockCache`** via the new `cache_bytes=` arg, so a worker's decompressed-block memory is bounded no matter how many shards it samples. Under N workers, size for `RAM_target / N`.
- Optional `max_open_files=` LRU-bounds how many shard handles a worker keeps open.
- `.members` stays (now lazy) for introspection / single-file use. Public Dataset contract (`len`, indexing, `path`) unchanged.

## Measured (90 shards, 110M spectra, random sampling, 512 MB/worker cache)
| num_workers | parent RSS after build | peak tree RSS | spectra/s | epoch-slice |
|---|---|---|---|---|
| 0 | **0.138 GB** | 25.4 GB | 16.3 | 58.9 s |
| 4 | **0.138 GB** | 51.5 GB | 39.5 | 24.3 s |
| 8 | **0.138 GB** | 76.2 GB | 54.1 | 17.8 s |

- **Parent RSS after constructing over all 90 shards: 0.138 GB**, independent of worker count — vs the old ~15 GB index dict + ~22 GB of eager opens.
- **Throughput now scales with workers** (16 → 40 → 54 spectra/s for 0 → 4 → 8), where before each worker inherited the 15 GB dict and reopened everything.
- Aggregate tree RSS grows per-worker; with `cache_bytes` the *heap* block cache per worker is bounded, and the remainder is per-worker reclaimable mmap footer/page residency — the `madvise(MADV_RANDOM/DONTNEED)` follow-up (noted on #163) is the lever for that, and matters more with workers.

Random-access throughput stays modest because of the ~6000× read amplification from coarse 97-division shards (a compression-time layout property, separate ticket) — but workers now scale it.

## Tests
`pytest` 254 passed, 1 xfailed. `test_dataset.py` rewritten + extended (9): prefix-sum offsets, parent holds no open handles, `cache_bytes` makes a shared per-worker cache, `cache_bytes=0` disables, `max_open_files` eviction, and an **end-to-end `num_workers=2` `DataLoader`** run covering the full dataset.
