### PR TITLE
fix: keep test fixtures byte-identical on Windows, and test that they are

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Test fixtures must be byte-identical on every platform.
+#
+# An .msz encodes the exact bytes of the .mzML it was made from, so the two are
+# only comparable if neither is rewritten on checkout. Git detects .mzML as text
+# and, with core.autocrlf=true (the default on Windows runners), converts it to
+# CRLF, while the .msz is detected as binary and left alone. Any byte comparison
+# then fails by one byte per line.
+test/data/** -text

--- a/node-ts/test/decompress-fidelity.test.ts
+++ b/node-ts/test/decompress-fidelity.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Byte-fidelity of decompression against committed archives.
+ *
+ * The existing msz test only asserts the output is non-empty, so nothing
+ * checked that the bytes are actually right. The CLI has always compared them
+ * (cli/test/run_test.cmake); the bindings never did.
+ *
+ * On failure these report where and how the output diverges, because the known
+ * failure is Windows-only and reachable only through CI.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+import { read, MZMLFile, MSZFile } from "../src/index.js";
+import { MZML_PATH, MSZ_PATH } from "./fixtures.js";
+
+const tmpDirs = new Set<string>();
+
+function makeTmpDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.add(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    } catch {
+      // best-effort cleanup; the assertions above already covered the happy path
+    }
+  }
+  tmpDirs.clear();
+});
+
+/** First divergence plus surrounding context, as an assertion message. */
+function describeDifference(expected: Buffer, actual: Buffer): string {
+  const sizeNote =
+    expected.length !== actual.length
+      ? `SIZE DIFFERS: expected ${expected.length}, got ${actual.length}`
+      : `sizes match (${expected.length})`;
+
+  const limit = Math.min(expected.length, actual.length);
+  let offset = limit;
+  for (let i = 0; i < limit; i++) {
+    if (expected[i] !== actual[i]) {
+      offset = i;
+      break;
+    }
+  }
+
+  if (offset === limit) {
+    return `${sizeNote}; common prefix identical, output truncated or extended`;
+  }
+
+  const lo = Math.max(0, offset - 32);
+  const hi = Math.min(limit, offset + 32);
+  return (
+    `${sizeNote}; first difference at byte ${offset} ` +
+    `(expected 0x${expected[offset].toString(16)}, got 0x${actual[offset].toString(16)})\n` +
+    `  expected[${lo}:${hi}] = ${JSON.stringify(expected.subarray(lo, hi).toString("latin1"))}\n` +
+    `  actual  [${lo}:${hi}] = ${JSON.stringify(actual.subarray(lo, hi).toString("latin1"))}`
+  );
+}
+
+/** Decompress `mszPath` into a tracked temp dir and return the output bytes. */
+function decompressToBuffer(mszPath: string, prefix: string): Buffer {
+  const dir = makeTmpDir(prefix);
+  const restored = path.join(dir, "restored.mzML");
+
+  const msz = read(mszPath) as MSZFile;
+  let out: MZMLFile | undefined;
+  try {
+    out = msz.decompress(restored) as MZMLFile;
+  } finally {
+    // Handles must close before the temp dir is removed, or Windows throws
+    // EPERM on unlink.
+    out?.close();
+    msz.close();
+  }
+
+  return fs.readFileSync(restored);
+}
+
+describe("decompression byte fidelity", () => {
+  it("decompresses a committed .msz to exactly its source mzML", () => {
+    // Round-trip tests cannot catch a platform that encodes and decodes with a
+    // matching deviation; only committed bytes can.
+    const expected = fs.readFileSync(MZML_PATH);
+    const actual = decompressToBuffer(MSZ_PATH, "mscompress-fidelity-committed-");
+
+    expect(actual.equals(expected), describeDifference(expected, actual)).toBe(true);
+  });
+
+  it("decompresses an archive written by this build to exactly its source", () => {
+    // Paired with the test above: if the committed archive fails while this one
+    // passes, compression and decompression agree with each other but disagree
+    // with the reference bytes.
+    const dir = makeTmpDir("mscompress-fidelity-roundtrip-");
+    const mszPath = path.join(dir, "roundtrip.msz");
+
+    const file = read(MZML_PATH) as MZMLFile;
+    let compressed: MSZFile | undefined;
+    try {
+      compressed = file.compress(mszPath) as MSZFile;
+    } finally {
+      compressed?.close();
+      file.close();
+    }
+
+    const expected = fs.readFileSync(MZML_PATH);
+    const actual = decompressToBuffer(mszPath, "mscompress-fidelity-roundtrip-out-");
+
+    expect(actual.equals(expected), describeDifference(expected, actual)).toBe(true);
+  });
+});

