### PR TITLE
ci: build release CLI binaries as an optimized Release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,12 +64,12 @@ jobs:
       - name: Configure CMake (Unix)
         if: matrix.platform != 'windows'
         working-directory: ./cli
-        run: cmake -DENABLE_DEBUG_SYMBOLS=ON .
+        run: cmake -DCMAKE_BUILD_TYPE=Release .
       
       - name: Configure CMake (Windows)
         if: matrix.platform == 'windows'
         working-directory: ./cli
-        run: cmake -A x64 -DENABLE_DEBUG_SYMBOLS=ON -S . -B build
+        run: cmake -A x64 -S . -B build
       
       - name: Build CLI (Unix)
         if: matrix.platform != 'windows'


### PR DESCRIPTION
> Part of stack #188, on top of #185 — see the stack navigation above for the full chain. This PR's diff shows only the CI change.

## Problem

The CLI build job configures with `-DENABLE_DEBUG_SYMBOLS=ON`:

```yaml
- name: Configure CMake (Unix)
  run: cmake -DENABLE_DEBUG_SYMBOLS=ON .
```

`cli/CMakeLists.txt:34` turns that into `CMAKE_BUILD_TYPE=Debug`, and on GCC/Clang CMake's `Debug` is `-g` with **no optimization flag at all**. The `cmake --build . --config Release` that follows is a no-op on single-config generators, so it never undid it.

The published Linux and macOS CLI binaries have therefore been shipping unoptimized — `C_FLAGS = -g` instead of `-O3 -DNDEBUG`. For a compression tool that is a straight throughput loss.

Release artifacts should not carry debug symbols in the first place; this is a CI misconfiguration, not something `CMakeLists.txt` should work around.

Found while working on #185: deriving the version status from the build configuration made the published binaries report `Debug`, which led back to why they were Debug builds at all.

## Change

Configure the CLI build job with `-DCMAKE_BUILD_TYPE=Release` explicitly instead of `-DENABLE_DEBUG_SYMBOLS=ON`.

The Windows job drops the flag too. It was already unaffected in practice — the Visual Studio generator is multi-config and takes its configuration from `--build --config Release` — but leaving the flag there implied otherwise.

**The ASan job is deliberately untouched.** It passes `-DENABLE_DEBUG_SYMBOLS=ON` alongside an explicit `-DCMAKE_BUILD_TYPE=Debug` and its own `-fsanitize=address,leak ... -g -O1` flags, and genuinely wants an unoptimized build.

`ENABLE_DEBUG_SYMBOLS` itself is left as-is, so local `-DENABLE_DEBUG_SYMBOLS=ON` builds still behave exactly as before.

## Testing

Configured and built with the job's new command, `cmake -DCMAKE_BUILD_TYPE=Release .`:

| | Before | After |
|---|---|---|
| `C_FLAGS` | `-g` | `-O3 -DNDEBUG` |
| `--version` | `1.0.16 Debug` *(with #185)* | `1.0.16 Release` |

`ctest --test-dir cli` — 41/43 pass. `MSZXDecompressTest` and `CompressSciexNoScanAttr` fail with segfaults, but they fail identically on a clean `dev` build, so they are pre-existing and unrelated.

The resulting binary is still "not stripped" — `-DNDEBUG` and `-O3` do not remove the symbol table, so backtraces remain usable even though DWARF debug info is gone.
