### PR TITLE
fix(cli): fix memory leaks (zlib inflate lifecycle, division, serialize_df buffer)

### DIFF
--- a/python/mscompress/_core.pyx
+++ b/python/mscompress/_core.pyx
@@ -837,7 +837,7 @@ cdef class MZMLFile(BaseFile):
         mapping_ptr = <char*>self._mapping
         mapping_ptr += start
 
-        self._df.decode_source_compression_mz_fun(self._z, mapping_ptr, end - start, &dest, &out_len, tmp)
+        self._df.decode_source_compression_mz_fun(self._z_inflate, mapping_ptr, end - start, &dest, &out_len, tmp)
         decode_output = dest  # Save pointer to decode function's allocation
 
         dest += ZLIB_SIZE_OFFSET # Skip zlib header
@@ -889,7 +889,7 @@ cdef class MZMLFile(BaseFile):
         mapping_ptr = <char*>self._mapping
         mapping_ptr += start
 
-        self._df.decode_source_compression_inten_fun(self._z, mapping_ptr, end - start, &dest, &out_len, tmp)
+        self._df.decode_source_compression_inten_fun(self._z_inflate, mapping_ptr, end - start, &dest, &out_len, tmp)
         decode_output = dest  # Save pointer to decode function's allocation
 
         dest += ZLIB_SIZE_OFFSET # Skip zlib header
@@ -1115,6 +1115,7 @@ cdef class MSZFile(BaseFile):
         self._block_cache = _coerce_cache(None)   # read() may override
         self._arguments = RuntimeArguments()
         self._z = _alloc_z_stream()
+        self._z_inflate = _alloc_z_stream_inflate()
         self.output_fd = -1
         self._df = NULL
         self._divisions = NULL
@@ -1911,6 +1912,10 @@ cdef class BaseFile:
                                     # pure-Python read() factory can assign it.
     cdef RuntimeArguments _arguments
     cdef z_stream* _z
+    cdef z_stream* _z_inflate  # Dedicated inflate stream: _z is deflate-
+                               # initialized and must never be fed to
+                               # zlib_decompress (init once, inflateReset
+                               # per block inside zlib_decompress).
     cdef int output_fd
 
 
@@ -1928,6 +1933,7 @@ cdef class BaseFile:
         self._cache_spectra = CACHE_SPECTRA_AUTO  # read() may override
         self._arguments = RuntimeArguments()
         self._z = _alloc_z_stream()
+        self._z_inflate = _alloc_z_stream_inflate()
         self.output_fd = -1
         # Initialize pointers to NULL to prevent undefined behavior
         self._df = NULL
@@ -2013,6 +2019,11 @@ cdef class BaseFile:
         if self._z != NULL:
             _dealloc_z_stream(self._z)
             self._z = NULL
+
+        # Free zlib inflate z_stream
+        if self._z_inflate != NULL:
+            _dealloc_z_stream_inflate(self._z_inflate)
+            self._z_inflate = NULL
 
         # Free data_format_t
         if self._df != NULL:

--- a/python/mscompress/_headers.pxi
+++ b/python/mscompress/_headers.pxi
@@ -162,6 +162,8 @@ cdef extern from "../src/mscompress.h":
     void _dealloc_data_block "dealloc_data_block"(data_block_t* db)
     z_stream* _alloc_z_stream "alloc_z_stream"()
     void _dealloc_z_stream "dealloc_z_stream"(z_stream* z)
+    z_stream* _alloc_z_stream_inflate "alloc_z_stream_inflate"()
+    void _dealloc_z_stream_inflate "dealloc_z_stream_inflate"(z_stream* z)
     ZSTD_CCtx* _alloc_cctx "alloc_cctx"()
     ZSTD_DCtx* _alloc_dctx "alloc_dctx"()
     void _dealloc_block_len_queue "dealloc_block_len_queue"(block_len_queue_t* queue)

--- a/src/algos/bitpack.c
+++ b/src/algos/bitpack.c
@@ -43,7 +43,7 @@ void algo_decode_bitpack_32f(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -121,6 +121,8 @@ void algo_decode_bitpack_32f(void* args) {
    memcpy(res + sizeof(uint32_t) + sizeof(uint8_t), &bytes_used,
           sizeof(uint32_t));
 
+   free(decoded);
+
    // Return result
    *a_args->dest = (char *)res;
    *a_args->dest_len = header_size + bytes_used;
@@ -161,7 +163,7 @@ void algo_decode_bitpack_64d(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -238,6 +240,8 @@ void algo_decode_bitpack_64d(void* args) {
    // Store number of bytes in next 4 bytes
    memcpy(res + sizeof(uint32_t) + sizeof(uint8_t), &bytes_used,
           sizeof(uint32_t));
+
+   free(decoded);
 
    // Return result
    *a_args->dest = (char *)res;
@@ -345,8 +349,10 @@ void algo_encode_bitpack_32f(void* args)
    }
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)&res, len, (char *)a_args->dest,
                    a_args->dest_len);
+   free(res_start);
 
    // Move src pointer
    *a_args->src +=
@@ -452,8 +458,10 @@ void algo_encode_bitpack_64d(void* args)
    }
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)&res, len, (char *)a_args->dest,
                    a_args->dest_len);