--- a/python/test/test_decompress_fidelity.py
+++ b/python/test/test_decompress_fidelity.py
@@ -1,0 +1,79 @@
+"""Byte-fidelity of decompression against committed archives.
+
+The existing tests only assert that decompression produces a non-empty file, so
+nothing checked that the bytes are actually right. The CLI has always compared
+them (cli/test/run_test.cmake); the bindings never did.
+
+On failure these report where and how the output diverges, because the known
+failure is Windows-only and reachable only through CI.
+"""
+
+import filecmp
+
+import pytest
+
+from mscompress import read
+
+
+def _describe_difference(expected: bytes, actual: bytes) -> str:
+    """First divergence plus surrounding context, as a pytest failure message."""
+    if len(expected) != len(actual):
+        size_note = f"SIZE DIFFERS: expected {len(expected)}, got {len(actual)}"
+    else:
+        size_note = f"sizes match ({len(expected)})"
+
+    limit = min(len(expected), len(actual))
+    offset = next((i for i in range(limit) if expected[i] != actual[i]), limit)
+
+    if offset == limit:
+        return f"{size_note}; common prefix identical, output truncated or extended"
+
+    lo = max(0, offset - 32)
+    hi = min(limit, offset + 32)
+    return (
+        f"{size_note}; first difference at byte {offset} "
+        f"(expected {expected[offset]:#04x}, got {actual[offset]:#04x})\n"
+        f"  expected[{lo}:{hi}] = {expected[lo:hi]!r}\n"
+        f"  actual  [{lo}:{hi}] = {actual[lo:hi]!r}"
+    )
+
+
+def test_committed_msz_decompresses_byte_identically(
+    msz_file_path, mzml_file_path, tmp_path
+):
+    """A committed .msz must decompress to exactly the mzML it was made from.
+
+    Round-trip tests cannot catch a platform that encodes and decodes with a
+    matching deviation; only committed bytes can.
+    """
+    restored_path = tmp_path / "restored.mzML"
+
+    with read(msz_file_path) as msz:
+        msz.decompress(restored_path)
+
+    if not filecmp.cmp(mzml_file_path, restored_path, shallow=False):
+        with open(mzml_file_path, "rb") as f:
+            expected = f.read()
+        pytest.fail(_describe_difference(expected, restored_path.read_bytes()))
+
+
+def test_roundtrip_decompresses_byte_identically(mzml_file_path, tmp_path):
+    """The same check against an archive written by this build.
+
+    Paired with the test above: if the committed archive fails while this one
+    passes, compression and decompression are consistent with each other but
+    disagree with the reference bytes.
+    """
+    msz_path = tmp_path / "roundtrip.msz"
+    restored_path = tmp_path / "roundtrip.mzML"
+
+    with read(mzml_file_path) as mzml:
+        mzml.compress(msz_path)
+
+    with read(msz_path) as msz:
+        msz.decompress(restored_path)
+
+    if not filecmp.cmp(mzml_file_path, restored_path, shallow=False):
+        with open(mzml_file_path, "rb") as f:
+            expected = f.read()
+        pytest.fail(_describe_difference(expected, restored_path.read_bytes()))


### PR DESCRIPTION
## What this fixes

The repo has no `.gitattributes`, so git applies its own text detection. On a Windows runner (`core.autocrlf=true` by default) `test.mzML` is detected as text and rewritten to CRLF on checkout, while `test.msz` is detected as binary and left alone — still encoding the LF bytes it was built from. The two fixtures stop describing the same data.

Nothing was wrong with mscompress. Decompressed output was byte-perfect throughout; the reference it gets compared against had been rewritten underneath it.

## How it surfaced

Neither binding has ever checked that decompressed output *matches* the source mzML. `node-ts/test/msz.test.ts` asserts only that the file exists and is non-empty; Python had no equivalent. This PR adds that check, and it immediately failed on Windows:

```
SIZE DIFFERS: expected 4991147, got 4946404
first difference at byte 38 (expected 0x0d, got 0x0a)
  expected = "...utf-8\"?>\r\n<indexedmzML..."
  actual   = "...utf-8\"?>\n<indexedmzML..."
```

The delta is 44,743 bytes — exactly the line count of `test.mzML` — and the output matches the LF file byte for byte. Python and Node reported identical sizes and offsets independently.

## Why nothing caught it before

| | |
|---|---|
| Round-trip tests | Compress the CRLF file, decompress back to CRLF — agree with themselves |
| CLI suite | `run_test.cmake` decompress mode compares its own two outputs and **ignores the `EXPECTED_FILE` it is passed** |
| Binding tests | Only asserted the output was non-empty |

Only a comparison against committed bytes exposes it.

## Changes

- **`f00ad76`** — paired byte-fidelity tests in both bindings: committed archive *and* round trip. The pairing is what localizes a failure — a round trip cannot catch a platform whose compress and decompress deviate together. On failure they print the first differing offset with surrounding context, or a size mismatch.
- **`f9de15f`** — `.gitattributes` marking `test/data/** -text`. Files are already stored with LF, so `git add --renormalize` is a no-op and no content changes.

## Verification

Full CI run green on every platform ([31509608465](https://github.com/chrisagrams/mscompress/actions/runs/31509608465)). On Windows specifically:

| | Before | After |
|---|---|---|
| Node | 1 failed, 109 passed | **110 passed** |
| Python | 1 failed, 222 passed | **223 passed** |

Both fidelity tests ran (not skipped) and passed.

## Notes

- This also explains and clears the four Windows failures on #191 (byte-shuffle); that branch needs no changes of its own.
- Follow-up worth doing separately: `run_test.cmake` accepts an `EXPECTED_FILE` it never uses, so several CLI tests — including `ShuffleBackwardCompatTest` — assert less than their names imply.