### PR TITLE
ci: add ASan/LeakSanitizer CLI job to catch memory leaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,49 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Memory-leak gate: builds the CLI with AddressSanitizer + LeakSanitizer and runs
+  # the full ctest suite under it. Catches leak classes like the unbalanced zlib
+  # inflateInit/inflateEnd leak (test/data/sciex_ttof6600_100.mzML has 201 zlib
+  # blocks; the CompressSciexNoScanAttr test exercises that decode path).
+  # Linux-only: ASan/LSan is a gcc/clang feature. Kept separate from the build-cli
+  # matrix so a sanitizer failure is clearly attributable and doesn't disturb
+  # artifact uploads.
+  asan-leak-cli:
+    name: ASan/LSan CLI (linux x86_64)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
+          submodules: recursive
+
+      - name: Configure CMake (ASan/LSan)
+        working-directory: ./cli
+        run: >
+          cmake -S . -B build-asan
+          -DENABLE_DEBUG_SYMBOLS=ON
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_C_FLAGS="-fsanitize=address,leak -fno-omit-frame-pointer -g -O1"
+          -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,leak"
+
+      - name: Build CLI (ASan/LSan)
+        working-directory: ./cli
+        run: cmake --build build-asan -j
+
+      - name: Verify sanitizer instrumentation
+        working-directory: ./cli
+        run: |
+          nm build-asan/mscompress | grep -q __asan
+          ldd build-asan/mscompress | grep -qi libasan
+
+      - name: Run CTest under LeakSanitizer
+        working-directory: ./cli/build-asan
+        env:
+          ASAN_OPTIONS: detect_leaks=1:abort_on_error=1:halt_on_error=1:symbolize=1
+        run: ctest --output-on-failure
+
   build-python:
     name: Build Python - ${{ matrix.runner }} ${{ matrix.cibw_arch }}
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
## What

Adds a dedicated CI job `asan-leak-cli` ("ASan/LSan CLI (linux x86_64)") to `.github/workflows/build.yml` that:

- builds the CLI with `-fsanitize=address,leak -fno-omit-frame-pointer -g -O1` in a dedicated `cli/build-asan` dir (tests reference the binary via `$<TARGET_FILE:mscompress>`, so no clobbering of the normal build),
- verifies the binary is actually instrumented (`nm | grep __asan`, `ldd | grep libasan`),
- runs the **existing** ctest suite with `ASAN_OPTIONS=detect_leaks=1:abort_on_error=1:halt_on_error=1:symbolize=1` — any leak aborts the process, fails the test, fails the job.

## Why

We recently found and fixed a serious heap leak in the CLI (unbalanced zlib `inflateInit`/`inflateEnd`, plus a leaked division struct and a `serialize_df` buffer) that OOM-killed large batch runs. Nothing in CI would have caught it. This job makes that class of bug fail the build.

## Scoping

- **Linux x86_64 only** (`ubuntu-latest`) — ASan/LSan is a gcc/clang feature; not added to the Windows/macOS matrix.
- **Separate job**, not part of the `build-cli` matrix, so a sanitizer failure is clearly attributable and doesn't disturb artifact uploads.
- **No new test fixtures needed**: `test/data/sciex_ttof6600_100.mzML` has 201 zlib blocks and the existing `CompressSciexNoScanAttr` test (cli/test/CMakeLists.txt:122) compresses it, so the zlib decode/encode path is exercised by the existing suite.
- **No suppressions file**: every leak LSan reports on current `dev` traces into *our* source (`src/zl.c`, `src/preprocess.c`, `src/file.c`) — none are benign one-time globals or vendored-library-internal leaks, so an `lsan.supp` is not justified. Suppressing them would defeat the gate.

## ⚠️ Expected RED on this PR (deliberate, not a job bug)

The leak fixes live on `feat/mszx-batch-mode`, which is **not merged to dev yet**. On current dev, the ASan job correctly detects those real leaks: locally, **37 of 43 tests fail** under LSan (the 6 passing are the trivial version/help/list-algorithms tests). Representative LSan stack from `CompressSciexNoScanAttr` — this is exactly the leak the job exists to catch:

```
Direct leak of 1816000 byte(s) in 200 object(s) allocated from:
    #1 zcalloc
    #2 inflateInit2_
    #3 inflateInit_
    #4 zlib_decompress src/zl.c:221
    #5 decode_zlib_fun src/decode.c:115
    #6 algo_decode_lossless src/algos/lossless.c:33
    #7 cmp_binary_routine src/compress.c:562
    #8 compress_routine src/compress.c:695
```

Plus `deflateInit_` streams from `alloc_z_stream` (src/zl.c:115), `alloc_dp` division structs (src/preprocess.c:126/140/141), and the `serialize_df` buffer (src/file.c:248) — all the leaks fixed on `feat/mszx-batch-mode`.

**Tradeoff considered:** scoping the ctest run to leak-clean tests or marking the job `continue-on-error` would give green CI on this PR immediately, but would defeat the purpose of the gate. I kept the job strict; it will go green once `feat/mszx-batch-mode` merges. The red check on this PR is the job doing its job.

## Local verification (real output, this worktree, gcc 13)

Instrumentation check:
```
$ nm build-asan/mscompress | grep -c __asan
30
$ ldd build-asan/mscompress | grep asan
        libasan.so.8 => /lib/x86_64-linux-gnu/libasan.so.8
```

Full suite under LSan on dev (expected red, see above):
```
14% tests passed, 37 tests failed out of 43
SUMMARY: AddressSanitizer: 8728 byte(s) leaked in 17 allocation(s).  (example, CompressTest)
```

Gate-catches-leaks proof — temporarily injected `volatile char *p = malloc(1); p[0] = 42;` into the `--version` path (exercised by the currently-green VersionTest), rebuilt, ran ctest (a bare `malloc(1)` is dead-code-eliminated at -O1, so the canary write is needed):
```
1/1 Test #1: VersionTest ......................Subprocess aborted***Exception:   1.17 sec
==1904129==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #1 parse_arguments cli/mscompress.c:245
    #2 main cli/mscompress.c:294
SUMMARY: AddressSanitizer: 1 byte(s) leaked in 1 allocation(s).
0% tests passed, 1 tests failed out of 1
```
After reverting the injected leak (not committed):
```
1/1 Test #1: VersionTest ......................   Passed    0.01 sec
100% tests passed, 0 tests failed out of 1
```

YAML validated with `python -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"`.
`git diff --name-only origin/dev..HEAD` → `.github/workflows/build.yml` only.