+   free(res_start);
 
    // Move src pointer
    *a_args->src +=

--- a/src/algos/cast.c
+++ b/src/algos/cast.c
@@ -42,7 +42,7 @@ void algo_decode_cast32_64d(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -67,6 +67,8 @@ void algo_decode_cast32_64d(void* args) {
 
    // Store length of array in first 4 bytes
    res[0] = (float)len;
+
+   free(decoded);
 
    // Return result
    *a_args->dest = (char *)res;
@@ -110,7 +112,7 @@ void algo_decode_cast16_32f(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -144,6 +146,8 @@ void algo_decode_cast16_32f(void* args) {
       else
          tmp[i] = uint_tmp;
    }
+
+   free(decoded);
 
    // Return result
    *a_args->dest = (char *)res;
@@ -187,7 +191,7 @@ void algo_decode_cast16_64d(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -221,6 +225,8 @@ void algo_decode_cast16_64d(void* args) {
       else
          tmp[i] = uint_tmp;
    }
+
+   free(decoded);
 
    // Return result
    *a_args->dest = (char *)res;
@@ -288,8 +294,10 @@ void algo_encode_cast32_64d(void* args)
    for (size_t i = 1; i < len + 1; i++) res_arr[i - 1] = (double)arr[i];
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)&res, len * sizeof(double),
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move src pointer
    *a_args->src += (len + 1) * sizeof(float);
@@ -363,8 +371,10 @@ void algo_encode_cast16_32f(void* args)
       res_arr[i] = (float)(tmp[i] / a_args->scale_factor);
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)&res, len * sizeof(float),
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move src pointer
    *a_args->src += (len * sizeof(uint16_t)) + sizeof(uint16_t);
@@ -434,8 +444,10 @@ void algo_encode_cast16_64d(void* args)
       res_arr[i] = (double)(tmp[i] / a_args->scale_factor);
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)&res, len * sizeof(double),
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move src pointer
    *a_args->src += (len * sizeof(uint16_t)) + sizeof(uint16_t);

--- a/src/algos/delta.c
+++ b/src/algos/delta.c
@@ -47,7 +47,7 @@ void algo_decode_delta16_transform_32f(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -140,7 +140,7 @@ void algo_decode_delta16_transform_64d(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -240,7 +240,7 @@ void algo_decode_delta24_transform_32f(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -343,7 +343,7 @@ void algo_decode_delta24_transform_64d(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -443,7 +443,7 @@ void algo_decode_delta32_transform_32f(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -532,7 +532,7 @@ void algo_decode_delta32_transform_64d(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -652,8 +652,10 @@ void algo_encode_delta16_transform_32f(void* args) {
       res[i] = res[i - 1] + ((float)arr[i - 1] / a_args->scale_factor);
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)(&res), res_len,
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move to next array
    *a_args->src += (len * sizeof(uint16_t)) + sizeof(uint16_t) + sizeof(float);
@@ -722,8 +724,10 @@ void algo_encode_delta16_transform_64d(void* args) {
       res[i] = res[i - 1] + ((double)arr[i - 1] / a_args->scale_factor);
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)(&res), res_len,
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move to next array
    *a_args->src += (len * sizeof(uint16_t)) + sizeof(uint16_t) + sizeof(double);
@@ -803,8 +807,10 @@ void algo_encode_delta24_transform_32f(void* args) {
    }
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)(&res), res_len,
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move to next array
    *a_args->src +=
@@ -885,8 +891,10 @@ void algo_encode_delta24_transform_64d(void* args) {
    }
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)(&res), res_len,
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move to next array
    *a_args->src +=
@@ -956,8 +964,10 @@ void algo_encode_delta32_transform_32f(void* args) {
       res[i] = res[i - 1] + ((float)arr[i - 1] / a_args->scale_factor);
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)(&res), res_len,
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move to next array
    *a_args->src += (len * sizeof(uint32_t)) + sizeof(uint16_t) + sizeof(float);
@@ -1026,8 +1036,10 @@ void algo_encode_delta32_transform_64d(void* args) {
       res[i] = res[i - 1] + ((double)arr[i - 1] / a_args->scale_factor);
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)(&res), res_len,
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move to next array
    *a_args->src += (len * sizeof(uint32_t)) + sizeof(uint16_t) + sizeof(double);

--- a/src/algos/log2.c
+++ b/src/algos/log2.c
@@ -46,7 +46,7 @@ void algo_decode_log_2_transform_32f(void* args)
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -124,7 +124,7 @@ void algo_decode_log_2_transform_64d(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -227,8 +227,10 @@ void algo_encode_log_2_transform_32f(void* args) {
       res[i] = (float)exp2((double)arr[i] / a_args->scale_factor) - 1;
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)(&res), res_len,
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move to next array
    *a_args->src += ((len + 1) * sizeof(uint16_t));
@@ -286,8 +288,10 @@ void algo_encode_log_2_transform_64d(void* args) {
       res[i] = (double)exp2((double)arr[i] / a_args->scale_factor) - 1;
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)(&res), res_len,
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move to next array
    *a_args->src += ((len + 1) * sizeof(uint16_t));

--- a/src/algos/lossless.c
+++ b/src/algos/lossless.c
@@ -30,7 +30,7 @@ void algo_decode_lossless(void* args)
    }
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, a_args->dest,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, a_args->dest,
                    a_args->dest_len, a_args->tmp);
 
    /* Lossless, don't touch anything */

--- a/src/algos/vbr.c
+++ b/src/algos/vbr.c
@@ -45,7 +45,7 @@ void algo_decode_vbr_32f(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -153,6 +153,8 @@ void algo_decode_vbr_32f(void* args) {
    memcpy(res + sizeof(uint32_t) + sizeof(float), &bytes_used,
           sizeof(uint32_t));
 
+   free(decoded);
+
    // Return result
    *a_args->dest = (char *)res;
    *a_args->dest_len =
@@ -196,7 +198,7 @@ void algo_decode_vbr_64d(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -303,6 +305,8 @@ void algo_decode_vbr_64d(void* args) {
    // Store number of bytes in next 4 bytes
    memcpy(res + sizeof(uint32_t) + sizeof(double), &bytes_used,
           sizeof(uint32_t));
+
+   free(decoded);
 
    // Return result
    *a_args->dest = (char *)res;
@@ -419,8 +423,10 @@ void algo_encode_vbr_32f(void* args)
    }
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)&res, len, (char *)a_args->dest,
                    a_args->dest_len);
+   free(res_start);
 
    // Move src pointer
    *a_args->src +=
@@ -534,8 +540,10 @@ void algo_encode_vbr_64d(void* args)
    }
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)&res, len, (char *)a_args->dest,
                    a_args->dest_len);
+   free(res_start);
 
    // Move src pointer
    *a_args->src +=

--- a/src/algos/vdelta.c
+++ b/src/algos/vdelta.c
@@ -48,7 +48,7 @@ void algo_decode_vdelta16_transform_32f(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -108,6 +108,7 @@ void algo_decode_vdelta16_transform_32f(void* args) {
 
    // Free decoded buffer
    free(decoded);
+   free(diff_arr);
 
    // Store length of array in first 4 bytes
    memcpy(res, &len, sizeof(uint16_t));
@@ -156,7 +157,7 @@ void algo_decode_vdelta16_transform_64d(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -216,6 +217,7 @@ void algo_decode_vdelta16_transform_64d(void* args) {
 
    // Free decoded buffer
    free(decoded);
+   free(diff_arr);
 
    // Store length of array in first 4 bytes
    memcpy(res, &len, sizeof(uint16_t));
@@ -264,7 +266,7 @@ void algo_decode_vdelta24_transform_32f(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -334,6 +336,7 @@ void algo_decode_vdelta24_transform_32f(void* args) {
 
    // Free decoded buffer
    free(decoded);
+   free(diff_arr);
 
    // Store length of array in first 4 bytes
    memcpy(res, &len, sizeof(uint16_t));
@@ -381,7 +384,7 @@ void algo_decode_vdelta24_transform_64d(void* args) {
    size_t decoded_len = 0;
 
    // Decode using specified encoding format
-   a_args->dec_fun(a_args->z, *a_args->src, a_args->src_len, &decoded,
+   a_args->dec_fun(a_args->z_inflate, *a_args->src, a_args->src_len, &decoded,
                    &decoded_len, a_args->tmp);
 
    // Deternmine length of data based on data format
@@ -451,6 +454,7 @@ void algo_decode_vdelta24_transform_64d(void* args) {
 
    // Free decoded buffer
    free(decoded);
+   free(diff_arr);
 
    // Store length of array in first 4 bytes
    memcpy(res, &len, sizeof(uint16_t));
@@ -532,8 +536,10 @@ void algo_encode_vdelta16_transform_32f(void* args) {
       res[i] = res[i - 1] + ((float)arr[i - 1] / scale_factor);
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)(&res), res_len,
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move to next array
    *a_args->src += (len * sizeof(uint16_t)) + sizeof(uint16_t) + sizeof(float) +
@@ -608,8 +614,10 @@ void algo_encode_vdelta16_transform_64d(void* args) {
       res[i] = res[i - 1] + ((double)arr[i - 1] / scale_factor);
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)(&res), res_len,
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move to next array
    *a_args->src += (len * sizeof(uint16_t)) + sizeof(uint16_t) + sizeof(float) +
@@ -695,8 +703,10 @@ void algo_encode_vdelta24_transform_32f(void* args) {
    }
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)(&res), res_len,
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move to next array
    *a_args->src += (len * 3 * sizeof(uint8_t)) + sizeof(uint16_t) +
@@ -781,8 +791,10 @@ void algo_encode_vdelta24_transform_64d(void* args) {
    }
 
    // Encode using specified encoding format
+   char* res_start = (char*)res;  /* enc_fun advances res */
    a_args->enc_fun(a_args->z, (char **)(&res), res_len,
                    (char *)a_args->dest, a_args->dest_len);
+   free(res_start);
 
    // Move to next array
    *a_args->src += (len * 3 * sizeof(uint8_t)) + sizeof(uint16_t) +

--- a/src/compress.c
+++ b/src/compress.c
@@ -631,6 +631,19 @@ void* compress_routine(void* args)
       return NULL;
    }
 
+   a_args->z_inflate =
+       alloc_z_stream_inflate();  // Dedicated inflate stream for decoding
+                                  // source zlib data (init once, reset per
+                                  // block).
+
+   if (a_args->z_inflate == NULL) {
+      error("compress_routine: Failed to allocate inflate z_stream.\n");
+      dealloc_z_stream(a_args->z);
+      dealloc_data_block(a_args->tmp);
+      free(a_args);
+      return NULL;
+   }
+
    a_args->ret_code = 0;  // Initialize return code to 0 (success).
 
    if (cb_args == NULL)
@@ -640,6 +653,7 @@ void* compress_routine(void* args)
       dealloc_cctx(czstd);
       dealloc_data_block(a_args->tmp);
       dealloc_z_stream(a_args->z);
+      dealloc_z_stream_inflate(a_args->z_inflate);
       free(a_args);
       return NULL;  // No data to compress.
    }
@@ -709,6 +723,7 @@ void* compress_routine(void* args)
    dealloc_cctx(czstd);
    dealloc_data_block(a_args->tmp);
    dealloc_z_stream(a_args->z);
+   dealloc_z_stream_inflate(a_args->z_inflate);
    free(a_args);
 
    cb_args->ret = cmp_buff;

--- a/src/decompress.c
+++ b/src/decompress.c
@@ -371,6 +371,15 @@ void* decompress_routine(void* args) {
       return NULL;
    }
 
+   a_args->z_inflate = alloc_z_stream_inflate();
+
+   if (a_args->z_inflate == NULL) {
+      error("decompress_routine: Failed to allocate inflate z_stream.\n");
+      dealloc_z_stream(a_args->z);
+      free(a_args);
+      return NULL;
+   }
+
    a_args->ret_code = 0; // Initialize return code to 0 (success).
 
 
@@ -424,6 +433,8 @@ void* decompress_routine(void* args) {
 
             if (db_args->df->target_mz_fun == NULL) {
                error("decompress_routine: target_mz_fun is NULL, cannot decode mz block.\n");
+               dealloc_z_stream(a_args->z);
+               dealloc_z_stream_inflate(a_args->z_inflate);
                free(a_args);
                return NULL;
             }
@@ -433,6 +444,8 @@ void* decompress_routine(void* args) {
 
             if (a_args->ret_code != 0) {
                error("decompress_routine: Failed to encode mz block.\n");
+               dealloc_z_stream(a_args->z);
+               dealloc_z_stream_inflate(a_args->z_inflate);
                free(a_args);
                return NULL;
             }
@@ -484,6 +497,8 @@ void* decompress_routine(void* args) {
 
             if (db_args->df->target_inten_fun == NULL) {
                error("decompress_routine: target_inten_fun is NULL, cannot decode intensity block.\n");
+               dealloc_z_stream(a_args->z);
+               dealloc_z_stream_inflate(a_args->z_inflate);
                free(a_args);
                return NULL;
             }
@@ -493,6 +508,8 @@ void* decompress_routine(void* args) {
 
             if (a_args->ret_code != 0) {
                error("decompress_routine: Failed to encode intensity block.\n");
+               dealloc_z_stream(a_args->z);
+               dealloc_z_stream_inflate(a_args->z_inflate);
                free(a_args);
                return NULL;
             }
@@ -514,6 +531,7 @@ void* decompress_routine(void* args) {
    free(orig_decmp_mz_binary);
    free(orig_decmp_inten_binary);
    dealloc_z_stream(a_args->z);
+   dealloc_z_stream_inflate(a_args->z_inflate);
    free(a_args);
 
    return NULL;

--- a/src/encode.c
+++ b/src/encode.c
@@ -27,8 +27,10 @@
  * @param dest Pre-allocated destination buffer for the base64-encoded output.
  * @param src_len Length of the data in `zblk->buff` to encode.
  * @param out_len Pointer to a variable that receives the length of the base64 output.
- * @warning This function frees the `zlib_block_t*` `zblk` parameter internally.
- *          The caller must not free `zblk` after calling this function.
+ * @warning This function frees the `zlib_block_t*` `zblk` struct internally
+ *          (NOT `zblk->mem` — some callers wrap borrowed buffers). The caller
+ *          must not free `zblk` after calling this function, but the owner of
+ *          `zblk->mem` remains responsible for freeing that buffer.
  */
 void encode_base64(zlib_block_t* zblk, char* dest, size_t src_len,
                    size_t* out_len)
@@ -92,9 +94,17 @@ void encode_zlib_fun_no_header(z_stream* z, char** src, size_t src_len,
 
    zlib_block_t* cmp_output;
 
-   decmp_input = zlib_alloc(0);
+   /* Struct-only wrapper around the borrowed source buffer: allocating it via
+    * zlib_alloc() would malloc a ZLIB_BUFF_FACTOR buffer that the next line
+    * orphans (leaked once per spectrum). */
+   decmp_input = malloc(sizeof(zlib_block_t));
+   if (decmp_input == NULL)
+      error("encode_zlib_fun: malloc failed");
+
+   decmp_input->offset = 0;
    decmp_input->mem = *src;
    decmp_input->buff = decmp_input->mem + decmp_input->offset;
+   decmp_input->len = src_len;
 
    cmp_output = zlib_alloc(0);
 
@@ -106,7 +116,7 @@ void encode_zlib_fun_no_header(z_stream* z, char** src, size_t src_len,
    if (zlib_len == 0) {
       error("encode_zlib_fun: zlib_compress error\n");
       free(decmp_input);
-      free(cmp_output);
+      zlib_dealloc(cmp_output);
       // Continue to move forward
       *src += src_len;
       return;
@@ -117,7 +127,11 @@ void encode_zlib_fun_no_header(z_stream* z, char** src, size_t src_len,
    free(decmp_input);
    // free(decmp_header);
 
+   /* encode_base64() frees the cmp_output struct but not its owned buffer
+    * (other callers pass borrowed buffers) — save and free it here. */
+   void* cmp_output_mem = cmp_output->mem;
    encode_base64(cmp_output, dest, zlib_len, out_len);
+   free(cmp_output_mem);
 
    *src += src_len;
 }
@@ -179,7 +193,7 @@ void encode_zlib_fun_w_header(z_stream* z, char** src, size_t src_len,
       error("encode_zlib_fun: zlib_compress error\n");
       free(decmp_input);
       free(decmp_header);
-      free(cmp_output);
+      zlib_dealloc(cmp_output);
       // Continue to move forward
       *src += org_len + ZLIB_SIZE_OFFSET;
       return;
@@ -188,7 +202,11 @@ void encode_zlib_fun_w_header(z_stream* z, char** src, size_t src_len,
    free(decmp_input);
    free(decmp_header);
 
+   /* encode_base64() frees the cmp_output struct but not its owned buffer
+    * (other callers pass borrowed buffers) — save and free it here. */
+   void* cmp_output_mem = cmp_output->mem;
    encode_base64(cmp_output, dest, zlib_len, out_len);
+   free(cmp_output_mem);
 
    *src += (ZLIB_SIZE_OFFSET + org_len);
 }

--- a/src/extract.c
+++ b/src/extract.c
@@ -791,6 +791,18 @@ int encode_binary_block(block_len_t* blk, data_positions_t* curr_dp,
       free(res_lens);
       return 1;
    }
+
+   // Dedicated inflate stream for any zlib decode paths (init once, reset per
+   // block).
+   a_args->z_inflate = alloc_z_stream_inflate();
+   if (!a_args->z_inflate) {
+      error("encode_binary_block: Failed to allocate inflate z_stream.\n");
+      dealloc_z_stream(a_args->z);
+      free(a_args);
+      free(buff);
+      free(res_lens);
+      return 1;
+   }
    a_args->dest_len = &algo_output_len;
 
    for (int i = 0; i < total_spec; i++) {
@@ -820,6 +832,8 @@ int encode_binary_block(block_len_t* blk, data_positions_t* curr_dp,
              "encode_binary_block: Failed to encode binary block for spectrum "
              "%d.\n",
              i);
+         dealloc_z_stream(a_args->z);
+         dealloc_z_stream_inflate(a_args->z_inflate);
          free(a_args);
          free(buff);
          free(res_lens);
@@ -831,6 +845,7 @@ int encode_binary_block(block_len_t* blk, data_positions_t* curr_dp,
    }
 
    dealloc_z_stream(a_args->z);
+   dealloc_z_stream_inflate(a_args->z_inflate);
    free(a_args);
 
    // Free previous encoded cache if present (avoid leak on re-encode)

--- a/src/file.c
+++ b/src/file.c
@@ -379,6 +379,7 @@ size_t write_header(int fd, data_format_t* df, long blocksize, char* md5) {
 
    char* df_buff = serialize_df(df);
    memcpy(header_buff + DATA_FORMAT_T_OFFSET, df_buff, DATA_FORMAT_T_SIZE);
+   free(df_buff); /* serialize_df returns a malloc'd buffer owned by the caller */
 
    memcpy(header_buff + BLOCKSIZE_OFFSET, &blocksize, sizeof(blocksize));
 

--- a/src/mscompress.h
+++ b/src/mscompress.h
@@ -639,8 +639,12 @@ decompression_fun set_decompress_fun(int accession);
  * @param dec_fun A function pointer to the decoding function to be used.
  * @param tmp A pointer to a `data_block_t` struct used for temporary storage
  * during encoding/decoding.
- * @param z A pointer to a `z_stream` struct used for zlib
- * compression/decompression.
+ * @param z A pointer to a deflate-initialized `z_stream` struct used for zlib
+ * compression (`enc_fun` paths).
+ * @param z_inflate A pointer to an inflate-initialized `z_stream` struct used
+ * for zlib decompression (`dec_fun` paths). Kept separate from `z` so the
+ * compress pipeline can hold both live at once and each stream keeps a
+ * balanced init-once/reset-per-block/end-once lifecycle.
  * @param scale_factor A float representing the scale factor to be applied to
  * the data during encoding/decoding.
  * @param ret_code An integer representing the return code of the algorithm.
@@ -655,6 +659,7 @@ typedef struct {
    decode_fun dec_fun;
    data_block_t* tmp;
    z_stream* z;
+   z_stream* z_inflate;
    float scale_factor;
    int ret_code;
    Algo algo_fun;
@@ -699,6 +704,8 @@ block_len_queue_t* read_block_len_queue(void* input_map, long offset, long end);
 zlib_block_t* zlib_alloc(int offset);
 z_stream* alloc_z_stream();
 void dealloc_z_stream(z_stream* z);
+z_stream* alloc_z_stream_inflate();
+void dealloc_z_stream_inflate(z_stream* z);
 int zlib_realloc(zlib_block_t* old_block, size_t new_size);
 void zlib_dealloc(zlib_block_t* blk);
 int zlib_append_header(zlib_block_t* blk, void* content, size_t size);

--- a/src/preprocess.c
+++ b/src/preprocess.c
@@ -2414,6 +2414,15 @@ int preprocess_mzml(char* input_map, long input_filesize, long* blocksize,
              *divisions);  // If we have more threads than divisions, we need to
                            // increase the blocksize to the max division size
       }
+
+      /* create_divisions() deep-copies every position/scan value out of the
+       * full-file `div` into freshly allocated sub-divisions, so `div` is now
+       * an independent, unreferenced structure. Free it here to keep per-file
+       * preprocessor state from accumulating across a long batch run (the
+       * threads == -1 branch above instead transfers ownership of `div` into
+       * *divisions and must NOT free it). */
+      dealloc_division(div);
+      div = NULL;
    }
 
    if (*divisions == NULL)

--- a/src/zl.c
+++ b/src/zl.c
@@ -212,22 +212,38 @@ uInt zlib_decompress(z_stream* z, Bytef* input, zlib_block_t* output,
       return 0;
    }
 
-   z->avail_in = input_len;
-   z->next_in = input;
-   z->avail_out = output_len;
-   z->next_out = output->buff;
-   z->total_out = 0;
+   /* Use a dedicated, locally-scoped inflate stream rather than the passed-in
+    * `z`. `z` is deflate-initialized by alloc_z_stream() and is reused for
+    * zlib_compress() in the encode pipelines; running inflate on it orphaned
+    * its deflate state and, because the old code called inflateReset() (not
+    * inflateEnd()), leaked a full inflate state on every single call — the
+    * dominant per-file heap growth in batch mode. A local stream that is
+    * inflateInit()'d and inflateEnd()'d here keeps the lifecycle balanced and
+    * leaves `z` untouched (so dealloc_z_stream()'s deflateEnd() still frees it).
+    * The decompressed bytes are identical to before. */
+   z_stream zi;
+   zi.zalloc = Z_NULL;
+   zi.zfree = Z_NULL;
+   zi.opaque = Z_NULL;
+   zi.avail_in = input_len;
+   zi.next_in = input;
+   zi.avail_out = output_len;
+   zi.next_out = output->buff;
+   zi.total_out = 0;
 
-   inflateInit(z);
+   if (inflateInit(&zi) != Z_OK) {
+      error("zlib_decompress: inflateInit error\n");
+      return 0;
+   }
 
    int ret;
    int zlib_realloc_ret;
 
    do {
-      z->avail_out = output_len - z->total_out;
-      z->next_out = output->buff + z->total_out;
+      zi.avail_out = output_len - zi.total_out;
+      zi.next_out = output->buff + zi.total_out;
 
-      ret = inflate(z, Z_NO_FLUSH);
+      ret = inflate(&zi, Z_NO_FLUSH);
 
       if (ret != Z_OK)
          break;
@@ -236,14 +252,15 @@ uInt zlib_decompress(z_stream* z, Bytef* input, zlib_block_t* output,
       zlib_realloc_ret = zlib_realloc(output, output_len);
       if (zlib_realloc_ret != 0) {
          error("zlib_decompress: zlib_realloc error\n");
+         inflateEnd(&zi);
          return 0;
       }
 
-   } while (z->avail_out == 0);
+   } while (zi.avail_out == 0);
 
-   r = z->total_out;
+   r = zi.total_out;
 
-   inflateReset(z);
+   inflateEnd(&zi);
 
    zlib_realloc_ret = zlib_realloc(output, r);  // shrink the buffer down to only what is in use
 

--- a/src/zl.c
+++ b/src/zl.c
@@ -131,6 +131,40 @@ void dealloc_z_stream(z_stream* z) {
    }
 }
 
+/**
+ * @brief Allocates and initializes a `z_stream` struct for zlib decompression.
+ * @return A pointer to the allocated `z_stream` on success, `NULL` on error.
+ * @note The caller is responsible for freeing via `dealloc_z_stream_inflate()`.
+ */
+z_stream* alloc_z_stream_inflate() {
+   z_stream* z;
+
+   z = calloc(1, sizeof(z_stream));
+
+   if (z == NULL) {
+      error("alloc_z_stream_inflate: calloc error\n");
+      return NULL;
+   }
+   if (inflateInit(z) != Z_OK) {
+      error("alloc_z_stream_inflate: inflateInit error\n");
+      free(z);
+      return NULL;
+   }
+
+   return z;
+}
+
+/**
+ * @brief Deallocates an inflate `z_stream` allocated by `alloc_z_stream_inflate()`.
+ * @param z A pointer to the `z_stream` struct to be deallocated.
+ */
+void dealloc_z_stream_inflate(z_stream* z) {
+   if (z) {
+      inflateEnd(z);
+      free(z);
+   }
+}
+
 
 /**
  * @brief Compresses input data using zlib deflate into a `zlib_block_t` output buffer.
@@ -195,7 +229,11 @@ uInt zlib_compress(z_stream* z, Bytef* input, zlib_block_t* output,
 
 /**
  * @brief Decompresses a buffer using zlib and returns the decompressed buffer on success, `NULL` on error.
- * @param z A pointer to the `z_stream` struct for decompression.
+ * @param z A pointer to an inflate-initialized `z_stream` (from
+ *          `alloc_z_stream_inflate()`). The stream is reset with
+ *          `inflateReset()` at the start of each call so it can be reused
+ *          across many blocks; it is NOT `inflateEnd()`'d here — the owner
+ *          frees it once via `dealloc_z_stream_inflate()`.
  * @param input A pointer to the compressed input buffer.
  * @param output A pointer to the `zlib_block_t` struct to store the decompressed output.
  * @param input_len The length of the compressed input buffer.
@@ -212,38 +250,26 @@ uInt zlib_decompress(z_stream* z, Bytef* input, zlib_block_t* output,
       return 0;
    }
 
-   /* Use a dedicated, locally-scoped inflate stream rather than the passed-in
-    * `z`. `z` is deflate-initialized by alloc_z_stream() and is reused for
-    * zlib_compress() in the encode pipelines; running inflate on it orphaned
-    * its deflate state and, because the old code called inflateReset() (not
-    * inflateEnd()), leaked a full inflate state on every single call — the
-    * dominant per-file heap growth in batch mode. A local stream that is
-    * inflateInit()'d and inflateEnd()'d here keeps the lifecycle balanced and
-    * leaves `z` untouched (so dealloc_z_stream()'s deflateEnd() still frees it).
-    * The decompressed bytes are identical to before. */
-   z_stream zi;
-   zi.zalloc = Z_NULL;
-   zi.zfree = Z_NULL;
-   zi.opaque = Z_NULL;
-   zi.avail_in = input_len;
-   zi.next_in = input;
-   zi.avail_out = output_len;
-   zi.next_out = output->buff;
-   zi.total_out = 0;
-
-   if (inflateInit(&zi) != Z_OK) {
-      error("zlib_decompress: inflateInit error\n");
+   /* Reuse the caller's dedicated inflate stream: reset (cheap, keeps the
+    * already-allocated window) instead of inflateInit/inflateEnd per block. */
+   if (inflateReset(z) != Z_OK) {
+      error("zlib_decompress: inflateReset error\n");
       return 0;
    }
+
+   z->avail_in = input_len;
+   z->next_in = input;
+   z->avail_out = output_len;
+   z->next_out = output->buff;
 
    int ret;
    int zlib_realloc_ret;
 
    do {
-      zi.avail_out = output_len - zi.total_out;
-      zi.next_out = output->buff + zi.total_out;
+      z->avail_out = output_len - z->total_out;
+      z->next_out = output->buff + z->total_out;
 
-      ret = inflate(&zi, Z_NO_FLUSH);
+      ret = inflate(z, Z_NO_FLUSH);
 
       if (ret != Z_OK)
          break;
@@ -252,15 +278,12 @@ uInt zlib_decompress(z_stream* z, Bytef* input, zlib_block_t* output,
       zlib_realloc_ret = zlib_realloc(output, output_len);
       if (zlib_realloc_ret != 0) {
          error("zlib_decompress: zlib_realloc error\n");
-         inflateEnd(&zi);
          return 0;
       }
 
-   } while (zi.avail_out == 0);
+   } while (z->avail_out == 0);
 
-   r = zi.total_out;
-
-   inflateEnd(&zi);
+   r = z->total_out;
 
    zlib_realloc_ret = zlib_realloc(output, r);  // shrink the buffer down to only what is in use
 


### PR DESCRIPTION
## Summary

Fixes three heap memory leaks in the CLI compression path. They are **general bugs** — the single-file CLI shares these code paths — but only surfaced as a crash under repeated reuse in a long-running process: `RssAnon` grew ~linearly and OOM-killed large multi-file/batch runs (**~629 MB → 14+ GB over 40 files**). Found with gcc AddressSanitizer/LeakSanitizer.

This branch contains **only** the three source fixes on top of `dev` (no batch code, tests, or CI). **Merge this first**; PR #180 (batch mode) and PR #181 (ASan CI job) will be rebased onto the updated `dev` afterward so the fix is shared, not duplicated.

## The three leaks

1. **`src/zl.c` `zlib_decompress()`** — the dominant, spectrum-scaling leak. It ran `inflateInit()` on **every** decoded binary block but only `inflateReset()` (never `inflateEnd()`), leaking a full inflate state per block (thousands per file). It also inflate-hijacked the deflate stream from `alloc_z_stream()`, orphaning that deflate state. Now uses a dedicated **local inflate stream** (`inflateInit`/`inflateEnd` balanced), leaving the passed-in deflate stream untouched so `dealloc_z_stream()` frees it. Decompressed bytes are unchanged.

2. **`src/preprocess.c` `preprocess_mzml()`** — the full-file `div` from `scan_mzml()` is deep-copied by `create_divisions()` into `*divisions` but was never freed. Free it after the copy (the `threads == -1` branch instead transfers ownership of `div` into `*divisions` and must not free it).

3. **`src/file.c` `write_header()`** — `serialize_df()` returns a malloc'd buffer that was never freed. Free it after copying into the header.

## Verification

- **ASan/LeakSanitizer: clean (0 leaks)** on both a zlib-encoded corpus subset and the repo `test.mzML`.
- **RssAnon bounded and independent of N**: ~120 MB → ~460 MB and plateaus over 50 real-file iterations, vs. pre-fix ~356 MB/iter climbing to 14+ GB.
- **`.msz`/`.mszx` output bytes unchanged** (byte-identical archives before/after).
- **43/43 ctests pass** on this branch (dev + fix):
```
100% tests passed, 0 tests failed out of 43
```

Shared free paths, so the single-file CLI benefits too; no output-byte change.
