### PR TITLE
fix(cli): report build configuration instead of Dev in version status

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -50,6 +50,13 @@ file(GLOB SOURCES ${SRC_DIR}/*.c ${SRC_DIR}/algos/*.c mscompress.c)
 add_executable(mscompress ${SOURCES})
 target_compile_definitions(mscompress PRIVATE VERSION="${PROJECT_VERSION}")
 
+# Build status reported by `--version`. $<CONFIG> resolves to CMAKE_BUILD_TYPE
+# for single-config generators and to the --config chosen at build time for
+# multi-config ones (Visual Studio, Ninja Multi-Config). Only Debug is called
+# out; RelWithDebInfo/MinSizeRel/unset all report as Release.
+target_compile_definitions(mscompress PRIVATE
+    STATUS="$<IF:$<CONFIG:Debug>,Debug,Release>")
+
 # Ensure winnt.h sees a target arch and keep headers tidy on MSVC
 if(WIN32)
   target_compile_definitions(mscompress PRIVATE

--- a/src/mscompress.h
+++ b/src/mscompress.h
@@ -7,7 +7,7 @@
 #include "../vendor/zlib/zlib.h"
 #include "../vendor/zstd/lib/zstd.h"
 
-#define STATUS "Dev"
+#define STATUS "Release"
 #define MIN_SUPPORT "0.1"
 #define MAX_SUPPORT "0.1"
 #define ADDRESS "chrisagrams@gmail.com"

--- a/src/mscompress.h
+++ b/src/mscompress.h
@@ -7,7 +7,12 @@
 #include "../vendor/zlib/zlib.h"
 #include "../vendor/zstd/lib/zstd.h"
 
+/* Build status reported by the CLI (`--version`). The CLI's CMakeLists.txt
+   defines this from the build configuration; the fallback covers consumers
+   that compile these sources without it (Python setup.py, Node addon). */
+#ifndef STATUS
 #define STATUS "Release"
+#endif
 #define MIN_SUPPORT "0.1"
 #define MAX_SUPPORT "0.1"
 #define ADDRESS "chrisagrams@gmail.com"


### PR DESCRIPTION
## Problem

The CLI has been printing a `Dev` status alongside the version since before 1.0:

```
$ mscompress --version
MSCompress version 1.0.16 Dev
```

The project is well past a dev build, so the suffix is now misleading. It shows up in `--help`, `--version`, and the `--json --version` output (`"status": "Dev"`).

## Change

`STATUS` is no longer a hardcoded string in `src/mscompress.h`. `cli/CMakeLists.txt` now defines it from the build configuration, alongside the existing `VERSION` definition:

```cmake
target_compile_definitions(mscompress PRIVATE
    STATUS="$<IF:$<CONFIG:Debug>,Debug,Release>")
```

`$<CONFIG>` resolves to `CMAKE_BUILD_TYPE` for single-config generators and to the `--config` chosen at build time for multi-config ones (Visual Studio, Ninja Multi-Config), so Windows builds get the right answer too. Only `Debug` is called out; `RelWithDebInfo`, `MinSizeRel`, and unset all report `Release`.

The header keeps an `#ifndef STATUS` fallback of `"Release"` for consumers that compile these sources without the CLI's CMakeLists — the Python extension (`setup.py`) and the Node addon.

After:

```
$ mscompress --version
MSCompress version 1.0.16 Release
Supports msz versions 0.1-0.1

$ mscompress --json --version
{
  "version": "1.0.16",
  "status": "Release",
  "min_support": "0.1",
  "max_support": "0.1"
}
```

The JSON `status` key is kept (only its value changes) so anything parsing that output keeps working.

## Testing

Built and checked `--version` under each configuration:

| Configure flags | `--version` |
|---|---|
| *(none)* | `1.0.16 Release` |
| `-DCMAKE_BUILD_TYPE=Debug` | `1.0.16 Debug` |
| `-DCMAKE_BUILD_TYPE=RelWithDebInfo` | `1.0.16 Release` |
| `-DCMAKE_BUILD_TYPE=MinSizeRel` | `1.0.16 Release` |
| `-DENABLE_DEBUG_SYMBOLS=ON` | `1.0.16 Debug` |

`ctest --test-dir cli` — 41/43 pass. `MSZXDecompressTest` and `CompressSciexNoScanAttr` fail with segfaults, but they fail identically on a clean `dev` build (verified by reverting this branch's changes and rebuilding), so they are pre-existing and unrelated.

## Note for reviewers

`build.yml` configures the published CLI binaries with `-DENABLE_DEBUG_SYMBOLS=ON`, which `cli/CMakeLists.txt:35` turns into `CMAKE_BUILD_TYPE=Debug`. With this change those artifacts will report `Debug` rather than `Release`.

That is accurate — they really are debug builds — but it also surfaces a separate pre-existing issue: `Debug` compiles with `-g` and **no optimization**, so the released CLI ships unoptimized (`C_FLAGS = -g` vs `-O2 -g -DNDEBUG` for `RelWithDebInfo`). Worth addressing separately; this PR does not change any build flags.
