### PR TITLE
fix(build): restore -O3 for vendored zlib (silently dropped since v1.0.11)

### DIFF
--- a/vendor/ZlibInclude.cmake
+++ b/vendor/ZlibInclude.cmake
@@ -11,14 +11,14 @@ elseif(APPLE)
     # On macOS, define fdopen to prevent zlib's macro redefinition conflict
     add_custom_target(
         zlib_build
-        COMMAND env "CFLAGS=-Dfdopen=fdopen ${ZLIB_EXTRA_CFLAGS}" ${ZLIB_SOURCE_DIR}/configure
+        COMMAND env "CFLAGS=-O3 -Dfdopen=fdopen ${ZLIB_EXTRA_CFLAGS}" ${ZLIB_SOURCE_DIR}/configure
         COMMAND make -C ${ZLIB_SOURCE_DIR}
         WORKING_DIRECTORY ${ZLIB_SOURCE_DIR}
     )
 else()
     add_custom_target(
         zlib_build
-        COMMAND env "CFLAGS=-fPIC ${ZLIB_EXTRA_CFLAGS}" ${ZLIB_SOURCE_DIR}/configure
+        COMMAND env "CFLAGS=-O3 -fPIC ${ZLIB_EXTRA_CFLAGS}" ${ZLIB_SOURCE_DIR}/configure
         COMMAND make -C ${ZLIB_SOURCE_DIR}
         WORKING_DIRECTORY ${ZLIB_SOURCE_DIR}
     )


### PR DESCRIPTION
## Problem

zlib has been compiled **without `-O3`** since v1.0.11, silently dropping single-file
compression throughput by ~20–24%.

`vendor/ZlibInclude.cmake` invokes zlib's `configure` with an explicit
`env "CFLAGS=-fPIC ..."`. zlib's `Makefile.in` sets its optimization via
**conditional assignment**:

```make
CFLAGS   ?= -O3
```

`?=` only applies when `CFLAGS` is unset. By exporting `CFLAGS` in the environment,
the invocation **suppressed zlib's default `-O3`**, so zlib was built with `-fPIC`
and **no optimization**. Since mscompress spends heavily in zlib inflate/deflate on
spectrum binaries, this dragged throughput down across the board.

Introduced in `7b4fc39` ("Zlib fix + slim down action") — the `-fPIC` was a legitimate
static-link fix, but it clobbered `-O3` as collateral. The macOS branch
(`CFLAGS=-Dfdopen=fdopen`) has the same latent bug.

## Fix

Prepend `-O3` to the explicit `CFLAGS` on both the Linux and macOS `configure`
invocations, preserving the existing `-fPIC` / `-Dfdopen` flags.

## Evidence

Bisected on a quiet aarch64 box (GB10, 20-core; merlin's shared x86 was too noisy to
see the signal). Single 369 MiB DIA mzML, `-t 20`, warm cache, interleaved reps.

Regression located by `git bisect run` (throughput predicate, threshold 700 MB/s):
first bad commit = `7b4fc39`, throughput 727 → 645 MB/s.

Two clean from-scratch v1.0.16 builds differing **only** in this flag:

| build            | zlib CFLAGS      | min       | median    |
|------------------|------------------|-----------|-----------|
| as-shipped       | `-fPIC`          | 602 MB/s  | 551 MB/s  |
| **with fix**     | `-O3 -fPIC`      | **744 MB/s** | **644 MB/s** |

**+24% (min) / +17% (median)** — recovers v1.0.16 back to the pre-regression
(v1.0.6 ≈ 735 MB/s) level.

## Correctness

- Output unchanged: compression ratio 0.4073, identical before/after.
- `ctest`: 100% passed (43/43).
- Build-only change; no source touched, orthogonal to any in-flight source work.
